### PR TITLE
Feature: Ergonomic bool parameters

### DIFF
--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -97,7 +97,7 @@ public:
 protected:
 
     template<typename T>
-    T parse(std::string value);
+    T parse(const std::string& value);
 
     template<typename T>
     std::string stringify(T value);
@@ -215,16 +215,28 @@ JParameter* JParameterManager::SetDefaultParameter(std::string name, T& val, std
 // Logic for parsing and stringifying different types
 
 template <typename T>
-inline T JParameterManager::parse(std::string value) {
+inline T JParameterManager::parse(const std::string& value) {
     std::stringstream ss(value);
     T val;
     ss >> val;
     return val;
 }
 
+template <>
+inline bool JParameterManager::parse(const std::string& value) {
+    if (value == "0") return false;
+    if (value == "1") return true;
+    if (value == "false") return false;
+    if (value == "true") return true;
+    if (value == "off") return false;
+    if (value == "on") return true;
+    throw JException("'%s' not parseable as bool", value.c_str());
+}
+
+
 /// Specialization for std::vector<std::string>
 template<>
-inline std::vector<std::string> JParameterManager::parse(std::string value) {
+inline std::vector<std::string> JParameterManager::parse(const std::string& value) {
     std::stringstream ss(value);
     std::vector<std::string> result;
     std::string s;

--- a/src/programs/tests/CMakeLists.txt
+++ b/src/programs/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_SOURCES
     JFactoryTests.cc
     NEventNSkipTests.cc
     JEventGetAllTests.cc
+    JParameterManagerTests.cc
     )
 
 add_executable(janatests ${TEST_SOURCES})

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -109,6 +109,16 @@ TEST_CASE("JParameterManagerBoolTests") {
         jpm.SetParameter("test_param", "maybe");
         CHECK_THROWS(jpm.GetParameterValue<bool>("test_param"));
     }
+
+    SECTION("Stringify still works") {
+        jpm.SetParameter("test_param", false);
+        std::string val = jpm.GetParameterValue<std::string>("test_param");
+        REQUIRE(val == "0");
+
+        jpm.SetParameter("test_param", true);
+        val = jpm.GetParameterValue<std::string>("test_param");
+        REQUIRE(val == "1");
+    }
 }
 
 

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -66,5 +66,51 @@ TEST_CASE("JParameterManager::SetDefaultParameter") {
 }
 
 
+TEST_CASE("JParameterManagerBoolTests") {
+    JParameterManager jpm;
+
+    SECTION("'0' parses to false") {
+        jpm.SetParameter("test_param", "0");
+        bool val = jpm.GetParameterValue<bool>("test_param");
+        REQUIRE(val == false);
+    }
+
+    SECTION("'1' parses to true") {
+        jpm.SetParameter("test_param", "1");
+        bool val = jpm.GetParameterValue<bool>("test_param");
+        REQUIRE(val == true);
+    }
+
+    SECTION("'off' parses to false") {
+        jpm.SetParameter("test_param", "off");
+        bool val = jpm.GetParameterValue<bool>("test_param");
+        REQUIRE(val == false);
+    }
+
+    SECTION("'on' parses to true") {
+        jpm.SetParameter("test_param", "on");
+        bool val = jpm.GetParameterValue<bool>("test_param");
+        REQUIRE(val == true);
+    }
+
+    SECTION("'true' parses to true") {
+        jpm.SetParameter("test_param", "true");
+        bool val = jpm.GetParameterValue<bool>("test_param");
+        REQUIRE(val == true);
+    }
+
+    SECTION("'false' parses to false") {
+        jpm.SetParameter("test_param", "false");
+        bool val = jpm.GetParameterValue<bool>("test_param");
+        REQUIRE(val == false);
+    }
+
+    SECTION("Parsing anything else as bool throws an exception") {
+        jpm.SetParameter("test_param", "maybe");
+        CHECK_THROWS(jpm.GetParameterValue<bool>("test_param"));
+    }
+}
+
+
 
 


### PR DESCRIPTION
JParameterManager can now parse '0','1','true','false','on','off' as bool. Any other values now throw an exception.

This is in response to issue #75. 