### PR TITLE
Pass only load() of atomic to switch

### DIFF
--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -128,7 +128,7 @@ public:
         auto first_evt_nr = m_nskip;
         auto last_evt_nr = m_nevents + m_nskip;
         try {
-            switch (m_status) {
+            switch (m_status.load()) {
 
                 case SourceStatus::Unopened: DoInitialize(); // Fall-through to Opened afterwards
 


### PR DESCRIPTION
This fixes the error Andrea noted in his e-mail copied below.

Hi Nathan, hi David,
I pulled last version of JANA2 from github. When trying to compile on MAC with Clang, I get:

src/libraries/JANA/JEventSource.h:131:13: error: multiple conversions from switch condition type 'std::atomic<SourceStatus>' to an integral or enumeration type
            switch (m_status) {
            ^       ~~~~~~~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/atomic:928:5: note: conversion to enumeration type 'JEventSource::SourceStatus'
    operator _Tp() const volatile _NOEXCEPT {return load();}
    ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/atomic:930:5: note: conversion to enumeration type 'JEventSource::SourceStatus'
    operator _Tp() const _NOEXCEPT          {return load();}
    ^

Googling around, following link is useful: https://stackoverflow.com/questions/25143860/implicit-conversion-from-class-to-enumeration-type-in-switch-conditional

Solution can be to change -std=c++11 to -std=c++14 in the Scontruct file.

I did so on my mac and it works.

Sorry If I did not open a pull request, but sending you an email was much faster - I don’t have my repo configured with proper remotes here.

Bests,
Andrea