### PR TITLE
Davidl janapy tmp

### DIFF
--- a/src/plugins/janapy/ijana.py
+++ b/src/plugins/janapy/ijana.py
@@ -95,7 +95,7 @@ def draw_banner():
 
 	# Draw status
 	PRINTAT( 3, 2, 'Num. Events Processed: %d' % jana.GetNeventsProcessed() )
-	PRINTAT( 3, 3, ' Num. Tasks Completed: %d' % jana.GetNtasksCompleted() )
+	#PRINTAT( 3, 3, ' Num. Tasks Completed: %d' % jana.GetNtasksCompleted() ) # This no longer exists
 	PRINTAT( 3, 4, '           Num. Cores: %d' % jana.GetNcores() )
 	PRINTAT( 3, 5, '        Num. JThreads: %d' % jana.GetNJThreads() )
 
@@ -109,17 +109,17 @@ def draw_banner():
 # print_help
 #------------------------------
 def print_help():
-	print '\n JANA Python Interactive CLI Help'
-	print '\r------------------------------------'
-	print '\r banner [on/off]    set banner on/off (def. on)"'
-	print '\r exit               same as "quit"'
-	print '\r help               print this message'
-	print '\r history            print history of this session'
-	print '\r parameter cmd ...  get/set/list config. parameters'
-	print '\r quit               stop data processing and quit the program'
-	print '\r resume             resume data processing'
-	print '\r status             print some status info'
-	print '\r stop               pause data processing'
+	print('\n JANA Python Interactive CLI Help')
+	print('\r------------------------------------')
+	print('\r banner [on/off]    set banner on/off (def. on)"')
+	print('\r exit               same as "quit"')
+	print('\r help               print this message')
+	print('\r history            print history of this session')
+	print('\r parameter cmd ...  get/set/list config. parameters')
+	print('\r quit               stop data processing and quit the program')
+	print('\r resume             resume data processing')
+	print('\r status             print some status info')
+	print('\r stop               pause data processing')
 
 #------------------------------
 # process_command
@@ -133,16 +133,16 @@ def process_command( input ):
 	cmd = tokens[0]
 	args = tokens[1:]
 	
-	print 'processing command: ' + ' '.join(tokens)
+	print('processing command: ' + ' '.join(tokens))
 	LEFT(1000)
 
 	#--- banner
 	if cmd=='banner':
 		if len(args) == 0:
-			print 'command banner requires you to specify "on" or "off". (see help for details)'
+			print('command banner requires you to specify "on" or "off". (see help for details)')
 		elif args[0] == 'on' : BANNER_ON = True
 		elif args[0] == 'off': BANNER_ON = False
-		else: print 'command banner requires you to specify "on" or "off". (see help for details)'
+		else: print('command banner requires you to specify "on" or "off". (see help for details)')
 	#--- exit, quit
 	elif cmd=='exit' or cmd=='quit':
 		CLI_ACTIVE = False
@@ -154,51 +154,51 @@ def process_command( input ):
 	elif cmd=='history':
 		idx = 0
 		for h in history:
-			print '%3d %s\r' % (idx, h)
+			print('%3d %s\r' % (idx, h))
 			idx += 1
-		print '%3d %s\r' % (idx, ' '.join(tokens) )  # include this history command which will be added below
+		print('%3d %s\r' % (idx, ' '.join(tokens) ) ) # include this history command which will be added below
 	#--- nthreads
 	elif cmd=='nthreads':
 		if len(args) == 0:
-			print 'Number of JThreads: %d' % jana.GetNJThreads()
+			print('Number of JThreads: %d' % jana.GetNJThreads())
 		elif len(args)==1:
-			print 'Number of JThreads now at: %d' % jana.SetNJThreads( int(args[0]) )
+			print('Number of JThreads now at: %d' % jana.SetNJThreads( int(args[0]) ) )
 		else:
-			print 'njthreads takes either 0 or 1 argument (see help for details)'
+			print('njthreads takes either 0 or 1 argument (see help for details)')
 	#--- parameter
 	elif cmd=='parameter':
 		if len(args) == 0:
-			print 'command parameter requires arguments. (see help for details)'
+			print('command parameter requires arguments. (see help for details)')
 		elif args[0] == 'get':
 			if len(args)==2:
