### PR TITLE
python3

### DIFF
--- a/src/plugins/janapy/SConscript
+++ b/src/plugins/janapy/SConscript
@@ -7,11 +7,12 @@ import subprocess
 Import('*')
 env = env.Clone()
 
-PYTHON_CFLAGS = subprocess.Popen(["python-config", "--cflags"], stdout=subprocess.PIPE).communicate()[0]
-PYTHON_LINKFLAGS = subprocess.Popen(["python-config", "--libs"], stdout=subprocess.PIPE).communicate()[0]
+PYTHON_CFLAGS = subprocess.Popen(["python3-config", "--cflags"], stdout=subprocess.PIPE).communicate()[0].strip()
+PYTHON_PREFIX = subprocess.Popen(["python3-config", "--prefix"], stdout=subprocess.PIPE).communicate()[0].strip()
+PYTHON_LINKFLAGS = subprocess.Popen(["python3-config", "--libs"], stdout=subprocess.PIPE).communicate()[0].strip()
 
 sbms.AddCompileFlags(env, PYTHON_CFLAGS)
-sbms.AddLinkFlags(env, PYTHON_LINKFLAGS)
+sbms.AddLinkFlags(env, PYTHON_LINKFLAGS + " -L"+PYTHON_PREFIX+"/lib")
 
 
 sbms.AddJANA(env)

--- a/src/plugins/janapy/jana.py
+++ b/src/plugins/janapy/jana.py
@@ -8,4 +8,4 @@ jana.WaitUntilAllThreadsRunning()
 
 for i in range(0,20):
 	time.sleep(1)
-	print '\nCalled jana.GetNeventsProcessed: %d' % jana.GetNeventsProcessed()
+	print( '\nCalled jana.GetNeventsProcessed: %d' % jana.GetNeventsProcessed())

--- a/src/plugins/janapy/janapy.cc
+++ b/src/plugins/janapy/janapy.cc
@@ -41,6 +41,7 @@
 #include <cstdio>
 #include <chrono>
 #include <Python.h>
+using namespace std;
 
 #include <JANA/JApplication.h>
 #include <JANA/JThreadManager.h>
@@ -49,6 +50,15 @@
 void JANA_PythonModuleInit(JApplication *sApp);
 
 static bool PY_INITIALIZED = false; // See JANA_PythonModuleInit
+
+// This is temporary and will likely be changed once the new arrow
+// system is fully adopted.
+static JApplication *pyjapp = NULL;
+
+#ifndef _DBG__
+#define _DBG__ std::cout<<__FILE__<<":"<<__LINE__<<std::endl
+#define _DBG_ std::cout<<__FILE__<<":"<<__LINE__<<" "
+#endif
 
 extern "C"{
 void InitPlugin(JApplication *app){
@@ -93,7 +103,68 @@ PyObject* PVdict( std::map<K,V> &m ){
 	for( auto p : m ) PyDict_SetItem( PDict, PV(p.first), PV(p.second));
 	return PDict;
 }
+
 //..........................................................
+// The following converts PyObject types that may be either single values
+// or arrays into a C++ vector of strings. The "require_str_type" option
+// may be used to require the object types to be strings. Otherwise, they
+// are automatically converted to string representations.
+PyObject* PyObjectToVectorOfStrings(PyObject *args, vector<string> &vstr, bool require_str_type=false)
+{
+	PyObject *pyobj;
+	if(!PyArg_ParseTuple(args, "O", &pyobj)) return NULL;
+	
+	// This may or may not be used below
+	PyObject *iter = PyObject_GetIter(pyobj);
+
+	// Check if this is a single string
+	if( PyUnicode_Check(pyobj) ){
+
+		// single value
+		const char* str = PyUnicode_AsUTF8( pyobj );
+		vstr.push_back( str );
+
+	// Check if this is an iterable list of objects
+	} else if(iter) {
+
+		// iterate over list of values
+		while (true) {
+			PyObject *next = PyIter_Next(iter);
+			if( !next ) break;
+			if( PyUnicode_Check(next) ){
+				// Already a string
+				const char* str = PyUnicode_AsUTF8( next );
+				vstr.push_back( str );
+			}else{
+				// Not a string
+				if( require_str_type ){
+					PyErr_SetString( PyExc_TypeError, "Argument must be string or list of strings. (Not all arugments in list passed were strings!)" );
+					return NULL;
+				} else {
+					// Get string representation
+					const char* str = PyUnicode_AsUTF8( PyObject_Str(next) );
+					vstr.push_back( str );
+				}
+			}
+		}
+
+	}else{
+
+		// Single value that is not a string
+		if( require_str_type ){
+			PyErr_SetString( PyExc_TypeError, "Argument must be string or list of strings. (Argument passed was not a string!)" );
+			return NULL;
+		} else {
+			// Get string representation
+			const char* str = PyUnicode_AsUTF8( PyObject_Str(pyobj) );
+			vstr.push_back( str );
+		}
+	}
+
+	return PV( "" );
+}
+//..........................................................
+
 
 //-------------------------------------
 // janapy_Start
@@ -106,12 +177,22 @@ static PyObject* janapy_Start(PyObject *self, PyObject *args)
 }
 
 //-------------------------------------
+// janapy_Run
+//-------------------------------------
+static PyObject* janapy_Run(PyObject *self, PyObject *args)
+{
+	if(!PyArg_ParseTuple(args, ":Run")) return NULL;
+	pyjapp->Run();
+	return PV("");
+}
+
+//-------------------------------------
 // janapy_Quit
 //-------------------------------------
 static PyObject* janapy_Quit(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":Quit")) return NULL;
