### PR TITLE
Feature: JFactory::GetAs<U>

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_subdirectory(DstExample)
 add_subdirectory(Tutorial)
 add_subdirectory(StreamingExample)
 add_subdirectory(EventGroupExample)

--- a/src/examples/DstExample/CMakeLists.txt
+++ b/src/examples/DstExample/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 set (DstExample_PLUGIN_SOURCES
 		DstExample.cc
+		DstExampleSource.cc
+		DstExampleSource.h
 		DstExampleProcessor.cc
 		DstExampleProcessor.h
 		DataObjects.h

--- a/src/examples/DstExample/CMakeLists.txt
+++ b/src/examples/DstExample/CMakeLists.txt
@@ -6,6 +6,8 @@ set (DstExample_PLUGIN_SOURCES
 		DstExampleSource.h
 		DstExampleProcessor.cc
 		DstExampleProcessor.h
+		DstExampleFactory.cc
+		DstExampleFactory.h
 		DataObjects.h
 	)
 

--- a/src/examples/DstExample/CMakeLists.txt
+++ b/src/examples/DstExample/CMakeLists.txt
@@ -4,6 +4,7 @@ set (DstExample_PLUGIN_SOURCES
 		DstExample.cc
 		DstExampleProcessor.cc
 		DstExampleProcessor.h
+		DataObjects.h
 	)
 
 add_library(DstExample_plugin SHARED ${DstExample_PLUGIN_SOURCES})

--- a/src/examples/DstExample/CMakeLists.txt
+++ b/src/examples/DstExample/CMakeLists.txt
@@ -12,7 +12,7 @@ set (DstExample_PLUGIN_SOURCES
 add_library(DstExample_plugin SHARED ${DstExample_PLUGIN_SOURCES})
 
 target_include_directories(DstExample_plugin PUBLIC ${JANA_INCLUDE_DIR})
-target_link_libraries(DstExample_plugin ${JANA_LIBRARY})
+target_link_libraries(DstExample_plugin jana2)
 set_target_properties(DstExample_plugin PROPERTIES PREFIX "" OUTPUT_NAME "DstExample" SUFFIX ".so")
 install(TARGETS DstExample_plugin DESTINATION plugins)
 

--- a/src/examples/DstExample/CMakeLists.txt
+++ b/src/examples/DstExample/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+
+set (DstExample_PLUGIN_SOURCES
+		DstExample.cc
+		DstExampleProcessor.cc
+		DstExampleProcessor.h
+	)
+
+add_library(DstExample_plugin SHARED ${DstExample_PLUGIN_SOURCES})
+
+target_include_directories(DstExample_plugin PUBLIC ${JANA_INCLUDE_DIR})
+target_link_libraries(DstExample_plugin ${JANA_LIBRARY})
+set_target_properties(DstExample_plugin PROPERTIES PREFIX "" OUTPUT_NAME "DstExample" SUFFIX ".so")
+install(TARGETS DstExample_plugin DESTINATION plugins)
+

--- a/src/examples/DstExample/DataObjects.h
+++ b/src/examples/DstExample/DataObjects.h
@@ -38,7 +38,8 @@ struct MyRenderable : public Renderable {
     int y;
     double E;
 
-    MyRenderable(int x, int y, double E) : x(x), y(y), E(E) {};
+    MyRenderable(int x, int y, double E) : x(x), y(y), E(E) {
+    };
 
     void Render() override {
         LOG << "MyRenderable::Render " << x << "," << y << "," << E << LOG_END;

--- a/src/examples/DstExample/DataObjects.h
+++ b/src/examples/DstExample/DataObjects.h
@@ -20,6 +20,8 @@ struct MyJObject : public JObject {
     int y;
     double E;
 
+    MyJObject(int x, int y, double E) : x(x), y(y), E(E) {};
+
     void Summarize(JObjectSummary& summary) const override {
         summary.add(x, NAME_OF(x), "%d", "Pixel coordinates centered around 0,0");
         summary.add(y, NAME_OF(y), "%d", "Pixel coordinates centered around 0,0");
@@ -36,6 +38,8 @@ struct MyRenderable : public Renderable {
     int y;
     double E;
 
+    MyRenderable(int x, int y, double E) : x(x), y(y), E(E) {};
+
     void Render() override {
         LOG << "MyRenderable::Render " << x << "," << y << "," << E << LOG_END;
     }
@@ -45,6 +49,10 @@ struct MyRenderableJObject : public JObject, Renderable {
     int x;
     int y;
     double E;
+
+    /// Constructor
+
+    MyRenderableJObject(int x, int y, double E) : x(x), y(y), E(E) {};
 
     /// Renderable vfunctions
 

--- a/src/examples/DstExample/DataObjects.h
+++ b/src/examples/DstExample/DataObjects.h
@@ -1,0 +1,68 @@
+//
+// Created by Nathan Brei on 5/19/20.
+//
+
+#ifndef JANA2_DSTEXAMPLE_DATAOBJECTS_H
+#define JANA2_DSTEXAMPLE_DATAOBJECTS_H
+
+#include <JANA/JObject.h>
+
+/// Renderable is another base class. We strongly encourage users to
+/// stick to _implementation_inheritance_, aka no member variables and all
+/// member functions are pure virtual.
+struct Renderable {
+    virtual void Render() = 0;
+    virtual ~Renderable() = default;
+};
+
+struct MyJObject : public JObject {
+    int x;
+    int y;
+    double E;
+
+    void Summarize(JObjectSummary& summary) const override {
+        summary.add(x, NAME_OF(x), "%d", "Pixel coordinates centered around 0,0");
+        summary.add(y, NAME_OF(y), "%d", "Pixel coordinates centered around 0,0");
+        summary.add(E, NAME_OF(E), "%f", "Energy loss in GeV");
+    }
+
+    const std::string className() const override {
+        return NAME_OF_THIS;
+    }
+};
+
+struct MyRenderable : public Renderable {
+    int x;
+    int y;
+    double E;
+
+    void Render() override {
+        LOG << "MyRenderable::Render " << x << "," << y << "," << E << LOG_END;
+    }
+};
+
+struct MyRenderableJObject : public JObject, Renderable {
+    int x;
+    int y;
+    double E;
+
+    /// Renderable vfunctions
+
+    void Render() override {
+        LOG << "MyRenderableJObject::Render " << x << "," << y << "," << E << LOG_END;
+    }
+
+    /// JObject vfunctions
+
+    void Summarize(JObjectSummary& summary) const override {
+        summary.add(x, NAME_OF(x), "%d", "Pixel coordinates centered around 0,0");
+        summary.add(y, NAME_OF(y), "%d", "Pixel coordinates centered around 0,0");
+        summary.add(E, NAME_OF(E), "%f", "Energy loss in GeV");
+    }
+
+    const std::string className() const override {
+        return NAME_OF_THIS;
+    }
+};
+
+#endif //JANA2_DATAOBJECTS_H

--- a/src/examples/DstExample/DstExample.cc
+++ b/src/examples/DstExample/DstExample.cc
@@ -1,0 +1,26 @@
+
+
+#include <JANA/JApplication.h>
+#include <JANA/JFactoryGenerator.h>
+
+#include "DstExampleProcessor.h"
+
+extern "C" {
+void InitPlugin(JApplication* app) {
+
+    // This code is executed when the plugin is attached.
+    // It should always call InitJANAPlugin(app) first, and then do one or more of:
+    //   - Read configuration parameters
+    //   - Register JFactoryGenerators
+    //   - Register JEventProcessors
+    //   - Register JEventSourceGenerators (or JEventSources directly)
+    //   - Register JServices
+
+    InitJANAPlugin(app);
+
+    LOG << "Loading DstExample" << LOG_END;
+    app->Add(new DstExampleProcessor);
+    // Add any additional components as needed
+}
+}
+

--- a/src/examples/DstExample/DstExample.cc
+++ b/src/examples/DstExample/DstExample.cc
@@ -4,6 +4,7 @@
 #include <JANA/JFactoryGenerator.h>
 
 #include "DstExampleProcessor.h"
+#include "DstExampleSource.h"
 
 extern "C" {
 void InitPlugin(JApplication* app) {
@@ -20,7 +21,7 @@ void InitPlugin(JApplication* app) {
 
     LOG << "Loading DstExample" << LOG_END;
     app->Add(new DstExampleProcessor);
-    // Add any additional components as needed
+    app->Add(new DstExampleSource("dummy", app));
 }
 }
 

--- a/src/examples/DstExample/DstExample.cc
+++ b/src/examples/DstExample/DstExample.cc
@@ -5,23 +5,17 @@
 
 #include "DstExampleProcessor.h"
 #include "DstExampleSource.h"
+#include "DstExampleFactory.h"
 
 extern "C" {
 void InitPlugin(JApplication* app) {
-
-    // This code is executed when the plugin is attached.
-    // It should always call InitJANAPlugin(app) first, and then do one or more of:
-    //   - Read configuration parameters
-    //   - Register JFactoryGenerators
-    //   - Register JEventProcessors
-    //   - Register JEventSourceGenerators (or JEventSources directly)
-    //   - Register JServices
 
     InitJANAPlugin(app);
 
     LOG << "Loading DstExample" << LOG_END;
     app->Add(new DstExampleProcessor);
     app->Add(new DstExampleSource("dummy", app));
+    app->Add(new JFactoryGeneratorT<DstExampleFactory>());
 }
 }
 

--- a/src/examples/DstExample/DstExampleFactory.cc
+++ b/src/examples/DstExample/DstExampleFactory.cc
@@ -1,0 +1,33 @@
+
+#include "DstExampleFactory.h"
+#include "DataObjects.h"
+
+#include <JANA/JEvent.h>
+
+void DstExampleFactory::Init() {
+
+    /// This is necessary to generate the virtual function which does the conversion.
+    /// Otherwise your datatype won't show up when you call event->GetAllChildren<T>.
+    /// You can call this from the ctor, from Init, or from JEventSource::GetEvent.
+
+    EnableGetAs<JObject>();
+    EnableGetAs<Renderable>();
+}
+
+void DstExampleFactory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
+}
+
+void DstExampleFactory::Process(const std::shared_ptr<const JEvent> &event) {
+
+    auto inputs = event->Get<MyRenderableJObject>("from_source");
+
+    std::vector<MyRenderableJObject*> results;
+
+    for (auto input : inputs) {
+        // "Smear" each input
+        auto mrj = new MyRenderableJObject(input->x + 1, input->y + 1, input->E + 1);
+        results.push_back(mrj);
+    }
+
+    Set(results);
+}

--- a/src/examples/DstExample/DstExampleFactory.h
+++ b/src/examples/DstExample/DstExampleFactory.h
@@ -1,0 +1,21 @@
+
+#ifndef _DstExampleFactory_h_
+#define _DstExampleFactory_h_
+
+#include <JANA/JFactoryT.h>
+
+#include "DataObjects.h"
+
+class DstExampleFactory : public JFactoryT<MyRenderableJObject> {
+
+    // Insert any member variables here
+
+public:
+    DstExampleFactory() : JFactoryT<MyRenderableJObject>(NAME_OF_THIS, "from_factory") {};
+    void Init() override;
+    void ChangeRun(const std::shared_ptr<const JEvent> &event) override;
+    void Process(const std::shared_ptr<const JEvent> &event) override;
+
+};
+
+#endif // _DstExampleFactory_h_

--- a/src/examples/DstExample/DstExampleProcessor.cc
+++ b/src/examples/DstExample/DstExampleProcessor.cc
@@ -19,9 +19,9 @@ void DstExampleProcessor::Process(const std::shared_ptr<const JEvent> &event) {
     auto renderable_map = event->GetAllChildren<Renderable>();
     auto jobject_map = event->GetAllChildren<JObject>();
 
-    /// Senquentially,
+    /// Senquentially, iterate over everything
     std::lock_guard<std::mutex>lock(m_mutex);
-    for (auto item : renderable_map) {
+    for (const auto& item : renderable_map) {
         // destructure
         std::string factory_name = item.first.first;
         std::string factory_tag = item.first.second;
@@ -33,7 +33,7 @@ void DstExampleProcessor::Process(const std::shared_ptr<const JEvent> &event) {
         }
     }
 
-    for (auto item : jobject_map) {
+    for (const auto& item : jobject_map) {
         // destructure
         std::string factory_name = item.first.first;
         std::string factory_tag = item.first.second;
@@ -45,8 +45,6 @@ void DstExampleProcessor::Process(const std::shared_ptr<const JEvent> &event) {
             LOG << "Found JObject with classname " << jobject->className() << LOG_END;
         }
     }
-
-
 }
 
 void DstExampleProcessor::Finish() {

--- a/src/examples/DstExample/DstExampleProcessor.cc
+++ b/src/examples/DstExample/DstExampleProcessor.cc
@@ -1,0 +1,35 @@
+
+#include "DstExampleProcessor.h"
+#include <JANA/JLogger.h>
+
+DstExampleProcessor::DstExampleProcessor() {
+    SetTypeName(NAME_OF_THIS); // Provide JANA with this class's name
+}
+
+void DstExampleProcessor::Init() {
+    LOG << "DstExampleProcessor::Init" << LOG_END;
+    // Open TFiles, set up TTree branches, etc
+}
+
+void DstExampleProcessor::Process(const std::shared_ptr<const JEvent> &event) {
+    LOG << "DstExampleProcessor::Process, Event #" << event->GetEventNumber() << LOG_END;
+    
+    /// Do everything we can in parallel
+    /// Warning: We are only allowed to use local variables and `event` here
+    //auto hits = event->Get<Hit>();
+
+    /// Lock mutex
+    std::lock_guard<std::mutex>lock(m_mutex);
+
+    /// Do the rest sequentially
+    /// Now we are free to access shared state such as m_heatmap
+    //for (const Hit* hit : hits) {
+        /// Update shared state
+    //}
+}
+
+void DstExampleProcessor::Finish() {
+    // Close any resources
+    LOG << "DstExampleProcessor::Finish" << LOG_END;
+}
+

--- a/src/examples/DstExample/DstExampleProcessor.h
+++ b/src/examples/DstExample/DstExampleProcessor.h
@@ -1,0 +1,25 @@
+
+#ifndef _DstExampleProcessor_h_
+#define _DstExampleProcessor_h_
+
+#include <JANA/JEventProcessor.h>
+
+class DstExampleProcessor : public JEventProcessor {
+
+    // Shared state (e.g. histograms, TTrees, TFiles) live
+    std::mutex m_mutex;
+    
+public:
+
+    DstExampleProcessor();
+    virtual ~DstExampleProcessor() = default;
+
+    void Init() override;
+    void Process(const std::shared_ptr<const JEvent>& event) override;
+    void Finish() override;
+
+};
+
+
+#endif // _DstExampleProcessor_h_
+

--- a/src/examples/DstExample/DstExampleSource.cc
+++ b/src/examples/DstExample/DstExampleSource.cc
@@ -59,7 +59,7 @@ void DstExampleSource::GetEvent(std::shared_ptr <JEvent> event) {
     /// Insert some canned MyRenderableJObjects
     std::vector<MyRenderableJObject*> my_renderable_jobjects;
     my_renderable_jobjects.push_back(new MyRenderableJObject(1,1,1.1));
-    auto my_both_fac = event->Insert(my_renderable_jobjects);
+    auto my_both_fac = event->Insert(my_renderable_jobjects, "from_source");
 
     /// Enable automatic upcast to both JObjects and Renderable
     my_both_fac->EnableGetAs<JObject>();

--- a/src/examples/DstExample/DstExampleSource.cc
+++ b/src/examples/DstExample/DstExampleSource.cc
@@ -1,0 +1,75 @@
+
+
+#include "DstExampleSource.h"
+
+#include <JANA/JApplication.h>
+#include <JANA/JEvent.h>
+#include "DataObjects.h"
+
+DstExampleSource::DstExampleSource(std::string resource_name, JApplication* app) : JEventSource(resource_name, app) {
+    SetTypeName(NAME_OF_THIS); // Provide JANA with class name
+}
+
+void DstExampleSource::Open() {
+
+    /// Open is called exactly once when processing begins.
+    
+    /// Get any configuration parameters from the JApplication
+    // GetApplication()->SetDefaultParameter("DstExampleSource:random_seed", m_seed, "Random seed");
+
+    /// For opening a file, get the filename via:
+    // std::string resource_name = GetResourceName();
+    /// Open the file here!
+}
+
+void DstExampleSource::GetEvent(std::shared_ptr <JEvent> event) {
+
+    /// Calls to GetEvent are synchronized with each other, which means they can
+    /// read and write state on the JEventSource without causing race conditions.
+    
+    /// Configure event and run numbers
+    static size_t current_event_number = 1;
+    event->SetEventNumber(current_event_number++);
+    event->SetRunNumber(22);
+
+    /// Limit ourselves to 10 events
+    if (current_event_number > 10) {
+        throw RETURN_STATUS::kNO_MORE_EVENTS;
+    }
+
+    /// Insert some canned MyJObjects
+    std::vector<MyJObject*> my_jobjects;
+    my_jobjects.push_back(new MyJObject(7,7,1.8));
+    my_jobjects.push_back(new MyJObject(8,8,9.9));
+    event->Insert(my_jobjects);
+
+    /// Insert some canned MyRenderables
+    std::vector<MyRenderable*> my_renderables;
+    my_renderables.push_back(new MyRenderable(0,0,22.2));
+    my_renderables.push_back(new MyRenderable(0,1,17.0));
+    my_renderables.push_back(new MyRenderable(1,0,21.9));
+    event->Insert(my_renderables);
+
+    /// Insert some canned MyRenderableJObjects
+    std::vector<MyRenderableJObject*> my_renderable_jobjects;
+    my_renderable_jobjects.push_back(new MyRenderableJObject(1,1,1.1));
+    event->Insert(my_renderable_jobjects);
+}
+
+std::string DstExampleSource::GetDescription() {
+    return "Dummy source for demonstrating DST example";
+}
+
+
+template <>
+double JEventSourceGeneratorT<DstExampleSource>::CheckOpenable(std::string resource_name) {
+
+    /// CheckOpenable() decides how confident we are that this EventSource can handle this resource.
+    ///    0.0        -> 'Cannot handle'
+    ///    (0.0, 1.0] -> 'Can handle, with this confidence level'
+    
+    /// To determine confidence level, feel free to open up the file and check for magic bytes or metadata.
+    /// Returning a confidence <- {0.0, 1.0} is perfectly OK!
+    
+    return (resource_name == "DstExampleSource") ? 1.0 : 0.0;
+}

--- a/src/examples/DstExample/DstExampleSource.cc
+++ b/src/examples/DstExample/DstExampleSource.cc
@@ -32,8 +32,8 @@ void DstExampleSource::GetEvent(std::shared_ptr <JEvent> event) {
     event->SetEventNumber(current_event_number++);
     event->SetRunNumber(22);
 
-    /// Limit ourselves to 10 events
-    if (current_event_number > 10) {
+    /// Limit ourselves to 1 event
+    if (current_event_number > 2) {
         throw RETURN_STATUS::kNO_MORE_EVENTS;
     }
 
@@ -41,19 +41,29 @@ void DstExampleSource::GetEvent(std::shared_ptr <JEvent> event) {
     std::vector<MyJObject*> my_jobjects;
     my_jobjects.push_back(new MyJObject(7,7,1.8));
     my_jobjects.push_back(new MyJObject(8,8,9.9));
-    event->Insert(my_jobjects);
+    auto my_jobj_fac = event->Insert(my_jobjects);
+
+    /// Enable automatic upcast to JObject
+    my_jobj_fac->EnableGetAs<JObject>();
 
     /// Insert some canned MyRenderables
     std::vector<MyRenderable*> my_renderables;
     my_renderables.push_back(new MyRenderable(0,0,22.2));
     my_renderables.push_back(new MyRenderable(0,1,17.0));
     my_renderables.push_back(new MyRenderable(1,0,21.9));
-    event->Insert(my_renderables);
+    auto my_ren_fac = event->Insert(my_renderables);
+
+    /// Enable automatic upcast to Renderable
+    my_ren_fac->EnableGetAs<Renderable>();
 
     /// Insert some canned MyRenderableJObjects
     std::vector<MyRenderableJObject*> my_renderable_jobjects;
     my_renderable_jobjects.push_back(new MyRenderableJObject(1,1,1.1));
-    event->Insert(my_renderable_jobjects);
+    auto my_both_fac = event->Insert(my_renderable_jobjects);
+
+    /// Enable automatic upcast to both JObjects and Renderable
+    my_both_fac->EnableGetAs<JObject>();
+    my_both_fac->EnableGetAs<Renderable>();
 }
 
 std::string DstExampleSource::GetDescription() {

--- a/src/examples/DstExample/DstExampleSource.h
+++ b/src/examples/DstExample/DstExampleSource.h
@@ -1,0 +1,30 @@
+
+
+#ifndef _DstExampleSource_h_
+#define  _DstExampleSource_h_
+
+#include <JANA/JEventSource.h>
+#include <JANA/JEventSourceGeneratorT.h>
+
+class DstExampleSource : public JEventSource {
+
+    /// Add member variables here
+
+public:
+    DstExampleSource(std::string resource_name, JApplication* app);
+
+    virtual ~DstExampleSource() = default;
+
+    void Open() override;
+
+    void GetEvent(std::shared_ptr<JEvent>) override;
+    
+    static std::string GetDescription();
+
+};
+
+template <>
+double JEventSourceGeneratorT<DstExampleSource>::CheckOpenable(std::string);
+
+#endif // _DstExampleSource_h_
+

--- a/src/examples/DstExample/README.md
+++ b/src/examples/DstExample/README.md
@@ -1,0 +1,5 @@
+
+DST Example
+-----------
+This example demonstrates using data objects which don't share a common base class. 
+Event processors which 

--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -99,7 +99,10 @@ class JEvent : public JResettable, public std::enable_shared_from_this<JEvent>
 		template<class T> typename JFactoryT<T>::PairType GetIterators(const std::string& aTag = "") const;
         template<class T> std::vector<const T*> GetAll() const;
 
-		// Insert
+        template<class T>
+        std::map<std::pair<std::string,std::string>,std::vector<T*>> GetAllChildren() const;
+
+    // Insert
 		template <class T> void Insert(T* item, const std::string& aTag = "") const;
 		template <class T> void Insert(const std::vector<T*>& items, const std::string& tag = "") const;
 
@@ -276,6 +279,25 @@ std::vector<const T*> JEvent::GetAll() const {
         }
     }
     return vec; // Assumes RVO
+}
+
+
+// GetAllChildren will furnish a map { (type_name,tag_name) : [BaseClass*] } containing all JFactoryT<T> data where
+// T inherits from BaseClass. Note that this _won't_ compute any results (unlike GetAll) because this is meant for
+// things like visualizing and persisting DSTs.
+// TODO: This is conceptually inconsistent with GetAll. Reconcile.
+
+template<class S>
+std::map<std::pair<std::string, std::string>, std::vector<S*>> JEvent::GetAllChildren() const {
+    std::map<std::pair<std::string, std::string>, std::vector<S*>> results;
+    for (JFactory* factory : mFactorySet->GetAll()) {
+        auto val = factory->GetAs<S>();
+        if (!val.empty()) {
+            auto key = std::make_pair(factory->GetName(), factory->GetTag());
+            results.insert(std::make_pair(key, val));
+        }
+    }
+    return results;
 }
 
 

--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -102,9 +102,9 @@ class JEvent : public JResettable, public std::enable_shared_from_this<JEvent>
         template<class T>
         std::map<std::pair<std::string,std::string>,std::vector<T*>> GetAllChildren() const;
 
-    // Insert
-		template <class T> void Insert(T* item, const std::string& aTag = "") const;
-		template <class T> void Insert(const std::vector<T*>& items, const std::string& tag = "") const;
+        // Insert
+		template <class T> JFactoryT<T>* Insert(T* item, const std::string& aTag = "") const;
+		template <class T> JFactoryT<T>* Insert(const std::vector<T*>& items, const std::string& tag = "") const;
 
 		//SETTERS
 		void SetRunNumber(uint32_t aRunNumber){mRunNumber = aRunNumber;}
@@ -137,7 +137,7 @@ class JEvent : public JResettable, public std::enable_shared_from_this<JEvent>
 /// Repeated calls to Insert() will append to the previous data rather than overwrite it,
 /// which saves the user from having to allocate a throwaway vector and requires less error handling.
 template <class T>
-inline void JEvent::Insert(T* item, const std::string& tag) const {
+inline JFactoryT<T>* JEvent::Insert(T* item, const std::string& tag) const {
 
 	auto factory = mFactorySet->GetFactory<T>(tag);
 	if (factory == nullptr) {
@@ -145,10 +145,11 @@ inline void JEvent::Insert(T* item, const std::string& tag) const {
 		mFactorySet->Add(factory);
 	}
 	factory->Insert(item);
+	return factory;
 }
 
 template <class T>
-inline void JEvent::Insert(const std::vector<T*>& items, const std::string& tag) const {
+inline JFactoryT<T>* JEvent::Insert(const std::vector<T*>& items, const std::string& tag) const {
 
 	auto factory = mFactorySet->GetFactory<T>(tag);
 	if (factory == nullptr) {
@@ -158,6 +159,7 @@ inline void JEvent::Insert(const std::vector<T*>& items, const std::string& tag)
 	for (T* item : items) {
 		factory->Insert(item);
 	}
+	return factory;
 }
 
 /// GetFactory() should be used with extreme care because it subverts the JEvent abstraction.

--- a/src/libraries/JANA/JFactory.h
+++ b/src/libraries/JANA/JFactory.h
@@ -55,6 +55,8 @@
 #include <vector>
 #include <mutex>
 #include <unordered_map>
+#include <functional>
+
 
 class JEvent;
 class JObject;

--- a/src/libraries/JANA/JFactorySet.cc
+++ b/src/libraries/JANA/JFactorySet.cc
@@ -112,6 +112,18 @@ JFactory* JFactorySet::GetFactory(std::type_index aObjectType, const std::string
 }
 
 //---------------------------------
+// GetFactory
+//---------------------------------
+std::vector<JFactory*> JFactorySet::GetAll() const {
+    std::vector<JFactory*> results;
+    for (auto p : mFactories) {
+        results.push_back(p.second);
+    }
+    return results;
+}
+
+
+//---------------------------------
 // Merge
 //---------------------------------
 void JFactorySet::Merge(JFactorySet &aFactorySet)

--- a/src/libraries/JANA/JFactorySet.h
+++ b/src/libraries/JANA/JFactorySet.h
@@ -70,6 +70,7 @@ class JFactorySet : public JResettable
 
 		JFactory* GetFactory(std::type_index aObjectType, const std::string& aFactoryTag="") const;
 		template<typename T> JFactoryT<T>* GetFactory(const std::string& tag = "") const;
+        std::vector<JFactory*> GetAll() const;
 		template<typename T> std::vector<JFactoryT<T>*> GetFactoryAll() const;
 
 		std::vector<JFactorySummary> Summarize() const;

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -163,6 +163,12 @@ public:
         mStatus = Status::Inserted;
     }
 
+
+    /// EnableGetAs generates a vtable entry so that users may extract the
+    /// contents of this JFactoryT using JFactory
+    template <typename S> void EnableGetAs ();
+
+
     void ClearData() override {
 
         // ClearData won't do anything if Init() hasn't been called
@@ -197,6 +203,24 @@ protected:
     std::vector<T*> mData;
     JMetadata<T> mMetadata;
 };
+
+template<typename T>
+template<typename S>
+void JFactoryT<T>::EnableGetAs() {
+
+    auto upcast_lambda = [this]() {
+        std::vector<S*> results;
+        for (auto t : mData) {
+            results.push_back(static_cast<S*>(t));
+        }
+        return results;
+    };
+
+    auto key = std::type_index(typeid(S));
+    using upcast_fn_t = std::function<std::vector<S*>()>;
+    auto upcast_fn = new upcast_fn_t(upcast_lambda);
+    mUpcastVTable[key] = upcast_fn;
+}
 
 #endif // _JFactoryT_h_
 

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -67,7 +67,9 @@ public:
 
 
     JFactoryT(const std::string& aName = JTypeInfo::demangle<T>(), const std::string& aTag = "")
-    : JFactory(aName, aTag) {}
+    : JFactory(aName, aTag) {
+        EnableGetAs<T>();
+    }
 
     ~JFactoryT() override = default;
 
@@ -165,7 +167,9 @@ public:
 
 
     /// EnableGetAs generates a vtable entry so that users may extract the
-    /// contents of this JFactoryT using JFactory
+    /// contents of this JFactoryT from the type-erased JFactory. The user has to manually specify which upcasts
+    /// to allow, and they have to do so for each instance. It is recommended to do so in the constructor.
+    /// Note that EnableGetAs<T>() is called automatically.
     template <typename S> void EnableGetAs ();
 
 

--- a/src/programs/tests/CMakeLists.txt
+++ b/src/programs/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TEST_SOURCES
     JFactoryTests.h
     JFactoryTests.cc
     NEventNSkipTests.cc
+    JEventGetAllTests.cc
     )
 
 add_executable(janatests ${TEST_SOURCES})

--- a/src/programs/tests/JEventGetAllTests.cc
+++ b/src/programs/tests/JEventGetAllTests.cc
@@ -150,3 +150,35 @@ TEST_CASE("JFactoryGetAs") {
         REQUIRE(multiples[0]->multiple == 49);
     }
 }
+
+TEST_CASE("JEventGetAllChildren") {
+
+    auto event = std::make_shared<JEvent>();
+    event->SetFactorySet(new JFactorySet);
+
+    SECTION("Single-item JEvent::Insert() can be retrieved via JEvent::GetAllChildren()") {
+        auto b = new Base(22);
+        auto d = new Derived(33,44);
+        auto u = new Unrelated(19);
+        auto m = new Multiple(1,2,3,4);
+
+        event->Insert(b);
+        event->Insert(u);
+        event->Insert(d)->EnableGetAs<Base>();
+
+        auto f = event->Insert(m);
+        f->EnableGetAs<Base>();
+        f->EnableGetAs<Derived>();
+        f->EnableGetAs<Unrelated>();
+
+        auto base_map = event->GetAllChildren<Base>();
+        REQUIRE(base_map.size() == 3);
+        REQUIRE(base_map[{"Base",""}].size() == 1);
+        REQUIRE(base_map[{"Base",""}][0]->base == 22);
+        REQUIRE(base_map[{"Derived",""}].size() == 1);
+        REQUIRE(base_map[{"Derived",""}][0]->base == 33);
+        REQUIRE(base_map[{"Multiple",""}].size() == 1);
+        REQUIRE(base_map[{"Multiple",""}][0]->base == 1);
+    }
+
+}

--- a/src/programs/tests/JEventGetAllTests.cc
+++ b/src/programs/tests/JEventGetAllTests.cc
@@ -1,0 +1,152 @@
+#include "catch.hpp"
+#include <JANA/JEvent.h>
+
+struct Base {
+    double base;
+    Base(double base) : base(base) {};
+};
+
+struct Derived : public Base {
+    double derived;
+    Derived(double base, double derived) : Base(base), derived(derived) {};
+};
+
+struct Unrelated {
+    double unrelated;
+    Unrelated(double unrelated) : unrelated(unrelated) {};
+};
+
+struct Multiple : public Derived, Unrelated {
+    double multiple;
+    Multiple(double base, double derived, double unrelated, double multiple)
+        : Derived(base, derived), Unrelated(unrelated), multiple(multiple) {};
+};
+
+class DerivedFactory : public JFactoryT<Derived> {
+public:
+    DerivedFactory() {
+        EnableGetAs<Base>();
+    }
+};
+
+class OtherDerivedFactory : public JFactoryT<Derived> {
+public:
+    OtherDerivedFactory() {
+        EnableGetAs<Base>();
+    }
+
+    void Process(const std::shared_ptr<const JEvent>& event) override {
+        Insert(new Derived(19, 13));
+        Insert(new Derived(29, 23));
+    }
+};
+
+class UnrelatedFactory : public JFactoryT<Unrelated> {};
+
+class MultipleFactory : public JFactoryT<Multiple> {
+public:
+    MultipleFactory() {
+        EnableGetAs<Base>();
+        EnableGetAs<Derived>();
+        EnableGetAs<Unrelated>();
+    }
+};
+
+class MultipleFactoryMissing : public JFactoryT<Multiple> {
+public:
+    MultipleFactoryMissing() {
+        EnableGetAs<Derived>();
+    }
+};
+
+TEST_CASE("JFactoryGetAs") {
+
+    SECTION("Upcast Derived to Base (single item inserted)") {
+        DerivedFactory f;
+        f.Insert(new Derived (7, 22));
+        auto bases = f.GetAs<Base>();
+        REQUIRE(bases.size() == 1);
+        REQUIRE(bases[0]->base == 7);
+    }
+
+    SECTION("Upcast Derived to Base (multiple items inserted)") {
+        DerivedFactory f;
+        f.Insert(new Derived (7, 22));
+        f.Insert(new Derived (8, 23));
+        f.Insert(new Derived (9, 24));
+        auto bases = f.GetAs<Base>();
+
+        REQUIRE(bases.size() == 3);
+        REQUIRE(bases[0]->base == 7);
+        REQUIRE(bases[1]->base == 8);
+        REQUIRE(bases[2]->base == 9);
+    }
+
+    SECTION("Upcast Derived to Unrelated (single item inserted)") {
+        DerivedFactory f;
+        f.Insert(new Derived (7, 22));
+        auto bases = f.GetAs<Unrelated>();
+        REQUIRE(bases.size() == 0);
+        REQUIRE(bases.size() == 0);
+    }
+
+    SECTION("Upcast Derived to Derived (single item inserted)") {
+        DerivedFactory f;
+        f.Insert(new Derived(22, 18));
+        auto deriveds = f.GetAs<Derived>();
+        REQUIRE(deriveds.size() == 1);
+        REQUIRE(deriveds[0]->derived == 18);
+    }
+
+    SECTION("GetAs doesn't trigger Process()") {
+        OtherDerivedFactory f;
+        auto deriveds_before = f.GetAs<Derived>();
+        REQUIRE(deriveds_before.size() == 0);
+        f.Process(std::make_shared<JEvent>());
+        auto deriveds_after = f.GetAs<Derived>();
+        REQUIRE(deriveds_after.size() == 2);
+    }
+
+    SECTION("Upcast Multiple to each of its bases") {
+        MultipleFactory f;
+        f.Insert(new Multiple(22, 27, 42, 49));
+
+        auto bases = f.GetAs<Base>();
+        REQUIRE(bases.size() == 1);
+        REQUIRE(bases[0]->base == 22);
+
+        auto deriveds = f.GetAs<Derived>();
+        REQUIRE(deriveds.size() == 1);
+        REQUIRE(deriveds[0]->derived == 27);
+
+        auto unrelateds = f.GetAs<Unrelated>();
+        REQUIRE(unrelateds.size() == 1);
+        REQUIRE(unrelateds[0]->unrelated == 42);
+
+        auto multiples = f.GetAs<Multiple>();
+        REQUIRE(multiples.size() == 1);
+        REQUIRE(multiples[0]->multiple == 49);
+    }
+
+    SECTION("Upcast only succeeds if bases have been enabled") {
+        MultipleFactoryMissing f;
+        f.Insert(new Multiple(22, 27, 42, 49));
+
+        auto bases = f.GetAs<Base>();
+        REQUIRE(bases.size() == 0);
+
+        auto deriveds = f.GetAs<Derived>();
+        REQUIRE(deriveds.size() == 1);
+        REQUIRE(deriveds[0]->derived == 27);
+
+        auto unrelateds = f.GetAs<Unrelated>();
+        REQUIRE(unrelateds.size() == 0);
+
+        auto multiples = f.GetAs<Multiple>();
+        REQUIRE(multiples.size() == 1);
+        REQUIRE(multiples[0]->base == 22);
+        REQUIRE(multiples[0]->derived == 27);
+        REQUIRE(multiples[0]->unrelated == 42);
+        REQUIRE(multiples[0]->multiple == 49);
+    }
+}


### PR DESCRIPTION
This feature allows JFactories to wrap data of arbitrary type T without putting constraints on the base class U. Furthermore, it allows the user to _optionally_ automatically upcast from T to U. If JFactory type-erases T, JFactory::GetAs<U> more or less makes JFactory covariant. Icing on the cake: the conversion from T to U only requires a static_cast. JEvent meanwhile is given the method GetAllChildren<U>, which essentially projects the JEvent down to a map like so: 
`{ (factory_name: string, factory_tag: string) : [U*] }`. This lets an EventProcessor which only knows about U access everything in the event it knows how to deal with, without depriving it of any contextual information.

GetAs is important because it means that the data objects in our domain model can multiply inherit from JObject, TObject, and any other interface we'd like. This means we can build a ROOT DST, and it means we can write plugins like janaview without tacking on additional requirements to JObject. This goes a long way towards having good integration with ROOT/Apache Arrow/etc while at the same time keeping concerns separate and orthogonal.