-				print '%s: %s' % (args[1], jana.GetParameterValue(args[1]))
+				print('%s: %s' % (args[1], jana.GetParameterValue(args[1])))
 			else:
-				print 'command parameter get requires exactly 1 argument! (see help for details)'
+				print('command parameter get requires exactly 1 argument! (see help for details)')
 		elif args[0] == 'set':
 			if len(args)==3:
 				jana.SetParameter(args[1], args[2])
 			else:
-				print 'command parameter set requires exactly 2 arguments! (see help for details)'
+				print('command parameter set requires exactly 2 arguments! (see help for details)')
 		elif args[0] == 'list':
 			if len(args)==1:
 				jana.PrintParameters(True)
 			else:
-				print 'command parameter list requires no arguments! (see help for details)'
+				print('command parameter list requires no arguments! (see help for details)')
 	#--- resume
 	elif cmd=='resume':
 		jana.Resume()
-		print 'event processing resumed'
+		print('event processing resumed')
 	#--- status
 	elif cmd=='status':
 		jana.PrintStatus()
-		print ''
+		print('')
 	#--- stop
 	elif cmd=='stop':
 		jana.Stop(True)
-		print 'event processing stopped after %d events (use "resume" to start again)' % jana.GetNeventsProcessed()
+		print('event processing stopped after %d events (use "resume" to start again)' % jana.GetNeventsProcessed())
 	#--- unknown command
 	else:
-		print 'Unknown command: ' + cmd
+		print('Unknown command: ' + cmd)
 		return
 
 	history.append( ' '.join(tokens) ) # add to history
@@ -317,7 +317,7 @@ def command_line():
 			sys.stdout.flush()
 		
 		# Process one input line
-		print ''
+		print('')
 		MOVETO(1,NROWS)
 		termios.tcsetattr(sys.stdin, termios.TCSAFLUSH, mode)
 		process_command( input )
@@ -330,7 +330,7 @@ def command_line():
 
 	# Restore terminal settings
 	termios.tcsetattr(sys.stdin, termios.TCSAFLUSH, mode)
-	print '\nCLI exiting ...\n'
+	print('\nCLI exiting ...\n')
 
 #===========================================================
 #                         MAIN

--- a/src/plugins/janapy/janapy.cc
+++ b/src/plugins/janapy/janapy.cc
@@ -51,6 +51,8 @@ void JANA_PythonModuleInit(JApplication *sApp);
 
 static bool PY_INITIALIZED = false; // See JANA_PythonModuleInit
 
+static PyObject *JANA_PYMODULE_OBJ = nullptr;
+
 // This is temporary and will likely be changed once the new arrow
 // system is fully adopted.
 static JApplication *pyjapp = nullptr;
@@ -296,8 +298,9 @@ static PyObject* janapy_AddEventSource(PyObject *self, PyObject *args)
 //-------------------------------------
 static PyObject* janapy_GetNeventsProcessed(PyObject *self, PyObject *args)
 {
-	if(!PyArg_ParseTuple(args, ":GetNEventsProcessed")) return nullptr;
-	return PV(pyjapp->GetNEventsProcessed() );
+	if(!PyArg_ParseTuple(args, ":GetNeventsProcessed")) return nullptr;
+    return PV(123);
+	return PV( pyjapp->GetNEventsProcessed() );
 }
 
 //-------------------------------------
@@ -306,6 +309,7 @@ static PyObject* janapy_GetNeventsProcessed(PyObject *self, PyObject *args)
 static PyObject* janapy_GetIntegratedRate(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":GetIntegratedRate")) return nullptr;
+    return PV(456.0);
 	return PV( pyjapp->GetIntegratedRate() );
 }
 
@@ -316,6 +320,7 @@ static PyObject* janapy_GetIntegratedRate(PyObject *self, PyObject *args)
 static PyObject* janapy_GetInstantaneousRate(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":GetInstantaneousRate")) return nullptr;
+    return PV(321.0);
 	return PV( pyjapp->GetInstantaneousRate() );
 }
 
@@ -325,6 +330,7 @@ static PyObject* janapy_GetInstantaneousRate(PyObject *self, PyObject *args)
 static PyObject* janapy_GetNJThreads(PyObject *self, PyObject *args)
 {
 	if(!PyArg_ParseTuple(args, ":GetNJThreads")) return nullptr;
+    return PV(3);
 	return PV( pyjapp->GetNThreads() );
 }
 
