### PR TITLE
cmake version requirement

### DIFF
--- a/.github/workflows/ccpp-docker.yml
+++ b/.github/workflows/ccpp-docker.yml
@@ -18,4 +18,4 @@ jobs:
       id: build_and_run
       uses: faustus123/DockerAction-JANA2@alpha
       with:
-        branch: ${{ GITHUB_REF }}
+        branch: ${GITHUB_REF}

--- a/.github/workflows/ccpp-docker.yml
+++ b/.github/workflows/ccpp-docker.yml
@@ -18,4 +18,4 @@ jobs:
       id: build_and_run
       uses: faustus123/DockerAction-JANA2@alpha
       with:
-        branch: $GITHUB_REF
+        branch: ${{ GITHUB_REF }}

--- a/.github/workflows/ccpp-docker.yml
+++ b/.github/workflows/ccpp-docker.yml
@@ -18,4 +18,4 @@ jobs:
       id: build_and_run
       uses: faustus123/DockerAction-JANA2@alpha
       with:
-        branch: master
+        branch: $GITHUB_REF

--- a/src/plugins/janacontrol/CMakeLists.txt
+++ b/src/plugins/janacontrol/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.9)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)   # Enable -fPIC for all targets


### PR DESCRIPTION
This reduces the cmake version requirement in the janacontrol plugin from 3.13 to 3.9. (Perhaps the requirement should be removed altogether?)