### PR TITLE
Python JEventProcessor interface 

### DIFF
--- a/src/libraries/JANA/Services/JPluginLoader.h
+++ b/src/libraries/JANA/Services/JPluginLoader.h
@@ -21,7 +21,7 @@ class JPluginLoader : public JService {
 public:
 
     JPluginLoader(JApplication* app);
-    ~JPluginLoader() override = default;
+    ~JPluginLoader() override;
     void acquire_services(JServiceLocator*) override;
 
     void add_plugin(std::string plugin_name);
@@ -34,7 +34,7 @@ private:
     std::vector<std::string> _plugins_to_include;
     std::vector<std::string> _plugins_to_exclude;
     std::vector<std::string> _plugin_paths;
-    std::vector<void*> _sohandles;
+    std::map<std::string, void*> _sohandles; // key=plugin name  val=dlopen handle
 
     bool _verbose = false;
     JLogger _logger;

--- a/src/python/common/JEventProcessorPY.h
+++ b/src/python/common/JEventProcessorPY.h
@@ -2,6 +2,21 @@
 #ifndef _JEVEVENTPROCESSOR_PY_H_
 #define _JEVEVENTPROCESSOR_PY_H_
 
+// This defines the JEventProcessorPY classes used to implement
+// a JEventProcessor class in Python. The design uses a pair of
+// classes with a HasA relationship.
+//
+// The JEventProcessorPY class is a C++ class that inherits from
+// JEventProcessor.
+//
+// The JEventProcessorPYpyobject class is a python class that
+// inherits from pyobject in pybind11.
+//
+// Two classes are needed because the design of JANA requires
+// ownership of the JEventProcessor object be given to JApplication.
+// At the same time, pybind11 insists on ownership of all pyobjects.
+
+
 #include <mutex>
 #include <iostream>
 using std::cout;
@@ -14,7 +29,9 @@ namespace py = pybind11;
 #include <JANA/JEventProcessor.h>
 #include <JANA/JEvent.h>
 
-class JEventProcessorPY : public JEventProcessor{
+//#pragma GCC visibility push(hidden)
+
+class JEventProcessorPY {
 
     public:
 
@@ -79,4 +96,18 @@ class JEventProcessorPY : public JEventProcessor{
 
 };
 
+class JEventProcessorPYTrampoline: public JEventProcessor {
+
+public:
+    JEventProcessorPYTrampoline(JEventProcessorPY *jevent_proc):jevent_proc_py(jevent_proc){
+        SetTypeName("JEventProcessorPY");
+    }
+
+    void Init(void){ jevent_proc_py->Init(); }
+    void Process(const std::shared_ptr<const JEvent>& aEvent){ jevent_proc_py->Process(aEvent); }
+    void Finish(void){ jevent_proc_py->Finish(); }
+
+private:
+    JEventProcessorPY *jevent_proc_py = nullptr;
+};
 #endif  // _JEVEVENTPROCESSOR_PY_H_

--- a/src/python/common/janapy.h
+++ b/src/python/common/janapy.h
@@ -71,11 +71,16 @@ inline void     janapy_SetParameterValue(string key, py::object valobj)
     pyjapp->SetParameterValue<string>( key, ss.str() );
 }
 
-inline void janapy_AddProcessor(py::object &pyproc )
-{
-    cout << "JANAPY2_AddProcessor called!" << endl;
+inline void janapy_AddProcessor(py::object &pyproc ) {
+    cout << "JANAPY_AddProcessor called!" << endl;
     JEventProcessorPY *proc = pyproc.cast<JEventProcessorPY *>();
-    pyjapp->Add( proc );
+//    JEventProcessorPY *proc = new JEventProcessorPYTrampoline(pyproc);
+    if (pyjapp != nullptr) {
+        cout << "[INFO] Adding JEventProcessorPY" << endl;
+        pyjapp->Add( new JEventProcessorPYTrampoline(proc) );
+    }else {
+        cerr << "[ERROR] pyjapp not set before call to janapy_AddProcessor() !!" << endl;
+    }
 }
 
 //================================================================================
@@ -94,9 +99,10 @@ inline void janapy_AddProcessor(py::object &pyproc )
 \
 /* JEventProcessor */ \
 py::class_<JEventProcessorPY>(m, "JEventProcessor") \
-.def(py::init<py::object&>()) \
-.def("Init", &JEventProcessorPY::Init) \
-.def("Process", &JEventProcessorPY::Process); \
+.def(py::init<py::object&>())\
+.def("Init",    &JEventProcessorPY::Init)\
+.def("Process", &JEventProcessorPY::Process)\
+.def("Finish",  &JEventProcessorPY::Finish);\
 \
 /* C-wrapper routines */ \
 m.def("Start",                       &janapy_Start,                       "Allow JANA system to start processing data. (Not needed for short scripts.)"); \


### PR DESCRIPTION
This updates the python interface implementing a JEventProcessor. It was tested on Mac OS X 10.15 with python 3.9 and on CentOS 7.7 with python 3.6.8 (via Docker).