-	japp->Quit();
+	pyjapp->Quit();
 	return PV("");
 }
 
@@ -122,7 +203,7 @@ static PyObject* janapy_Stop(PyObject *self, PyObject *args)
 {
 	int wait_until_idle=false;
 	if(!PyArg_ParseTuple(args, "|i:Stop", &wait_until_idle)) return NULL;
-	japp->Stop(wait_until_idle);
+	pyjapp->Stop(wait_until_idle);
 	return PV("");
 }
 
@@ -132,7 +213,7 @@ static PyObject* janapy_Stop(PyObject *self, PyObject *args)
 static PyObject* janapy_Resume(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":Resume")) return NULL;
-	japp->Resume();
+	pyjapp->Resume();
 	return PV("");
 }
 
@@ -143,7 +224,7 @@ static PyObject* janapy_WaitUntilAllThreadsRunning(PyObject *self, PyObject *arg
 {
 	if(!PyArg_ParseTuple(args, ":WaitUntilAllThreadsRunning")) return NULL;
 	PY_INITIALIZED = true; // (in case user doesn't call Start before calling this)
-	japp->GetJThreadManager()->WaitUntilAllThreadsRunning();
+	pyjapp->GetJThreadManager()->WaitUntilAllThreadsRunning();
 	return PV("");
 }
 
@@ -154,7 +235,7 @@ static PyObject* janapy_WaitUntilAllThreadsIdle(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":WaitUntilAllThreadsIdle")) return NULL;
 	PY_INITIALIZED = true; // (in case user doesn't call Start before calling this)
-	japp->GetJThreadManager()->WaitUntilAllThreadsIdle();
+	pyjapp->GetJThreadManager()->WaitUntilAllThreadsIdle();
 	return PV("");
 }
 
@@ -165,8 +246,46 @@ static PyObject* janapy_WaitUntilAllThreadsEnded(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":WaitUntilAllThreadsEnded")) return NULL;
 	PY_INITIALIZED = true; // (in case user doesn't call Start before calling this)
-	japp->GetJThreadManager()->WaitUntilAllThreadsEnded();
+	pyjapp->GetJThreadManager()->WaitUntilAllThreadsEnded();
 	return PV("");
+}
+
+//-------------------------------------
+// janapy_AddPlugin
+//-------------------------------------
+static PyObject* janapy_AddPlugin(PyObject *self, PyObject *args)
+{
+	vector<string> plugins;
+	auto retval = PyObjectToVectorOfStrings( args, plugins, true);
+
+	for(auto p : plugins ) pyjapp->AddPlugin( p );
+
+	return retval;
+}
+
+//-------------------------------------
+// janapy_AddPluginPath
+//-------------------------------------
+static PyObject* janapy_AddPluginPath(PyObject *self, PyObject *args)
+{
+	vector<string> paths;
+	auto retval = PyObjectToVectorOfStrings( args, paths, true);
+
+	for(auto p : paths ) pyjapp->AddPluginPath( p );
+
+	return retval;
+}
+
+//-------------------------------------
+// janapy_AddEventSource
+//-------------------------------------
+static PyObject* janapy_AddEventSource(PyObject *self, PyObject *args)
+{
+	char *key;
+	char *val;
+	if(!PyArg_ParseTuple(args, "s:AddEventSource", &key, &val)) return NULL;
+	pyjapp->SetParameterValue<string>( key, val );
+	return PV( "" );
 }
 
 //-------------------------------------