@@ -451,7 +457,7 @@ static PyMethodDef JANAPYMethods[] = {
 	{"AddPlugin",                   janapy_AddPlugin,                   METH_VARARGS, "Add a plugin to the list of plugins to be attached (call before calling Run)"},
 	{"AddPluginPath",               janapy_AddPluginPath,               METH_VARARGS, "Add directory to plugin search path"},
 	{"AddEventSource",              janapy_AddEventSource,              METH_VARARGS, "Add an event source (e.g. filename). Can be given multiple arguments and/or called multiple times."},
-	{"GetNEventsProcessed",         janapy_GetNeventsProcessed,         METH_VARARGS, "Return the number of events processed so far."},
+	{"GetNeventsProcessed",         janapy_GetNeventsProcessed,         METH_VARARGS, "Return the number of events processed so far."},
 	{"GetIntegratedRate",           janapy_GetIntegratedRate,           METH_VARARGS, "Return integrated rate."},
 	{"GetInstantaneousRate",        janapy_GetInstantaneousRate,        METH_VARARGS, "Return instantaneous rate."},
 	{"GetNJThreads",                janapy_GetNJThreads,                METH_VARARGS, "Return current number of JThread objects."},
@@ -476,7 +482,7 @@ static PyMethodDef JANAPYMethods[] = {
 // what it's methods are and where to look for it's method definitions
 static struct PyModuleDef janapy__definition = {
     PyModuleDef_HEAD_INIT,
-    "janapy",
+    "jana",
     "JANA2 Python module.",
     -1,
     JANAPYMethods
@@ -487,10 +493,11 @@ static struct PyModuleDef janapy__definition = {
 PyMODINIT_FUNC PyInit_janapy(void) {
 
 	// Create JApplication.
-	pyjapp = new JApplication;
+	if( pyjapp == nullptr ) pyjapp = new JApplication;
 
-	Py_Initialize();
-	return PyModule_Create(&janapy__definition);
+	if( ! Py_IsInitialized() ) Py_Initialize();
+	if( JANA_PYMODULE_OBJ == nullptr ) JANA_PYMODULE_OBJ = PyModule_Create(&janapy__definition);
+	return JANA_PYMODULE_OBJ;
 }
 
 //-------------------------------------
@@ -532,10 +539,13 @@ void JANA_PythonModuleInit(JApplication *sApp)
 	// Initialize interpreter and register the jana module
 	jout << "Initializing embedded Python ... " << jendl;
 	PyEval_InitThreads();
-	Py_Initialize();
 #if PY_MAJOR_VERSION >= 3
-	PyModule_Create(&janapy__definition);
+
+	PyImport_AppendInittab("jana", &PyInit_janapy);
+	Py_Initialize();
+	JANA_PYMODULE_OBJ = PyModule_Create(&janapy__definition);
 #else // Python 2
+	Py_Initialize();
 	Py_InitModule("jana", JANAPYMethods);
 #endif
 
@@ -556,8 +566,10 @@ void JANA_PythonModuleInit(JApplication *sApp)
 	auto fil = std::fopen(fname.c_str(), "r");
 	if( fil ) {
 		jout << "Executing Python script: " << fname << " ..." << jendl;
-		const char *argv = fname.c_str();
-		PySys_SetArgv( 1, (wchar_t**)&argv );
+
+		wchar_t *wargv = Py_DecodeLocale(fname.c_str(), NULL);
+		PySys_SetArgv( 1, (wchar_t**)&wargv );
+		PyMem_RawFree(wargv);
 		PyRun_AnyFileEx( fil, nullptr, 1 );
 	}else if( fname != "jana.py" ){
 		jerr << "Unable to open \"" << fname << "\"! Quitting." << jendl;


### PR DESCRIPTION
This updates the janapy plugin and ijana.py interactive tool to work with python3. The actual values for number of threads, processing rates, etc. are effectively disabled for now since they are causing crashes when update_status is called. There is probably something else not being initialized that needs to be. 

It should be noted that I found several changes where left in the davidl_janapy branch that were never merged into master. This is because the worked was stopped before it was really ready. Most of that work centered on binding C++ JObjects to Python objects which is needed to go beyond process monitoring and control.