### PR TITLE
Retrieve method for _initialized member of JApplication

### DIFF
--- a/src/lib/JANA/JApplication.cc
+++ b/src/lib/JANA/JApplication.cc
@@ -115,7 +115,7 @@ void JApplication::Initialize() {
 
     // Only run this once
     if (_initialized) return;
-    _initialized = true;
+
 
     // Attach all plugins
     _plugin_loader->attach_plugins(_component_manager);
@@ -139,6 +139,8 @@ void JApplication::Initialize() {
 
     _params->SetDefaultParameter("JANA:EXTENDED_REPORT", _extended_report);
     _processing_controller->initialize();
+
+    _initialized = true;
 }
 
 void JApplication::Run(bool wait_until_finished) {

--- a/src/lib/JANA/JApplication.h
+++ b/src/lib/JANA/JApplication.h
@@ -102,7 +102,7 @@ public:
 
 
     // Performance/status monitoring
-
+    bool IsInitialized(void){return _initialized;}
     bool IsQuitting(void) { return _quitting; }
     bool IsDrainingQueues(void) { return _draining_queues; }
 


### PR DESCRIPTION
Adding a method to retrieve the private member _initialized from a JApplication object. Also, in the Initialize() method, put the _initialized=true line at the end, just before reutnr