### PR TITLE
Fix bug that blocked exceptions

### DIFF
--- a/src/lib/JANA/JFunctions.cc
+++ b/src/lib/JANA/JFunctions.cc
@@ -19,15 +19,8 @@ std::shared_ptr<JTaskBase> JMakeAnalyzeEventTask(std::shared_ptr<const JEvent>&&
 			// Make sure Init function is called for this processor, but only once.
 			std::call_once(sProcessor->init_flag, &JEventProcessor::Init, sProcessor);
 
-			try {
-				sProcessor->Process(aEvent);
-			} catch (JException& e) {
-				jerr << "Exception in JEventProcessor: " << e.GetMessage() << std::endl;
-			} catch (std::exception& e) {
-				jerr << "Exception in JEventProcessor: " << e.what() << std::endl;
-			} catch (...) {
-				jerr << "Unknown exception in JEventProcessor!" << std::endl;
-			}
+			// Do not catch exceptions here. Allow them to propagate up to caller
+			sProcessor->Process(aEvent);
 		}
 	};
 	auto sPackagedTask = std::packaged_task<void(const std::shared_ptr<const JEvent>&)>(sRunProcessors);

--- a/src/lib/JANA/JTask.h
+++ b/src/lib/JANA/JTask.h
@@ -43,6 +43,8 @@ class JTaskBase : public JResettable
 		std::shared_ptr<const JEvent> GetSharedEvent(void) {return mEvent;} //increase ref count
 
 		virtual bool IsFinished(void) const = 0;
+		
+		virtual void GetFuture(void) {}
 
 		//OPERATORS
 		virtual void operator()(void) = 0;
@@ -70,6 +72,7 @@ class JTask : public JTaskBase
 
 		bool IsFinished(void) const{return (mFuture.wait_for(std::chrono::seconds(0)) == std::future_status::ready);}
 		ReturnType GetResult(void){return mFuture.get();}
+		void GetFuture(void){ GetResult(); }
 
 		//EXECUTE
 		void operator()(void){mTask(mEvent);}

--- a/src/lib/JANA/JThreadManager.cc
+++ b/src/lib/JANA/JThreadManager.cc
@@ -558,6 +558,7 @@ void JThreadManager::ExecuteTask(const std::shared_ptr<JTaskBase>& aTask, JEvent
 	try{
 		//Execute task
 		(*aTask)();
+		aTask->GetFuture(); // if task threw an exception, it will have been caught by the future and this will cause it to be re-thrown
 		LOG_TRACE(mLogger, mDebugLevel) << "Thread " << JTHREAD->GetThreadID() << " JThreadManager::ExecuteTask(): Task executed successfully." << LOG_END;
 
 		// Release the JEvent


### PR DESCRIPTION
This fixes a bug that silently caught exceptions thrown in the user's JEventProcess::Process method. The issue was with the use of a std::future which catches exceptions, but only rethrows them when their get() method is called. This was not being explicitly called before, but is now.