@@ -176,7 +295,7 @@ static PyObject* janapy_GetNtasksCompleted(PyObject *self, PyObject *args)
 {
 	char name[512] = "";
 	if(!PyArg_ParseTuple(args, "|s:GetNtasksCompleted", name)) return NULL;
-	return PV( japp->GetNtasksCompleted( name ) );
+	return PV( pyjapp->GetNtasksCompleted( name ) );
 }
 
 //-------------------------------------
@@ -185,7 +304,7 @@ static PyObject* janapy_GetNtasksCompleted(PyObject *self, PyObject *args)
 static PyObject* janapy_GetNeventsProcessed(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":GetNeventsProcessed")) return NULL;
-	return PV( japp->GetNeventsProcessed() );
+	return PV( pyjapp->GetNeventsProcessed() );
 }
 
 //-------------------------------------
@@ -194,7 +313,7 @@ static PyObject* janapy_GetNeventsProcessed(PyObject *self, PyObject *args)
 static PyObject* janapy_GetIntegratedRate(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":GetIntegratedRate")) return NULL;
-	return PV( japp->GetIntegratedRate() );
+	return PV( pyjapp->GetIntegratedRate() );
 }
 
 //-------------------------------------
@@ -204,7 +323,7 @@ static PyObject* janapy_GetIntegratedRates(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":GetIntegratedRates")) return NULL;
 	std::map<string,double> rates_by_thread;
-	japp->GetIntegratedRates(rates_by_thread);
+	pyjapp->GetIntegratedRates(rates_by_thread);
 	return PVdict( rates_by_thread );
 }
 
@@ -214,7 +333,7 @@ static PyObject* janapy_GetIntegratedRates(PyObject *self, PyObject *args)
 static PyObject* janapy_GetInstantaneousRate(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":GetInstantaneousRate")) return NULL;
-	return PV( japp->GetInstantaneousRate() );
+	return PV( pyjapp->GetInstantaneousRate() );
 }
 
 //-------------------------------------
@@ -224,7 +343,7 @@ static PyObject* janapy_GetInstantaneousRates(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":GetInstantaneousRates")) return NULL;
 	vector<double> rates_by_queue;
-	japp->GetInstantaneousRates(rates_by_queue);
+	pyjapp->GetInstantaneousRates(rates_by_queue);
 	return PVlist( rates_by_queue );
 }
 
@@ -234,7 +353,7 @@ static PyObject* janapy_GetInstantaneousRates(PyObject *self, PyObject *args)
 static PyObject* janapy_GetNJThreads(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":GetNJThreads")) return NULL;
-	return PV( japp->GetJThreadManager()->GetNJThreads() );
+	return PV( pyjapp->GetJThreadManager()->GetNJThreads() );
 }
 
 //-------------------------------------
@@ -255,7 +374,7 @@ static PyObject* janapy_GetParameterValue(PyObject *self, PyObject *args)
 	if(!PyArg_ParseTuple(args, "s:GetParameterValue", &str)) return NULL;
 	try{
 		std::cout << "\n\rLooking for parameter: " << str << "\n\r";
-		return PV( japp->GetParameterValue<string>( str ) );
+		return PV( pyjapp->GetParameterValue<string>( str ) );
 	}catch(...){
 		return PV("Not Defined");
 	}
@@ -267,9 +386,10 @@ static PyObject* janapy_GetParameterValue(PyObject *self, PyObject *args)
 static PyObject* janapy_SetParameterValue(PyObject *self, PyObject *args)
 {
 	char *key;
-	char *val;
-	if(!PyArg_ParseTuple(args, "ss:SetParameterValue", &key, &val)) return NULL;
-	japp->SetParameterValue<string>( key, val );
+	PyObject *valobj;
+	if(!PyArg_ParseTuple(args, "sO:SetParameterValue", &key, &valobj)) return NULL;
+	const char* val = PyUnicode_AsUTF8( PyObject_Str(valobj) );
+	pyjapp->SetParameterValue<string>( key, val );
 	return PV( "" );
 }
 
@@ -280,7 +400,7 @@ static PyObject* janapy_SetTicker(PyObject *self, PyObject *args)
 {
 	int ticker_on = true;
 	if(!PyArg_ParseTuple(args, "|i:SetTicker", &ticker_on)) return NULL;
-	japp->SetTicker( ticker_on );
+	pyjapp->SetTicker( ticker_on );
 	return PV( "" );
 }
 
