### PR TITLE
JMetadata example

### DIFF
--- a/docs/Howto.md
+++ b/docs/Howto.md
@@ -23,17 +23,18 @@ Table of contents
 2.  [Use the JANA command-line program](#using-the-jana-cli)
 3.  [Configure JANA](#configuring-jana)
 4.  [Generate code skeletons](#creating-code-skeletons) for projects, plugins, components, etc
-5.  Create a service which can be shared between different plugins
-6.  Handle both real and simulated data
-7.  Handle EPICS data
-8.  [Detect when a group of events has finished](howto_group_events.md)
-9.  Use JANA with ROOT
-10.  Persist the entire DST using ROOT
-11. Checkpoint the entire DST using ROOT
-12. [Stream data to and from JANA](howto_streaming.html)
-13. Build and filter events ("L1 and L2 triggers")
-14. Process subevents
-15. Migrate from JANA1 to JANA2
+5.  [Work with factory metadata](#Using-factory-metadata) for collecting statistics, etc
+6.  Create a service which can be shared between different plugins
+7.  Handle both real and simulated data
+8.  Handle EPICS data
+9.  [Detect when a group of events has finished](howto_group_events.md)
+10.  Use JANA with ROOT
+11.  Persist the entire DST using ROOT
+12. Checkpoint the entire DST using ROOT
+13. [Stream data to and from JANA](howto_streaming.html)
+14. Build and filter events ("L1 and L2 triggers")
+15. Process subevents
+16. Migrate from JANA1 to JANA2
 
 
 Using the JANA CLI
@@ -211,6 +212,28 @@ JObject name is 'RecoTrack', and the factory uses Genfit under the hood, the fac
 'RecoTrackFactory_Genfit'. 
 
 ```jana-generate.py JFactory JFactoryNameInCamelCase JObjectNameInCamelCase```
+
+
+
+Using factory metadata
+----------------------
+
+The `JFactoryT<T>` interface abstracts the creation logic for a vector of n objects of type `T`. However, often
+we also care about single pieces of data associated with the same computation. For instance, a track fitting factory
+might want to return statistics about how many fits succeeded and failed. 
+
+A naive solution is to put member variables on the factory and then access them from a `JEventProcessor` 
+by obtaining the `JFactoryT<T>` via `GetFactory<>` and performing a dynamic cast to the underlying factory type. 
+Although this works, it means that that factory can no longer be swapped with an alternate version without modifying
+the calling code. This degrades the whole project's ability to take advantage of the plugin architecture and hurts 
+its overall code quality.
+
+Instead, we recommend using the `JMetadata` template trait. Each `JFactoryT<T>` not only produces a vector of `T`, 
+but also a singular `JMetadata<T>` struct whose contents can be completely arbitrary, but cannot be redefined for a
+particular T. All `JFactoryT<T>` for some `T` will use it. 
+
+An example project demonstrating usage of JMetadata can be found under `examples/MetadataExample`. 
+
 
 
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -2,3 +2,4 @@
 add_subdirectory(Tutorial)
 add_subdirectory(StreamingExample)
 add_subdirectory(EventGroupExample)
+add_subdirectory(MetadataExample)

--- a/src/examples/MetadataExample/CMakeLists.txt
+++ b/src/examples/MetadataExample/CMakeLists.txt
@@ -1,0 +1,20 @@
+
+
+set (MetadataExample_PLUGIN_SOURCES
+		MetadataExample.cc
+		MetadataAggregator.cc
+		MetadataAggregator.h
+		Track.h
+		TrackSmearingFactory.cc
+		TrackSmearingFactory.h
+		RandomTrackSource.cc
+		RandomTrackSource.h
+	)
+
+add_library(MetadataExample_plugin SHARED ${MetadataExample_PLUGIN_SOURCES})
+
+target_include_directories(MetadataExample_plugin PUBLIC ${JANA_INCLUDE_DIR})
+target_link_libraries(MetadataExample_plugin ${JANA_LIBRARY})
+set_target_properties(MetadataExample_plugin PROPERTIES PREFIX "" OUTPUT_NAME "MetadataExample" SUFFIX ".so")
+install(TARGETS MetadataExample_plugin DESTINATION plugins)
+

--- a/src/examples/MetadataExample/CMakeLists.txt
+++ b/src/examples/MetadataExample/CMakeLists.txt
@@ -14,7 +14,7 @@ set (MetadataExample_PLUGIN_SOURCES
 add_library(MetadataExample_plugin SHARED ${MetadataExample_PLUGIN_SOURCES})
 
 target_include_directories(MetadataExample_plugin PUBLIC ${JANA_INCLUDE_DIR})
-target_link_libraries(MetadataExample_plugin ${JANA_LIBRARY})
+target_link_libraries(MetadataExample_plugin jana2)
 set_target_properties(MetadataExample_plugin PROPERTIES PREFIX "" OUTPUT_NAME "MetadataExample" SUFFIX ".so")
 install(TARGETS MetadataExample_plugin DESTINATION plugins)
 

--- a/src/examples/MetadataExample/MetadataAggregator.cc
+++ b/src/examples/MetadataExample/MetadataAggregator.cc
@@ -1,0 +1,35 @@
+
+#include "MetadataAggregator.h"
+#include <JANA/JLogger.h>
+
+MetadataExampleProcessor::MetadataExampleProcessor() {
+    SetTypeName(NAME_OF_THIS); // Provide JANA with this class's name
+}
+
+void MetadataExampleProcessor::Init() {
+    LOG << "MetadataExampleProcessor::Init" << LOG_END;
+    // Open TFiles, set up TTree branches, etc
+}
+
+void MetadataExampleProcessor::Process(const std::shared_ptr<const JEvent> &event) {
+    LOG << "MetadataExampleProcessor::Process, Event #" << event->GetEventNumber() << LOG_END;
+    
+    /// Do everything we can in parallel
+    /// Warning: We are only allowed to use local variables and `event` here
+    //auto hits = event->Get<Hit>();
+
+    /// Lock mutex
+    std::lock_guard<std::mutex>lock(m_mutex);
+
+    /// Do the rest sequentially
+    /// Now we are free to access shared state such as m_heatmap
+    //for (const Hit* hit : hits) {
+        /// Update shared state
+    //}
+}
+
+void MetadataExampleProcessor::Finish() {
+    // Close any resources
+    LOG << "MetadataExampleProcessor::Finish" << LOG_END;
+}
+

--- a/src/examples/MetadataExample/MetadataAggregator.cc
+++ b/src/examples/MetadataExample/MetadataAggregator.cc
@@ -2,16 +2,16 @@
 #include "MetadataAggregator.h"
 #include <JANA/JLogger.h>
 
-MetadataExampleProcessor::MetadataExampleProcessor() {
+MetadataAggregator::MetadataAggregator() {
     SetTypeName(NAME_OF_THIS); // Provide JANA with this class's name
 }
 
-void MetadataExampleProcessor::Init() {
+void MetadataAggregator::Init() {
     LOG << "MetadataExampleProcessor::Init" << LOG_END;
     // Open TFiles, set up TTree branches, etc
 }
 
-void MetadataExampleProcessor::Process(const std::shared_ptr<const JEvent> &event) {
+void MetadataAggregator::Process(const std::shared_ptr<const JEvent> &event) {
     LOG << "MetadataExampleProcessor::Process, Event #" << event->GetEventNumber() << LOG_END;
     
     /// Do everything we can in parallel
@@ -28,7 +28,7 @@ void MetadataExampleProcessor::Process(const std::shared_ptr<const JEvent> &even
     //}
 }
 
-void MetadataExampleProcessor::Finish() {
+void MetadataAggregator::Finish() {
     // Close any resources
     LOG << "MetadataExampleProcessor::Finish" << LOG_END;
 }

--- a/src/examples/MetadataExample/MetadataAggregator.cc
+++ b/src/examples/MetadataExample/MetadataAggregator.cc
@@ -18,7 +18,7 @@ void MetadataAggregator::Init() {
 }
 
 void MetadataAggregator::Process(const std::shared_ptr<const JEvent> &event) {
-    LOG << "MetadataAggregator::Process, Event #" << event->GetEventNumber() << LOG_END;
+    LOG << "MetadataAggregator::Process, Run #" << event->GetRunNumber() << ", Event #" << event->GetEventNumber() << LOG_END;
 
     // Acquire tracks in parallel
     auto tracks = event->Get<Track>(m_track_factory);

--- a/src/examples/MetadataExample/MetadataAggregator.cc
+++ b/src/examples/MetadataExample/MetadataAggregator.cc
@@ -33,6 +33,7 @@ void MetadataAggregator::Process(const std::shared_ptr<const JEvent> &event) {
         m_last_statistics = &m_statistics[m_last_run_nr]; // Get-or-create
     }
 
+    // Update the statistics accumulator using the metadata from this event
     m_last_statistics->event_count += 1;
     m_last_statistics->total_track_count += tracks.size();
     m_last_statistics->total_latency_ns += event->GetMetadata<Track>(m_track_factory).elapsed_time_ns;

--- a/src/examples/MetadataExample/MetadataAggregator.h
+++ b/src/examples/MetadataExample/MetadataAggregator.h
@@ -1,0 +1,25 @@
+
+#ifndef _MetadataExampleProcessor_h_
+#define _MetadataExampleProcessor_h_
+
+#include <JANA/JEventProcessor.h>
+
+class MetadataExampleProcessor : public JEventProcessor {
+
+    // Shared state (e.g. histograms, TTrees, TFiles) live
+    std::mutex m_mutex;
+    
+public:
+
+    MetadataExampleProcessor();
+    virtual ~MetadataExampleProcessor() = default;
+
+    void Init() override;
+    void Process(const std::shared_ptr<const JEvent>& event) override;
+    void Finish() override;
+
+};
+
+
+#endif // _MetadataExampleProcessor_h_
+

--- a/src/examples/MetadataExample/MetadataAggregator.h
+++ b/src/examples/MetadataExample/MetadataAggregator.h
@@ -18,7 +18,7 @@ class MetadataAggregator : public JEventProcessor {
 
     std::mutex m_mutex;
 
-    std::string m_track_factory; // So we can choose what we are measuring at runtime
+    std::string m_track_factory = "smeared"; // So we can choose what we are measuring at runtime
 
     std::map<int, Statistics> m_statistics; // Keyed off of run nr
 

--- a/src/examples/MetadataExample/MetadataAggregator.h
+++ b/src/examples/MetadataExample/MetadataAggregator.h
@@ -3,12 +3,29 @@
 #define _MetadataExampleProcessor_h_
 
 #include <JANA/JEventProcessor.h>
+#include <map>
 
 class MetadataAggregator : public JEventProcessor {
 
-    // Shared state (e.g. histograms, TTrees, TFiles) live
     std::mutex m_mutex;
-    
+
+    std::string m_track_factory; // So we can choose what we are measuring at runtime
+
+    std::map<int, std::pair<int, std::chrono::nanoseconds>> track_factory_statistics;
+    // { run_number : (event_count, total_elapsed_time) }
+
+    // Note that just like with JObjects, we don't want to store pointers to JMetadata here, because
+    // they will be overwritten when JEvents get recycled and dangle when JEvents are destroyed.
+    // Instead, we may either copy data out, or copy the entire structure outright, which is
+    // cheap when the JMetadata object is TriviallyCopyable, which we obviously encourage.
+
+    // We are also going to cache the last entry in our map so that we only have to do a map lookup
+    // when the run number changes.
+
+    int last_run_nr = -1;
+    std::pair<int, std::chrono::nanoseconds>* last_run_statistics = nullptr;
+
+
 public:
 
     MetadataAggregator();

--- a/src/examples/MetadataExample/MetadataAggregator.h
+++ b/src/examples/MetadataExample/MetadataAggregator.h
@@ -5,14 +5,22 @@
 #include <JANA/JEventProcessor.h>
 #include <map>
 
+
+
 class MetadataAggregator : public JEventProcessor {
+
+    /// Container for all of the statistics we want to collect from our event stream
+    struct Statistics {
+        size_t event_count = 0;
+        size_t total_track_count = 0;
+        std::chrono::nanoseconds total_latency_ns {0};
+    };
 
     std::mutex m_mutex;
 
     std::string m_track_factory; // So we can choose what we are measuring at runtime
 
-    std::map<int, std::pair<int, std::chrono::nanoseconds>> track_factory_statistics;
-    // { run_number : (event_count, total_elapsed_time) }
+    std::map<int, Statistics> m_statistics; // Keyed off of run nr
 
     // Note that just like with JObjects, we don't want to store pointers to JMetadata here, because
     // they will be overwritten when JEvents get recycled and dangle when JEvents are destroyed.
@@ -22,8 +30,8 @@ class MetadataAggregator : public JEventProcessor {
     // We are also going to cache the last entry in our map so that we only have to do a map lookup
     // when the run number changes.
 
-    int last_run_nr = -1;
-    std::pair<int, std::chrono::nanoseconds>* last_run_statistics = nullptr;
+    int m_last_run_nr = -1;
+    Statistics* m_last_statistics = nullptr;
 
 
 public:

--- a/src/examples/MetadataExample/MetadataAggregator.h
+++ b/src/examples/MetadataExample/MetadataAggregator.h
@@ -4,15 +4,15 @@
 
 #include <JANA/JEventProcessor.h>
 
-class MetadataExampleProcessor : public JEventProcessor {
+class MetadataAggregator : public JEventProcessor {
 
     // Shared state (e.g. histograms, TTrees, TFiles) live
     std::mutex m_mutex;
     
 public:
 
-    MetadataExampleProcessor();
-    virtual ~MetadataExampleProcessor() = default;
+    MetadataAggregator();
+    virtual ~MetadataAggregator() = default;
 
     void Init() override;
     void Process(const std::shared_ptr<const JEvent>& event) override;

--- a/src/examples/MetadataExample/MetadataExample.cc
+++ b/src/examples/MetadataExample/MetadataExample.cc
@@ -1,0 +1,26 @@
+
+
+#include <JANA/JApplication.h>
+#include <JANA/JFactoryGenerator.h>
+
+#include "MetadataAggregator.h"
+
+extern "C" {
+void InitPlugin(JApplication* app) {
+
+    // This code is executed when the plugin is attached.
+    // It should always call InitJANAPlugin(app) first, and then do one or more of:
+    //   - Read configuration parameters
+    //   - Register JFactoryGenerators
+    //   - Register JEventProcessors
+    //   - Register JEventSourceGenerators (or JEventSources directly)
+    //   - Register JServices
+
+    InitJANAPlugin(app);
+
+    LOG << "Loading MetadataExample" << LOG_END;
+    app->Add(new MetadataExampleProcessor);
+    // Add any additional components as needed
+}
+}
+

--- a/src/examples/MetadataExample/MetadataExample.cc
+++ b/src/examples/MetadataExample/MetadataExample.cc
@@ -10,14 +10,6 @@
 extern "C" {
 void InitPlugin(JApplication* app) {
 
-    // This code is executed when the plugin is attached.
-    // It should always call InitJANAPlugin(app) first, and then do one or more of:
-    //   - Read configuration parameters
-    //   - Register JFactoryGenerators
-    //   - Register JEventProcessors
-    //   - Register JEventSourceGenerators (or JEventSources directly)
-    //   - Register JServices
-
     InitJANAPlugin(app);
 
     LOG << "Loading MetadataExample" << LOG_END;

--- a/src/examples/MetadataExample/MetadataExample.cc
+++ b/src/examples/MetadataExample/MetadataExample.cc
@@ -4,6 +4,8 @@
 #include <JANA/JFactoryGenerator.h>
 
 #include "MetadataAggregator.h"
+#include "RandomTrackSource.h"
+#include "TrackSmearingFactory.h"
 
 extern "C" {
 void InitPlugin(JApplication* app) {
@@ -19,8 +21,10 @@ void InitPlugin(JApplication* app) {
     InitJANAPlugin(app);
 
     LOG << "Loading MetadataExample" << LOG_END;
-    app->Add(new MetadataExampleProcessor);
-    // Add any additional components as needed
+    app->Add(new RandomTrackSource("dummy", app));           // To generate random "tracks"
+    app->Add(new JFactoryGeneratorT<TrackSmearingFactory>);  // To perturb tracks
+    app->Add(new MetadataAggregator);                        // To collect perf data on track generation and smearing
+
 }
 }
 

--- a/src/examples/MetadataExample/README.md
+++ b/src/examples/MetadataExample/README.md
@@ -1,0 +1,19 @@
+
+This example demonstrates how a user can collect arbitrary statistics from their JFactories and aggregate them 
+in a JEventProcessor. 
+
+We can collect statistics from a JFactory without tying ourselves to a specific JFactory implementation by 
+implementing the JMetadata template trait. Basically, each JFactory<T> produces (along with a vector of T*) 
+a single struct of type JMetadata<T>, which can be defined arbitrarily as long as it is copyable.
+
+In this example, the metadata being recorded is the latency of processing a vector of tracks. The struct
+itself is defined in TrackMetadata.h. The TrackSmearingFactory will set the metadata during Process(). 
+A dummy event source will also insert tracks, and set the metadata when it does so.
+
+In its Process() method, MetadataAggregator obtains both tracks and corresponding metadata, either 
+directly from the source, or from the TrackSmearingFactory. It then updates a map containing statistics 
+keyed off of run number. It caches the most recently used statistics so we don't have to do a map lookup 
+on each event. 
+
+In its Finalize() method, MetadataAggregator prints statistics for each run. 
+

--- a/src/examples/MetadataExample/RandomTrackSource.cc
+++ b/src/examples/MetadataExample/RandomTrackSource.cc
@@ -1,0 +1,76 @@
+
+
+#include "RandomTrackSource.h"
+
+#include <JANA/JApplication.h>
+#include <JANA/JEvent.h>
+
+/// Include headers to any JObjects you wish to associate with each event
+// #include "Hit.h"
+
+/// There are two different ways of instantiating JEventSources
+/// 1. Creating them manually and registering them with the JApplication
+/// 2. Creating a corresponding JEventSourceGenerator and registering that instead
+///    If you have a list of files as command line args, JANA will use the JEventSourceGenerator
+///    to find the most appropriate JEventSource corresponding to that filename, instantiate and register it.
+///    For this to work, the JEventSource constructor has to have the following constructor arguments:
+
+RandomTrackSource::RandomTrackSource(std::string resource_name, JApplication* app) : JEventSource(resource_name, app) {
+    SetTypeName(NAME_OF_THIS); // Provide JANA with class name
+}
+
+void RandomTrackSource::Open() {
+
+    /// Open is called exactly once when processing begins.
+    
+    /// Get any configuration parameters from the JApplication
+    // GetApplication()->SetDefaultParameter("RandomTrackSource:random_seed", m_seed, "Random seed");
+
+    /// For opening a file, get the filename via:
+    // std::string resource_name = GetResourceName();
+    /// Open the file here!
+}
+
+void RandomTrackSource::GetEvent(std::shared_ptr <JEvent> event) {
+
+    /// Calls to GetEvent are synchronized with each other, which means they can
+    /// read and write state on the JEventSource without causing race conditions.
+    
+    /// Configure event and run numbers
+    static size_t current_event_number = 1;
+    event->SetEventNumber(current_event_number++);
+    event->SetRunNumber(22);
+
+    /// Insert whatever data was read into the event
+    // std::vector<Hit*> hits;
+    // hits.push_back(new Hit(0,0,1.0,0));
+    // event->Insert(hits);
+
+    /// If you are reading a file of events and have reached the end, terminate the stream like this:
+    // // Close file pointer!
+    // throw RETURN_STATUS::kNO_MORE_EVENTS;
+
+    /// If you are streaming events and there are no new events in the message queue,
+    /// tell JANA that GetEvent() was temporarily unsuccessful like this:
+    // throw RETURN_STATUS::kBUSY;
+}
+
+std::string RandomTrackSource::GetDescription() {
+
+    /// GetDescription() helps JANA explain to the user what is going on
+    return "";
+}
+
+
+template <>
+double JEventSourceGeneratorT<RandomTrackSource>::CheckOpenable(std::string resource_name) {
+
+    /// CheckOpenable() decides how confident we are that this EventSource can handle this resource.
+    ///    0.0        -> 'Cannot handle'
+    ///    (0.0, 1.0] -> 'Can handle, with this confidence level'
+    
+    /// To determine confidence level, feel free to open up the file and check for magic bytes or metadata.
+    /// Returning a confidence <- {0.0, 1.0} is perfectly OK!
+    
+    return (resource_name == "RandomTrackSource") ? 1.0 : 0.0;
+}

--- a/src/examples/MetadataExample/RandomTrackSource.h
+++ b/src/examples/MetadataExample/RandomTrackSource.h
@@ -8,7 +8,10 @@
 
 class RandomTrackSource : public JEventSource {
 
-    /// Add member variables here
+    int m_events_in_run;
+    int m_current_run_number;
+    int m_current_event_number;
+    int m_max_run_number;
 
 public:
     RandomTrackSource(std::string resource_name, JApplication* app);

--- a/src/examples/MetadataExample/RandomTrackSource.h
+++ b/src/examples/MetadataExample/RandomTrackSource.h
@@ -1,0 +1,30 @@
+
+
+#ifndef _RandomTrackSource_h_
+#define  _RandomTrackSource_h_
+
+#include <JANA/JEventSource.h>
+#include <JANA/JEventSourceGeneratorT.h>
+
+class RandomTrackSource : public JEventSource {
+
+    /// Add member variables here
+
+public:
+    RandomTrackSource(std::string resource_name, JApplication* app);
+
+    virtual ~RandomTrackSource() = default;
+
+    void Open() override;
+
+    void GetEvent(std::shared_ptr<JEvent>) override;
+    
+    static std::string GetDescription();
+
+};
+
+template <>
+double JEventSourceGeneratorT<RandomTrackSource>::CheckOpenable(std::string);
+
+#endif // _RandomTrackSource_h_
+

--- a/src/examples/MetadataExample/Track.h
+++ b/src/examples/MetadataExample/Track.h
@@ -1,0 +1,49 @@
+
+
+#ifndef _Track_h_
+#define _Track_h_
+
+#include <JANA/JObject.h>
+
+/// JObjects are plain-old data containers for inputs, intermediate results, and outputs.
+/// They have member functions for introspection and maintaining associations with other JObjects, but
+/// all of the numerical code which goes into their creation should live in a JFactory instead.
+/// You are allowed to include STL containers and pointers to non-POD datatypes inside your JObjects,
+/// however, it is highly encouraged to keep them flat and include only primitive datatypes if possible.
+/// Think of a JObject as being a row in a database table, with event number as an implicit foreign key.
+
+struct Track : public JObject {
+    int x;     // Pixel coordinates centered around 0,0
+    int y;     // Pixel coordinates centered around 0,0
+    double E;  // Energy loss in GeV
+    double t;  // Time in ms
+
+
+    /// Make it convenient to construct one of these things
+    Track(int x, int y, double E, double t) : x(x), y(y), E(E), t(t) {};
+
+
+    /// Override className to tell JANA to store the exact name of this class where we can
+    /// access it at runtime. JANA provides a NAME_OF_THIS macro so that this will return the correct value
+    /// even if you rename the class using automatic refactoring tools.
+
+    const std::string className() const override {
+        return NAME_OF_THIS;
+    }
+
+    /// Override Summarize to tell JANA how to produce a convenient string representation for our JObject.
+    /// This can be used called from user code, but also lets JANA automatically inspect its own data. For instance,
+    /// adding JCsvWriter<Hit> will automatically generate a CSV file containing each hit. Warning: This is obviously
+    /// slow, so use this for debugging and monitoring but not inside the performance critical code paths.
+
+    void Summarize(JObjectSummary& summary) const override {
+        summary.add(x, NAME_OF(x), "%d", "Pixel coordinates centered around 0,0");
+        summary.add(y, NAME_OF(y), "%d", "Pixel coordinates centered around 0,0");
+        summary.add(E, NAME_OF(E), "%f", "Energy loss in GeV");
+        summary.add(t, NAME_OF(t), "%f", "Time in ms");
+    }
+};
+
+
+#endif // _Track_h_
+

--- a/src/examples/MetadataExample/Track.h
+++ b/src/examples/MetadataExample/Track.h
@@ -5,23 +5,22 @@
 
 #include <JANA/JObject.h>
 
-/// JObjects are plain-old data containers for inputs, intermediate results, and outputs.
-/// They have member functions for introspection and maintaining associations with other JObjects, but
-/// all of the numerical code which goes into their creation should live in a JFactory instead.
-/// You are allowed to include STL containers and pointers to non-POD datatypes inside your JObjects,
-/// however, it is highly encouraged to keep them flat and include only primitive datatypes if possible.
-/// Think of a JObject as being a row in a database table, with event number as an implicit foreign key.
 
+/// A super basic Track model.
 struct Track : public JObject {
-    int x;     // Pixel coordinates centered around 0,0
-    int y;     // Pixel coordinates centered around 0,0
-    double E;  // Energy loss in GeV
-    double t;  // Time in ms
-
+    int pid;
+    double x;  // mm
+    double y;  // mm
+    double z;  // mm
+    double px; // GeV
+    double py; // GeV
+    double pz; // GeV
+    double t;  // ms
 
     /// Make it convenient to construct one of these things
-    Track(int x, int y, double E, double t) : x(x), y(y), E(E), t(t) {};
-
+    Track(int pid, double x, double y, double z, double px, double py, double pz, double t)
+        : pid(pid), x(x), y(y), z(z), px(px), py(py), pz(pz), t(t) {
+    }
 
     /// Override className to tell JANA to store the exact name of this class where we can
     /// access it at runtime. JANA provides a NAME_OF_THIS macro so that this will return the correct value
@@ -37,10 +36,14 @@ struct Track : public JObject {
     /// slow, so use this for debugging and monitoring but not inside the performance critical code paths.
 
     void Summarize(JObjectSummary& summary) const override {
-        summary.add(x, NAME_OF(x), "%d", "Pixel coordinates centered around 0,0");
-        summary.add(y, NAME_OF(y), "%d", "Pixel coordinates centered around 0,0");
-        summary.add(E, NAME_OF(E), "%f", "Energy loss in GeV");
-        summary.add(t, NAME_OF(t), "%f", "Time in ms");
+        summary.add(pid, NAME_OF(pid), "%d", "Particle PID");
+        summary.add(x, NAME_OF(x), "%d", "Pixel coordinates centered around 0,0 [mm]");
+        summary.add(y, NAME_OF(y), "%d", "Pixel coordinates centered around 0,0 [mm]");
+        summary.add(z, NAME_OF(z), "%d", "Pixel coordinates centered around 0,0 [mm]");
+        summary.add(px, NAME_OF(px), "%d", "Momentum in x direction [GeV]");
+        summary.add(py, NAME_OF(py), "%d", "Momentum in y direction [GeV]");
+        summary.add(pz, NAME_OF(pz), "%d", "Momentum in z direction [GeV]");
+        summary.add(t, NAME_OF(t), "%d", "Time in ms");
     }
 };
 

--- a/src/examples/MetadataExample/TrackMetadata.h
+++ b/src/examples/MetadataExample/TrackMetadata.h
@@ -17,7 +17,7 @@
 template <>
 struct JMetadata<Track> {
 
-    std::chrono::nanoseconds elapsed_time_ns = 0;
+    std::chrono::nanoseconds elapsed_time_ns {0};
 };
 
 #endif //JANA2_TRACKMETADATA_H

--- a/src/examples/MetadataExample/TrackMetadata.h
+++ b/src/examples/MetadataExample/TrackMetadata.h
@@ -1,0 +1,23 @@
+//
+// Created by Nathan Brei on 5/11/20.
+//
+
+#ifndef JANA2_TRACKMETADATA_H
+#define JANA2_TRACKMETADATA_H
+
+#include "Track.h"
+#include <chrono>
+
+/// We use the JMetadata template trait in order to attach arbitrary metadata to any JFactory<T>.
+/// This way we can extract metadata from our JFactory<T> while only knowing T. In other words,
+/// we are free to swap in and out different JFactories and still retrieve the metadata in our JEventProcessors.
+
+/// In this example, any JFactory which produces Tracks can also produced a time duration indicating how long
+/// the operation took.
+template <>
+struct JMetadata<Track> {
+
+    std::chrono::nanoseconds elapsed_time_ns = 0;
+};
+
+#endif //JANA2_TRACKMETADATA_H

--- a/src/examples/MetadataExample/TrackSmearingFactory.cc
+++ b/src/examples/MetadataExample/TrackSmearingFactory.cc
@@ -5,25 +5,9 @@
 #include <JANA/JEvent.h>
 
 void TrackSmearingFactory::Init() {
-    auto app = GetApplication();
-    
-    /// Acquire any parameters
-    // app->GetParameter("parameter_name", m_destination);
-    
-    /// Acquire any services
-    // m_service = app->GetService<ServiceT>();
-    
-    /// Set any factory flags
-    // SetFactoryFlag(JFactory_Flags_t::NOT_OBJECT_OWNER);
 }
 
 void TrackSmearingFactory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
-    /// This is automatically run before Process, when a new run number is seen
-    /// Usually we update our calibration constants by asking a JService
-    /// to give us the latest data for this run number
-    
-    auto run_nr = event->GetRunNumber();
-    // m_calibration = m_service->GetCalibrationsForRun(run_nr);
 }
 
 void TrackSmearingFactory::Process(const std::shared_ptr<const JEvent> &event) {
@@ -33,15 +17,14 @@ void TrackSmearingFactory::Process(const std::shared_ptr<const JEvent> &event) {
 
     // TODO: Start timer
 
-    // TODO: Do some work
+    // TODO: Do some work, with some delay
     // results.push_back(new Track(...));
 
     // TODO: Stop timer
 
-    // Share results with TrackSmearingFactory
-    Set(results);
-
+    // Publish results and metadata
     JMetadata<Track> metadata;
     metadata.elapsed_time_ns = std::chrono::nanoseconds {10};
     SetMetadata(metadata);
+    Set(results);
 }

--- a/src/examples/MetadataExample/TrackSmearingFactory.cc
+++ b/src/examples/MetadataExample/TrackSmearingFactory.cc
@@ -1,5 +1,6 @@
 
 #include "TrackSmearingFactory.h"
+#include "TrackMetadata.h"
 
 #include <JANA/JEvent.h>
 
@@ -27,18 +28,20 @@ void TrackSmearingFactory::ChangeRun(const std::shared_ptr<const JEvent> &event)
 
 void TrackSmearingFactory::Process(const std::shared_ptr<const JEvent> &event) {
 
-    /// JFactories are local to a thread, so we are free to access and modify
-    /// member variables here. However, be aware that events are _scattered_ to
-    /// different JFactory instances, not _broadcast_: this means that JFactory 
-    /// instances only see _some_ of the events. 
-    
-    /// Acquire inputs (This may recursively call other JFactories)
-    // auto inputs = event->Get<...>();
-    
-    /// Do some computation
-    
-    /// Publish outputs
-    // std::vector<Track*> results;
+    auto raw_tracks = event->Get<Track>("generated");
+    std::vector<Track*> results;
+
+    // TODO: Start timer
+
+    // TODO: Do some work
     // results.push_back(new Track(...));
-    // Set(results);
+
+    // TODO: Stop timer
+
+    // Share results with TrackSmearingFactory
+    Set(results);
+
+    JMetadata<Track> metadata;
+    metadata.elapsed_time_ns = std::chrono::nanoseconds {10};
+    SetMetadata(metadata);
 }

--- a/src/examples/MetadataExample/TrackSmearingFactory.cc
+++ b/src/examples/MetadataExample/TrackSmearingFactory.cc
@@ -1,0 +1,44 @@
+
+#include "TrackSmearingFactory.h"
+
+#include <JANA/JEvent.h>
+
+void TrackSmearingFactory::Init() {
+    auto app = GetApplication();
+    
+    /// Acquire any parameters
+    // app->GetParameter("parameter_name", m_destination);
+    
+    /// Acquire any services
+    // m_service = app->GetService<ServiceT>();
+    
+    /// Set any factory flags
+    // SetFactoryFlag(JFactory_Flags_t::NOT_OBJECT_OWNER);
+}
+
+void TrackSmearingFactory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
+    /// This is automatically run before Process, when a new run number is seen
+    /// Usually we update our calibration constants by asking a JService
+    /// to give us the latest data for this run number
+    
+    auto run_nr = event->GetRunNumber();
+    // m_calibration = m_service->GetCalibrationsForRun(run_nr);
+}
+
+void TrackSmearingFactory::Process(const std::shared_ptr<const JEvent> &event) {
+
+    /// JFactories are local to a thread, so we are free to access and modify
+    /// member variables here. However, be aware that events are _scattered_ to
+    /// different JFactory instances, not _broadcast_: this means that JFactory 
+    /// instances only see _some_ of the events. 
+    
+    /// Acquire inputs (This may recursively call other JFactories)
+    // auto inputs = event->Get<...>();
+    
+    /// Do some computation
+    
+    /// Publish outputs
+    // std::vector<Track*> results;
+    // results.push_back(new Track(...));
+    // Set(results);
+}

--- a/src/examples/MetadataExample/TrackSmearingFactory.h
+++ b/src/examples/MetadataExample/TrackSmearingFactory.h
@@ -5,13 +5,14 @@
 #include <JANA/JFactoryT.h>
 
 #include "Track.h"
+#include "TrackMetadata.h"
 
 class TrackSmearingFactory : public JFactoryT<Track> {
 
     // Insert any member variables here
 
 public:
-    TrackSmearingFactory() : JFactoryT<Track>(NAME_OF_THIS) {};
+    TrackSmearingFactory() : JFactoryT<Track>(NAME_OF_THIS, "smeared") {};
     void Init() override;
     void ChangeRun(const std::shared_ptr<const JEvent> &event) override;
     void Process(const std::shared_ptr<const JEvent> &event) override;

--- a/src/examples/MetadataExample/TrackSmearingFactory.h
+++ b/src/examples/MetadataExample/TrackSmearingFactory.h
@@ -1,0 +1,21 @@
+
+#ifndef _TrackSmearingFactory_h_
+#define _TrackSmearingFactory_h_
+
+#include <JANA/JFactoryT.h>
+
+#include "Track.h"
+
+class TrackSmearingFactory : public JFactoryT<Track> {
+
+    // Insert any member variables here
+
+public:
+    TrackSmearingFactory() : JFactoryT<Track>(NAME_OF_THIS) {};
+    void Init() override;
+    void ChangeRun(const std::shared_ptr<const JEvent> &event) override;
+    void Process(const std::shared_ptr<const JEvent> &event) override;
+
+};
+
+#endif // _TrackSmearingFactory_h_


### PR DESCRIPTION
This pull request adds an example demonstrating on how to use the JMetadata traits class in order to retrieve metadata from a JFactory without breaking the JFactory's substitutability.