### PR TITLE
Adding the GetAll method to JFactory

### DIFF
--- a/src/lib/JANA/JFactorySet.cc
+++ b/src/lib/JANA/JFactorySet.cc
@@ -111,6 +111,8 @@ JFactory* JFactorySet::GetFactory(std::type_index aObjectType, const std::string
 	return (sIterator != std::end(mFactories)) ? sIterator->second : nullptr;
 }
 
+
+
 //---------------------------------
 // Merge
 //---------------------------------

--- a/src/lib/JANA/JFactorySet.h
+++ b/src/lib/JANA/JFactorySet.h
@@ -70,6 +70,7 @@ class JFactorySet : public JResettable
 
 		JFactory* GetFactory(std::type_index aObjectType, const std::string& aFactoryTag="") const;
 		template<typename T> JFactoryT<T>* GetFactory(const std::string& tag = "") const;
+		template<typename T> std::vector<JFactoryT<T>*> GetFactoryAll() const;
 
 		std::vector<JFactorySummary> Summarize() const;
 
@@ -86,6 +87,19 @@ JFactoryT<T>* JFactorySet::GetFactory(const std::string& tag) const {
 	auto sIterator = mFactories.find(sKeyPair);
 	return (sIterator != std::end(mFactories)) ? static_cast<JFactoryT<T>*>(sIterator->second) : nullptr;
 }
+
+template<typename T>
+std::vector<JFactoryT<T>*> JFactorySet::GetFactoryAll() const {
+	auto sKey = std::type_index(typeid(T));
+	std::vector<JFactoryT<T>*> data;
+	for (auto it=std::begin(mFactories);it!=std::end(mFactories);it++){
+		if (it->first.first==sKey){
+			data.push_back(static_cast<JFactoryT<T>*>(it->second));
+		}
+	}
+	return data;
+}
+
 
 #endif // _JFactorySet_h_
 

--- a/src/lib/JANA/JFactoryT.h
+++ b/src/lib/JANA/JFactoryT.h
@@ -82,7 +82,6 @@ public:
     }
 
     PairType GetOrCreate(const std::shared_ptr<const JEvent>& event, JEventSource* source, uint64_t run_number) {
-
         //std::lock_guard<std::mutex> lock(mMutex);
         switch (mStatus) {
             case Status::Uninitialized:


### PR DESCRIPTION
In the situation where one ore more factories produce the same JObject-inhereted object (with different tag), this allows to get all objects from all factories, independently from the tag (clearly it is responsability of the user to differentiate the objects in the producing factories)