@@ -291,8 +411,8 @@ static PyObject* janapy_SetNJThreads(PyObject *self, PyObject *args)
 {
 	int nthreads=1;
 	if(!PyArg_ParseTuple(args, "i:SetNJThreads", &nthreads)) return NULL;
-	japp->GetJThreadManager()->SetNJThreads( nthreads );
-	return PV( japp->GetJThreadManager()->GetNJThreads() );
+	pyjapp->GetJThreadManager()->SetNJThreads( nthreads );
+	return PV( pyjapp->GetJThreadManager()->GetNJThreads() );
 }
 
 //-------------------------------------
@@ -301,7 +421,7 @@ static PyObject* janapy_SetNJThreads(PyObject *self, PyObject *args)
 static PyObject* janapy_IsQuitting(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":IsQuitting")) return NULL;
-	return PV( japp->IsQuitting() );
+	return PV( pyjapp->IsQuitting() );
 }
 
 //-------------------------------------
@@ -310,7 +430,7 @@ static PyObject* janapy_IsQuitting(PyObject *self, PyObject *args)
 static PyObject* janapy_IsDrainingQueues(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":IsDrainingQueues")) return NULL;
-	return PV( japp->IsDrainingQueues() );
+	return PV( pyjapp->IsDrainingQueues() );
 }
 
 //-------------------------------------
@@ -319,7 +439,17 @@ static PyObject* janapy_IsDrainingQueues(PyObject *self, PyObject *args)
 static PyObject* janapy_PrintStatus(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":PrintStatus")) return NULL;
-	japp->PrintStatus();
+	pyjapp->PrintStatus();
+	return PV( "" );
+}
+
+//-------------------------------------
+// janapy_PrintFinalReport
+//-------------------------------------
+static PyObject* janapy_PrintFinalReport(PyObject *self, PyObject *args)
+{
+	if(!PyArg_ParseTuple(args, ":PrintFinalReport")) return NULL;
+	pyjapp->PrintFinalReport();
 	return PV( "" );
 }
 
@@ -330,7 +460,7 @@ static PyObject* janapy_PrintParameters(PyObject *self, PyObject *args)
 {
 	int print_all = 0;
 	if(!PyArg_ParseTuple(args, "|i:PrintParameters", &print_all)) return NULL;
-	japp->GetJParameterManager()->PrintParameters( print_all );
+	pyjapp->GetJParameterManager()->PrintParameters( print_all );
 	return PV( "" );
 }
 
@@ -339,12 +469,16 @@ static PyObject* janapy_PrintParameters(PyObject *self, PyObject *args)
 // Define python methods
 static PyMethodDef JANAPYMethods[] = {
 	{"Start",                       janapy_Start,                       METH_VARARGS, "Allow JANA system to start processing data. (Not needed for short scripts.)"},
+	{"Run",                         janapy_Run,                         METH_VARARGS, "Begin processing events (use when running python as an extension)"},
 	{"Quit",                        janapy_Quit,                        METH_VARARGS, "Tell JANA to quit gracefully"},
 	{"Stop",                        janapy_Stop,                        METH_VARARGS, "Tell JANA to (temporarily) stop event processing. If optional agrument is True then block until all threads are stopped."},
 	{"Resume",                      janapy_Resume,                      METH_VARARGS, "Tell JANA to resume event processing."},
 	{"WaitUntilAllThreadsRunning",  janapy_WaitUntilAllThreadsRunning,  METH_VARARGS, "Wait until all threads have entered the running state."},
 	{"WaitUntilAllThreadsIdle",     janapy_WaitUntilAllThreadsIdle,     METH_VARARGS, "Wait until all threads have entered the idle state."},
 	{"WaitUntilAllThreadsEnded",    janapy_WaitUntilAllThreadsEnded,    METH_VARARGS, "Wait until all threads have entered the ended state."},
+	{"AddPlugin",                   janapy_AddPlugin,                   METH_VARARGS, "Add a plugin to the list of plugins to be attached (call before calling Run)"},
+	{"AddPluginPath",               janapy_AddPluginPath,               METH_VARARGS, "Add directory to plugin search path"},
+	{"AddEventSource",              janapy_AddEventSource,              METH_VARARGS, "Add an event source (e.g. filename). Can be given multiple arguments and/or called multiple times."},
 	{"GetNtasksCompleted",          janapy_GetNtasksCompleted,          METH_VARARGS, "Return the number of tasks completed. If specified, only count tasks for that JQueue."},
 	{"GetNeventsProcessed",         janapy_GetNeventsProcessed,         METH_VARARGS, "Return the number of events processed so far."},
 	{"GetIntegratedRate",           janapy_GetIntegratedRate,           METH_VARARGS, "Return integrated rate."},
@@ -359,11 +493,37 @@ static PyMethodDef JANAPYMethods[] = {
 	{"SetNJThreads",                janapy_SetNJThreads,                METH_VARARGS, "Set the number of JThread objects by creating or deleting."},
 	{"IsQuitting",                  janapy_IsQuitting,                  METH_VARARGS, "Returns true if the application quit flag has been set."},
 	{"IsDrainingQueues",            janapy_IsDrainingQueues,            METH_VARARGS, "Returns true if the application draining queues flag is set indicating all events have been read in."},
-	{"PrintStatus",                 janapy_PrintStatus,                 METH_VARARGS, "Print current JANA status."},
+	{"PrintStatus",                 janapy_PrintStatus,                 METH_VARARGS, "Print current JANA status (ticker without newline)."},
+	{"PrintFinalReport",            janapy_PrintFinalReport,            METH_VARARGS, "Print final JANA status."},
 	{"PrintParameters",             janapy_PrintParameters,             METH_VARARGS, "Print configuration parameters. Pass True to print all. Otherwise, only non-default ones will be printed."},
 	{NULL, NULL, 0, NULL}
 };
 //.....................................................
+
+
+//================================================================================
+// Module definition
+// The arguments of this structure tell Python what to call your extension,
+// what it's methods are and where to look for it's method definitions
+static struct PyModuleDef janapy__definition = {
+    PyModuleDef_HEAD_INIT,
+    "janapy",
+    "JANA2 Python module.",
+    -1,
+    JANAPYMethods
+};
+
+//================================================================================
+// Module entry point (for import)
+PyMODINIT_FUNC PyInit_janapy(void) {
+
+	// Create JApplication. This is temporary and will likely be replaced
+	// when the arrow system is fully integrated/
+	pyjapp = new JApplication();
+
+	Py_Initialize();
+	return PyModule_Create(&janapy__definition);
+}
 
 //-------------------------------------
 // JANA_PythonModuleInit
@@ -398,17 +558,23 @@ void JANA_PythonModuleInit(JApplication *sApp)
 		PY_INITIALIZED = true;
 		return;
 	}
+	
+	pyjapp = sApp;
 
 	// Initialize interpreter and register the jana module
 	jout << "Initializing embedded Python ... " << std::endl;
 	PyEval_InitThreads();
 	Py_Initialize();
+#if PY_MAJOR_VERSION >= 3
+	PyModule_Create(&janapy__definition);
+#else // Python 2
 	Py_InitModule("jana", JANAPYMethods);
+#endif
 
 	// Get name of python file to execute
 	string fname = "jana.py";
 	try{
-		fname = sApp->GetParameterValue<string>("JANA_PYTHON_FILE");
+		fname = pyjapp->GetParameterValue<string>("JANA_PYTHON_FILE");
 	}catch(...){
 		auto JANA_PYTHON_FILE = getenv("JANA_PYTHON_FILE");
 		if( JANA_PYTHON_FILE ) fname = JANA_PYTHON_FILE;
@@ -423,11 +589,11 @@ void JANA_PythonModuleInit(JApplication *sApp)
 	if( fil ) {
 		jout << "Executing Python script: " << fname << " ..." << std::endl;
 		const char *argv = fname.c_str();
-		PySys_SetArgv( 1, (char**)&argv );
+		PySys_SetArgv( 1, (wchar_t**)&argv );
 		PyRun_AnyFileEx( fil, NULL, 1 );
 	}else if( fname != "jana.py" ){
 		jerr << std::endl << "Unable to open \"" << fname << "\"! Quitting." << std::endl << std::endl;
-		sApp->Quit();
+		pyjapp->Quit();
 		PY_INITIALIZED = true;
 		std::this_thread::sleep_for(std::chrono::seconds(1));
 		exit(-1);


### PR DESCRIPTION
This modifies the janapy plugin to also work as a python extension in addition to allowing embedded python.

This also switches from python2 to python3. Python2 is now broken and will likely not be restored given it will no longer be supported by the python authors as of Jan. 2020.