### PR TITLE
Davidl python, ROOT, JStringification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,24 @@ else()
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "Comment explaining this nonsense" FORCE)
 endif()
 
+#---------------------------------------------------------------------------------------
+option(USE_ROOT "Include additional ROOT support if ROOT is available." ON)
+if (${USE_ROOT})
+    find_package(ROOT)
+    if(${ROOT_FOUND})
+        message(STATUS "USE_ROOT=ON: Found ROOT at: " ${ROOT_USE_FILE})
+        include(${ROOT_USE_FILE})
+        add_compile_definitions(HAVE_ROOT)
+        include_directories(${ROOT_INCLUDE_DIRS})
+        link_libraries(${ROOT_LIBRARIES})
+    else()
+        message(ERROR "USE_ROOT=ON: No ROOT found (make sure CMAKE_PREFIX_PATH includes ROOT location)")
+    endif()
+else()
+    message(STATUS "USE_ROOT=OFF: Additional ROOT support will not be included")
+endif()
+#---------------------------------------------------------------------------------------
+
 include_directories(src/libraries)   # So that everyone can find the JANA header files
 
 add_subdirectory(src/libraries/JANA)
@@ -34,6 +52,7 @@ add_subdirectory(src/plugins/janacontrol)
 add_subdirectory(src/programs/jana)
 add_subdirectory(src/programs/tests)
 
+#---------------------------------------------------------------------------------------
 option(USE_PYTHON "Compile optional python targets. This requires python-devel and python-distutils." OFF)
 if (${USE_PYTHON})
     message(STATUS "USE_PYTHON=ON: Including optional python targets")
@@ -41,6 +60,7 @@ if (${USE_PYTHON})
 else()
     message(STATUS "USE_PYTHON=OFF: Skipping optional python targets")
 endif()
+#---------------------------------------------------------------------------------------
 
 install(DIRECTORY scripts/ DESTINATION bin FILES_MATCHING PATTERN "jana-*.py"
         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_READ WORLD_EXECUTE)

--- a/src/libraries/JANA/CMakeLists.txt
+++ b/src/libraries/JANA/CMakeLists.txt
@@ -80,6 +80,8 @@ set(JANA2_SOURCES
     Utils/JProcessorMapping.cc
     Utils/JPerfUtils.cc
     Utils/JPerfUtils.h
+    Utils/JStringification.cc
+    Utils/JStringification.h
 
     Calibrations/JCalibration.cc
     Calibrations/JCalibration.h
@@ -116,7 +118,6 @@ set(JANA2_SOURCES
     Compatibility/JLockService.h
     Compatibility/JGetObjectsFactory.h
     )
-
 
 add_library(jana2 STATIC ${JANA2_SOURCES})
 

--- a/src/libraries/JANA/Utils/JStringification.cc
+++ b/src/libraries/JANA/Utils/JStringification.cc
@@ -1,0 +1,134 @@
+
+// Copyright 2021, Jefferson Science Associates, LLC.
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+
+#include "JStringification.h"
+
+//-------------------------------------------------------------
+// GetObjectSummariesAsJSON
+//
+/// Get objects for the specified factory in the form of
+/// JSON formatted strings.
+//-------------------------------------------------------------
+void JStringification::GetObjectSummariesAsJSON(std::vector<std::string> &json_vec, std::shared_ptr<const JEvent> &jevent, const std::string &object_name, const std::string factory_tag) const{
+
+    // Get object from the given JEvent from the specified factory
+    std::map<std::string, JObjectSummary> objects;
+    GetObjectSummaries(objects, jevent, object_name, factory_tag);
+
+    // Loop over objects and create a JSON string out of each
+    for(auto p : objects){
+        const std::string &hexaddr = p.first;
+        JObjectSummary &summary = p.second;
+        auto str = ObjectToJSON(hexaddr, summary);
+        json_vec.push_back(str);
+    }
+}
+
+//-------------------------------------------------------------
+// GetObjects
+//
+/// Get objects for the specified factory in the form of strings
+/// organized inside JObjectSummary objects.
+//-------------------------------------------------------------
+void JStringification::GetObjectSummaries(std::map<std::string, JObjectSummary> &objects, std::shared_ptr<const JEvent> &jevent, const std::string &object_name, const std::string factory_tag) const {
+
+    /// Get objects for the specified factory in the form of strings.
+
+    // bombproof against getting called with no active JEvent
+    if(jevent.get() == nullptr ) return;
+    auto fac = jevent->GetFactory(object_name, factory_tag);
+    if( fac ){
+        for( auto jobj : fac->GetAs<JObject>()){
+            JObjectSummary summary;
+            jobj->Summarize(summary);
+            std::stringstream ss;
+            ss << "0x" << std::hex << (uint64_t)jobj << std::dec;
+            objects[ss.str()] = summary; // key is address of object converted to string
+        }
+#ifdef HAVE_ROOT
+        // For objects inheriting from TObject, we try and convert members automatically
+        // into JObjectSummary form. This relies on dictionaries being compiled in.
+        // (see ROOT_GENERATE_DICTIONARY for cmake files).
+        for( auto tobj : fac->GetAs<TObject>()){
+            JObjectSummary summary;
+            auto tclass = TClass::GetClass(tobj->ClassName());
+            if(tclass){
+                auto *members = tclass->GetListOfAllPublicDataMembers();
+                for( auto item : *members){
+                    TDataMember *memitem = dynamic_cast<TDataMember*>(item);
+                    if( memitem == nullptr ) continue;
+                    if( memitem->Property() & kIsStatic ) continue; // exclude TObject enums
+                    JObjectMember jObjectMember;
+                    jObjectMember.name = memitem->GetName();
+                    jObjectMember.type = memitem->GetTypeName();
+                    jObjectMember.value = GetRootObjectMemberAsString(tobj, memitem, jObjectMember.type);
+                    summary.add(jObjectMember);
+                }
+            }else {
+                LOG << "Unable to get TClass for: " << object_name << LOG_END;
+            }
+            std::stringstream ss;
+            ss << "0x" << std::hex << (uint64_t)tobj << std::dec;
+            objects[ss.str()] = summary; // key is address of object converted to string
+        }
+#endif
+    }else{
+        _DBG_<<"No factory found! object_name=" << object_name << std::endl;
+    }
+}
+
+//-------------------------------------------------------------
+// ObjectToJSON
+//
+/// Convert a given JObjectSummary into a JSON formatted string.
+/// An additiona "hexaddr" member will be added with the value
+/// passed in to this method. This is meant to contain the address
+/// of the actual object the JObjectSummary represents.
+//-------------------------------------------------------------
+std::string JStringification::ObjectToJSON( const std::string &hexaddr, const JObjectSummary &summary ) const {
+
+    std::stringstream ss;
+    ss << "{\n";
+    ss << "\"hexaddr\":\"" << hexaddr << "\"\n";
+    for( auto m : summary.get_fields() ){
+        ss << ",\"" << m.name << "\":\"" << m.value << "\"\n";
+    }
+    ss << "}";
+
+    return std::move(ss.str());
+}
+
+//-------------------------------------------------------------
+// GetRootObjectMemberAsString
+//-------------------------------------------------------------
+#if HAVE_ROOT
+/// GetRootObjectMemberAsString is the entry point for converting members of
+/// TObject derived objects into strings. This really only works for a few
+/// primitive types, but is useful for debugging/viewing single events.
+std::string JStringification::GetRootObjectMemberAsString(const TObject *tobj, const TDataMember *memitem, std::string type) const {
+    void *addr = (void*)(((uint64_t)tobj) + memitem->GetOffset()); // untyped address of data member
+
+    // Convert char arrays to std:string so they display properly (assume that is what user wants)
+    std::string tmp;
+    if( (memitem->Property()&kIsArray) && (type=="char") ){
+        tmp = (char*)addr;
+        addr = (void*)&tmp;
+        type = "string";
+    }
+
+    if(      type == "int"           ) return GetAddrAsString<int>(addr);
+    else if( type == "double"        ) return GetAddrAsString<double>(addr);
+    else if( type == "float"         ) return GetAddrAsString<float>(addr);
+    else if( type == "char"          ) return GetAddrAsString<char>(addr);
+    else if( type == "unsigned char" ) return GetAddrAsString<unsigned char>(addr);
+    else if( type == "unsigned int"  ) return GetAddrAsString<unsigned int>(addr);
+    else if( type == "long"          ) return GetAddrAsString<long>(addr);
+    else if( type == "unsigned long" ) return GetAddrAsString<unsigned long>(addr);
+    else if( type == "ULong64_t"     ) return GetAddrAsString<ULong64_t>(addr);
+    else if( type == "Long64_t"      ) return GetAddrAsString<Long64_t>(addr);
+    else if( type == "string"        ) return GetAddrAsString<std::string>(addr);
+    return "unknown";
+}
+#endif // HAVE_ROOT

--- a/src/libraries/JANA/Utils/JStringification.h
+++ b/src/libraries/JANA/Utils/JStringification.h
@@ -1,0 +1,78 @@
+
+// Copyright 2021, Jefferson Science Associates, LLC.
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+
+#ifndef JSTRINGIFICATION_H
+#define JSTRINGIFICATION_H
+
+#include <sstream>
+
+#ifdef HAVE_ROOT
+#include <TObject.h>
+#include <TClass.h>
+#include <TDataMember.h>
+#include <TMethodCall.h>
+#include <Tlist.h>
+#endif // HAVE_ROOT
+
+#include <JANA/JObject.h>
+#include <JANA/JEvent.h>
+
+class JStringification {
+
+public:
+
+    JStringification() = default;
+    virtual ~JStringification() = default;
+
+    // These are the main entry points that users will want to use
+    void GetObjectSummaries(std::map<std::string, JObjectSummary> &objects, std::shared_ptr<const JEvent> &jevent, const std::string &object_name, const std::string factory_tag="") const;
+    void GetObjectSummariesAsJSON(std::vector<std::string> &json_vec, std::shared_ptr<const JEvent> &jevent, const std::string &object_name, const std::string factory_tag="") const;
+    std::string ObjectToJSON( const std::string &hexaddr, const JObjectSummary &summary ) const;
+
+    //-----------------------------------------------------------------------------------
+
+    // These 4 templates use SFINAE to allow the GetAddrAsString template below to compile
+    // even when the template argument is something like a string that cannot be cast to
+    // an (int) or (unsigned int). We need this because we want to treat char and unsigned
+    // char variables as numbers and not characters.
+    template <typename T> void ConvertInt(std::stringstream &ss, T val, std::true_type) const {ss << (int)val;}
+    template <typename T> void ConvertInt(std::stringstream &ss, T val, std::false_type) const {ss << "unknown";}
+    template <typename T> void ConvertUInt(std::stringstream &ss, T val, std::true_type) const {ss << "0x" << std::hex << (unsigned int)val << std::dec;}
+    template <typename T> void ConvertUInt(std::stringstream &ss, T val, std::false_type) const {ss << "unknown";}
+
+    template <typename T> std::string GetAddrAsString(void *addr) const;
+
+#ifdef HAVE_ROOT
+    std::string GetRootObjectMemberAsString(const TObject *tobj, const TDataMember *memitem, std::string type) const;
+#endif // HAVE_ROOT
+
+private:
+
+
+};
+
+/// The GetAddrAsString template is used to convert an untyped addr
+/// into a std::string. It interprets the address as pointing to
+/// a primitive object of the same type as the template argument.
+// This is done in a very C-style way by doing address arithmetic.
+// There is almost certainly a better way to do this, but the
+// ROOT documentation is not forthcoming.
+template <typename T>
+std::string JStringification::GetAddrAsString(void *addr) const {
+    auto val = *(T *)addr;
+    std::stringstream ss;
+    if( std::is_same<T, char>::value ) { // darn char types have to be treated special!
+        ConvertInt(ss, val, std::is_same<T, char>());
+    }else if( std::is_same<T, unsigned char>::value ){
+        ConvertUInt(ss, val, std::is_same<T, unsigned char>());
+    }else if( std::is_same<T, std::string>::value ){
+        ss  << val;
+    }else{
+        ss << val;
+    }
+    return ss.str();
+}
+
+#endif //JSTRINGIFICATION_H

--- a/src/plugins/janacontrol/src/CMakeLists.txt
+++ b/src/plugins/janacontrol/src/CMakeLists.txt
@@ -14,17 +14,6 @@ if (ZeroMQ_FOUND)
 
     find_package(Threads REQUIRED)
 
-    #---------------------------------------------------------------------------------------
-    # ROOT is optional
-    find_package(ROOT)
-    if(${ROOT_FOUND})
-        include(${ROOT_USE_FILE})
-        target_compile_definitions(janacontrol_plugin PUBLIC HAVE_ROOT)
-        target_include_directories(janacontrol_plugin PUBLIC ${ROOT_INCLUDE_DIRS})
-        target_link_libraries(janacontrol_plugin ${ROOT_LIBRARIES})
-    endif()
-    #---------------------------------------------------------------------------------------
-
 	target_include_directories(janacontrol_plugin PUBLIC ${JANA_INCLUDE_DIR} ${ZeroMQ_INCLUDE_DIRS})
     target_link_libraries(janacontrol_plugin jana2 Threads::Threads ${ZeroMQ_LIBRARY})
 	set_target_properties(janacontrol_plugin PROPERTIES PREFIX "" OUTPUT_NAME "janacontrol" SUFFIX ".so")

--- a/src/plugins/janacontrol/src/JControlEventProcessor.h
+++ b/src/plugins/janacontrol/src/JControlEventProcessor.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <JANA/JEventProcessor.h>
 #include <JANA/Services/JComponentManager.h>
+#include <JANA/Utils/JStringification.h>
 
 /// The JControlEventProcessor class is used by the janacontrol plugin, primarily
 /// to help with its debugging feature. It can be used to stall event processing
@@ -50,6 +51,7 @@ protected:
     bool _debug_mode    = false;
     bool _wait          = true;
     std::shared_ptr<const JEvent> _jevent;
+    std::shared_ptr<JStringification> jstringification;
 };
 
 // Compare function to allow JFactorySummary to be used as keys in std::map

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -11,6 +11,9 @@ add_subdirectory(externals/pybind11-2.6.1)
 # compiled by each of those separately (so it is compiled
 # multiple times).
 
+include_directories(${PROJECT_SOURCE_DIR}/src/plugins)  # needed to include janacontrol/janaJSON.h
+
+
 add_subdirectory(plugins/janapy)
 add_subdirectory(modules/jana)
 

--- a/src/python/common/JEventProcessorPY.h
+++ b/src/python/common/JEventProcessorPY.h
@@ -107,6 +107,7 @@ class JEventProcessorPY {
         // handle the case where the factory object is neither a JObject nor
         // a TObject.
         for( auto p : prefetch_factories ){
+
             auto fac = aEvent->GetFactory( p.first, p.second);
             if( fac == nullptr ){
                 jerr << "Unable to find factory specified for prefetching: factory=" << p.first << " tag=" << p.second << std::endl;
@@ -115,6 +116,8 @@ class JEventProcessorPY {
 #ifdef HAVE_ROOT
                 if( v.empty() )fac->GetAs<TObject>();
 #endif // HAVE_ROOT
+
+                _DBG_<<"Prefetching from factory: " << p.first <<":" << p.second << "  - " << v.size() << " objects" <<std::endl;
             }
         }
 

--- a/src/python/common/JEventProcessorPY.h
+++ b/src/python/common/JEventProcessorPY.h
@@ -29,9 +29,18 @@ using std::endl;
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
 
+#ifdef HAVE_ROOT
+#include <TObject.h>
+#include <TClass.h>
+#include <TDataMember.h>
+#include <TMethodCall.h>
+#include <Tlist.h>
+#endif // HAVE_ROOT
 
 #include <JANA/JEventProcessor.h>
 #include <JANA/JEvent.h>
+#include <janacontrol/src/janaJSON.h>
+#include <janacontrol/src/JControlEventProcessor.h>
 
 //#pragma GCC visibility push(hidden)
 
@@ -57,6 +66,8 @@ class JEventProcessorPY {
         cout << "JEventProcessorPY destructor called : " << this  << endl;
     }
 
+    //----------------------------------------
+    // Init
     void Init(void){
 
         cout << "JEventProcessorPY::Init called " << endl;
@@ -67,21 +78,54 @@ class JEventProcessorPY {
 
     }
 
+    //----------------------------------------
+    // Process
     void Process(const std::shared_ptr<const JEvent>& aEvent){
 
         cout << "JEventProcessorPY::Process called " << endl;
 
-        // According to the Python documentation we should be wrapping the call to pmProcess() below
-        // in the following that activate the GIL lock. In practice, this seemed to allow each thread
-        // to call pymProcess(), once, but then the program stalled. Hence, we use our own mutex.
-        // PyGILState_STATE gstate = PyGILState_Ensure();
-        // PyGILState_Release(gstate);
+        // Prefetch any factory in the prefetch list.
+        // This does not actually fetch them, but does activate the factories
+        // to ensure the objects are already created before locking the mutex.
+        // We try fetching as both JObject and TObject for the rare case when
+        // the objects may be TObjects but not JObjects. We cannot currently
+        // handle the case where the factory object is neither a JObject nor
+        // a TObject.
+        for( auto p : prefetch_factories ){
+            auto fac = aEvent->GetFactory( p.first, p.second);
+            if( fac == nullptr ){
+                jerr << "Unable to find factory specified for prefetching: factory=" << p.first << " tag=" << p.second << std::endl;
+            }else {
+                auto v = fac->GetAs<JObject>();
+#ifdef HAVE_ROOT
+                if( v.empty() )fac->GetAs<TObject>();
+#endif // HAVE_ROOT
+            }
+        }
+
         if( has_pymProcess ) {
+
+            // According to the Python documentation we should be wrapping the call to pmProcess() below
+            // in the following that activates the GIL lock. In practice, this seemed to allow each thread
+            // to call pymProcess(), once, but then the program stalled. Hence, we use our own mutex.
+            // PyGILState_STATE gstate = PyGILState_Ensure();
+            // PyGILState_Release(gstate);
             lock_guard<mutex> lck(pymutex);
+
+            // This magic line creates a shared_ptr on the stack with a custom deleter.
+            // The custom deleter is used to reset the _aEvent data member back to
+            // nullptr so that it does not hold on the the JEvent after we return
+            // from this method. We use this trick to ensure it happens even if an
+            // exception is thrown from pymProcess().
+            std::shared_ptr<int> _avent_free(nullptr, [=](int *ptr){_aEvent = nullptr;});
+            _aEvent = aEvent; // remember this JEvent so it can be used in calls to Get()
+
             pymProcess();
         }
     }
 
+    //----------------------------------------
+    // Finish
     void Finish(void){
 
         cout << "JEventProcessorPY::Finish called " << endl;
@@ -93,6 +137,151 @@ class JEventProcessorPY {
 
     }
 
+    //----------------------------------------
+    // Prefetch
+    void Prefetch(py::object &fac_name, py::object tag = py::none()){
+
+        /// This is called from python to register factories to be activated
+        /// before the Process method of the python JEventProcessor class
+        /// is called. Since the python code must be executed in serial, this
+        /// allows object generation by factories to be done in parallel before
+        /// that to try and minimize the time in serial operations.
+        ///
+        /// When calling from python, the first argument may be any of a
+        /// string, list, or dictionary. The second argument is for the optional
+        /// factory tag which is only considered if the first argument is a
+        /// string.
+        ///
+        /// If the first argument is a string, it is taken as the data type to
+        /// prefetch.
+        ///
+        /// If the first argument is a list, it is taken to be the names of multiple
+        /// data types to prefetch. For this case, the default (i.e. empty) factory
+        /// tag is used for all of them.
+        ///
+        /// If the first argument is a dictionary, then the keys are taken as
+        /// the data types and corresponding values taken as the factory tags.
+
+        if( py::isinstance<py::dict>(fac_name) ){
+            // Python dictionary was passed
+            for(auto p : fac_name.cast<py::dict>()){
+                auto &fac_obj = p.first;
+                auto &tag_obj = p.second;
+                std::string fac_name_str = py::str(fac_obj);
+                std::string tag_str = tag_obj.is(py::none()) ? "":py::str(tag_obj);
+                prefetch_factories[fac_name_str] = tag_str;
+            }
+        }else if( py::isinstance<py::list>(fac_name) ){
+            // Python list was passed
+            for(auto &fac_obj : fac_name.cast<py::list>()){
+                std::string fac_name_str = py::str(fac_obj);
+                prefetch_factories[fac_name_str] = "";
+            }
+        }else if( py::isinstance<py::str>(fac_name) ){
+            // Python string was passed
+            std::string fac_name_str = py::str(fac_name);
+            std::string tag_str = tag.is(py::none()) ? "":py::str(tag);
+            prefetch_factories[fac_name_str] = tag_str;
+        }else{
+            jerr << "Unknown type passed to Prefetch: " << std::string(py::str(fac_name)) << std::endl;
+        }
+    }
+
+    //----------------------------------------
+    // Get
+    py::object Get(py::object &fac_name, py::object tag = py::none()) {
+        std::string fac_name_str = py::str(fac_name);
+        std::string tag_str = tag.is(py::none()) ? "":py::str(tag);
+
+        std::map<std::string, JObjectSummary> objects;
+        GetObjectSummaries(fac_name_str, tag_str, objects);
+
+        py::list list;
+        for(auto p : objects){
+
+            const std::string &hexaddr = p.first;
+            const JObjectSummary &summary = p.second;
+//            std::string obj_json = JJSON_Create(summary);
+            std::string obj_json = ObjectToJSON( hexaddr, summary );
+
+            try {
+                auto json_loads = pymodule_json->attr("loads" );
+                auto dict = json_loads( py::str(obj_json) );
+                list.append( dict );
+            }catch(...){
+                jerr << "Python json loads function not available!" << std::endl;
+            }
+        }
+
+        return list;
+    }
+
+    //----------------------------------------
+    // GetObjectSummaries
+    //
+    // TODO: Take this and the (same) code in JControlEventPRocessor and move them to a common place
+    void GetObjectSummaries(const std::string &factory_name, const std::string &factory_tag, std::map<std::string, JObjectSummary> &objects){
+        // bombproof against getting called with no active JEvent
+        if(_aEvent.get() == nullptr ) return;
+        auto fac = _aEvent->GetFactory(factory_name, factory_tag);
+        if( fac == nullptr ){
+            jerr << "Unable to find factory specified for prefetching: factory=" << factory_name << " tag=" << factory_tag << std::endl;
+            return;
+        }
+        for( auto jobj : fac->GetAs<JObject>()){
+            JObjectSummary summary;
+            jobj->Summarize(summary);
+            std::stringstream ss;
+            ss << "0x" << std::hex << (uint64_t)jobj << std::dec;
+            objects[ss.str()] = summary; // key is address of object converted to string
+        }
+#ifdef HAVE_ROOT
+        // For objects inheriting from TObject, we try and convert members automatically
+        // into JObjectSummary form. This relies on dictionaries being compiled in.
+        // (see ROOT_GENERATE_DICTIONARY for cmake files).
+        for( auto tobj : fac->GetAs<TObject>()){
+            JObjectSummary summary;
+            auto tclass = TClass::GetClass(tobj->ClassName());
+            if(tclass){
+                auto *members = tclass->GetListOfAllPublicDataMembers();
+                for( auto item : *members){
+                    TDataMember *memitem = dynamic_cast<TDataMember*>(item);
+                    if( memitem == nullptr ) continue;
+                    if( memitem->Property() & kIsStatic ) continue; // exclude TObject enums
+                    JObjectMember jObjectMember;
+                    jObjectMember.name = memitem->GetName();
+                    jObjectMember.type = memitem->GetTypeName();
+                    jObjectMember.value = GetRootObjectMemberAsString(tobj, memitem, jObjectMember.type);
+                    summary.add(jObjectMember);
+                }
+            }else {
+                LOG << "Unable to get TClass for: " << tobj->ClassName() << LOG_END;
+            }
+            std::stringstream ss;
+            ss << "0x" << std::hex << (uint64_t)tobj << std::dec;
+            objects[ss.str()] = summary; // key is address of object converted to string
+        }
+#endif
+     }
+
+    //----------------------------------------
+    // ObjectToJSON
+    std::string ObjectToJSON( const std::string &hexaddr, const JObjectSummary &summary ){
+
+        stringstream ss;
+        ss << "{\n";
+        ss << "\"hexaddr\":\"" << hexaddr << "\"\n";
+        for( auto m : summary.get_fields() ){
+            ss << ",\"" << m.name << "\":\"" << m.value << "\"\n";
+        }
+        ss << "}";
+
+        return std::move(ss.str());
+    }
+
+    // Data members
+    py::module_ *pymodule = nullptr;       // This gets set in janapy_AddProcessor
+    py::module_ *pymodule_json = nullptr;  // This gets set in janapy_AddProcessor
     std::string class_name = "JEventProcssorPY";
     py::object &pyobj; // _self_
     py::object pymInit;
@@ -104,6 +293,8 @@ class JEventProcessorPY {
 
     mutex pymutex;
 
+    std::shared_ptr<const JEvent> _aEvent;
+    std::map<std::string, std::string> prefetch_factories;
 };
 
 class JEventProcessorPYTrampoline: public JEventProcessor {

--- a/src/python/common/janapy.h
+++ b/src/python/common/janapy.h
@@ -20,7 +20,7 @@ namespace py = pybind11;
 
 static py::module_ *PY_MODULE = nullptr;       // set at end of JANA_MODULE_DEF
 static py::module_ PY_MODULE_JSON = py::none();  // set at end of JANA_MODULE_DEF
-static bool PY_INITIALIZED = false;
+bool PY_INITIALIZED = false;
 static bool PY_MODULE_INSTANTIATED_JAPPLICATION = false;
 static JApplication *pyjapp = nullptr;
 
@@ -88,7 +88,7 @@ inline void janapy_AddProcessor(py::object &pyproc ) {
 
     if (pyjapp != nullptr) {
         cout << "[INFO] Adding JEventProcessorPY" << endl;
-        pyjapp->Add( new JEventProcessorPYTrampoline(proc) );
+        pyjapp->Add( new JEventProcessorPYTrampoline(pyjapp, proc) );
     }else {
         cerr << "[ERROR] pyjapp not set before call to janapy_AddProcessor() !!" << endl;
     }

--- a/src/python/common/janapy.h
+++ b/src/python/common/janapy.h
@@ -37,7 +37,7 @@ inline bool     janapy_IsInitialized(void) { return pyjapp->IsInitialized(); }
 inline bool     janapy_IsQuitting(void) { return pyjapp->IsQuitting(); }
 inline bool     janapy_IsDrainingQueues(void) { return pyjapp->IsDrainingQueues(); }
 
-inline void     janapy_AddPlugin(string plugin_name) { pyjapp->AddPlugin(plugin_name); _DBG__; }
+inline void     janapy_AddPlugin(string plugin_name) { pyjapp->AddPlugin(plugin_name); }
 inline void     janapy_AddPluginPath(string path) { pyjapp->AddPluginPath(path); }
 inline void     janapy_AddEventSource(string source) { pyjapp->Add( source ); }
 inline void     janapy_SetTicker(bool ticker_on=true) { pyjapp->SetTicker(ticker_on); }

--- a/src/python/common/janapy.h
+++ b/src/python/common/janapy.h
@@ -18,6 +18,8 @@ using namespace std;
 namespace py = pybind11;
 #include "JEventProcessorPY.h"
 
+static py::module_ *PY_MODULE = nullptr;       // set at end of JANA_MODULE_DEF
+static py::module_ PY_MODULE_JSON = py::none();  // set at end of JANA_MODULE_DEF
 static bool PY_INITIALIZED = false;
 static bool PY_MODULE_INSTANTIATED_JAPPLICATION = false;
 static JApplication *pyjapp = nullptr;
@@ -35,7 +37,7 @@ inline bool     janapy_IsInitialized(void) { return pyjapp->IsInitialized(); }
 inline bool     janapy_IsQuitting(void) { return pyjapp->IsQuitting(); }
 inline bool     janapy_IsDrainingQueues(void) { return pyjapp->IsDrainingQueues(); }
 
-inline void     janapy_AddPlugin(string plugin_name) { pyjapp->AddPlugin(plugin_name); }
+inline void     janapy_AddPlugin(string plugin_name) { pyjapp->AddPlugin(plugin_name); _DBG__; }
 inline void     janapy_AddPluginPath(string path) { pyjapp->AddPluginPath(path); }
 inline void     janapy_AddEventSource(string source) { pyjapp->Add( source ); }
 inline void     janapy_SetTicker(bool ticker_on=true) { pyjapp->SetTicker(ticker_on); }
@@ -71,10 +73,19 @@ inline void     janapy_SetParameterValue(string key, py::object valobj)
     pyjapp->SetParameterValue<string>( key, ss.str() );
 }
 
+//-----------------------------------------
+// janapy_AddProcessor
+//-----------------------------------------
 inline void janapy_AddProcessor(py::object &pyproc ) {
-    cout << "JANAPY_AddProcessor called!" << endl;
+
+    // The JEventProcessorPY is instantiated from python by vitue of
+    // it being a base class for whatever jana.JEventProcessor class
+    // the python script defines. Here though we set some data members
+    // only accessible via C++.
     JEventProcessorPY *proc = pyproc.cast<JEventProcessorPY *>();
-//    JEventProcessorPY *proc = new JEventProcessorPYTrampoline(pyproc);
+    proc->pymodule = PY_MODULE;
+    proc->pymodule_json = &PY_MODULE_JSON;
+
     if (pyjapp != nullptr) {
         cout << "[INFO] Adding JEventProcessorPY" << endl;
         pyjapp->Add( new JEventProcessorPYTrampoline(proc) );
@@ -98,11 +109,13 @@ inline void janapy_AddProcessor(py::object &pyproc ) {
 #define JANA_MODULE_DEF \
 \
 /* JEventProcessor */ \
-py::class_<JEventProcessorPY>(m, "JEventProcessor") \
+py::class_<JEventProcessorPY>(m, "JEventProcessor")\
 .def(py::init<py::object&>())\
-.def("Init",    &JEventProcessorPY::Init)\
-.def("Process", &JEventProcessorPY::Process)\
-.def("Finish",  &JEventProcessorPY::Finish);\
+.def("Init",       &JEventProcessorPY::Init)\
+.def("Process",    &JEventProcessorPY::Process)\
+.def("Finish",     &JEventProcessorPY::Finish)\
+.def("Prefetch",   &JEventProcessorPY::Prefetch, py::arg("fac_name"), py::arg("tag")="")\
+.def("Get",        &JEventProcessorPY::Get, py::arg("fac_name"), py::arg("tag")="");\
 \
 /* C-wrapper routines */ \
 m.def("Start",                       &janapy_Start,                       "Allow JANA system to start processing data. (Not needed for short scripts.)"); \
@@ -131,6 +144,8 @@ m.def("GetParameterValue",           &janapy_GetParameterValue,           "Retur
 m.def("SetParameterValue",           &janapy_SetParameterValue,           "Set configuration parameter."); \
 m.def("AddProcessor",                &janapy_AddProcessor,                "Add an event processor"); \
 \
-
+PY_MODULE = &m;\
+PY_MODULE_JSON = py::module_::import("json");\
+\
 //================================================================================
 

--- a/src/python/examples/MyProcessor.py
+++ b/src/python/examples/MyProcessor.py
@@ -1,37 +1,47 @@
-
-import jana
-#from DHit import *
-#from DCluster import *
 #
+# This example demonstrates how to implement a JEventProccessor in Python.
+#
+# This can be run like so:
+#
+#   jana -Pplugins=janapy -PJANA_PYTHON_FILE=MyProcessor.py
+#
+#
+import jana
+import inspect
+
 # JEventProcessor class defined in janapy module
-class MyProcessor( jana.JEventProcessor):
+class MyProcessor( jana.JEventProcessor ):
+	#--------------------------------------
+	# Constructor
 	def __init__(self):
 		super().__init__(self)
+		super().Prefetch('Hit')
 
+	#--------------------------------------
+	# Init
 	def Init( self ):
 		print('Python Init called')
 
-	# event is a JEvent object defined in janapy module
+	#--------------------------------------
+	# Process
 	def Process( self ):
-		print('Python Process called')
+		hits = super().Get('Hit') # hits is standard python dictionary with string types for keys and values
+		for hit in hits:
+			print('E=' + hit['E'] + '  t= ' + hit['t'] )
 
+	#--------------------------------------
+	# Finish
 	def Finish( self ):
 		print('Python Finish called')
 
-#		hits = event.Get( DHit )
-#		for h in hits:
-#			print('hit:  a=%d  b=%f  type=%s' % (h.a, h.b , type(h)))
-
 #-----------------------------------------------------------
 
-jana.SetParameterValue( 'JANA:DEBUG_PLUGIN_LOADING', '1')
-jana.SetParameterValue( 'NTHREADS', '4')
-jana.SetParameterValue( 'NEVENTS', '100')
+jana.SetParameterValue( 'NEVENTS', '10')
 
-# The janapy module itself serves as the JApplication facade
-jana.AddProcessor( MyProcessor() )
+proc = MyProcessor()
+jana.AddProcessor( proc )
 
-jana.AddPlugin('jtest')
+jana.AddPlugin('JTestRoot')
 jana.Run()
 
 print('PYTHON DONE.')

--- a/src/python/plugins/janapy/CMakeLists.txt
+++ b/src/python/plugins/janapy/CMakeLists.txt
@@ -1,50 +1,14 @@
 
 
-add_library(janapy_plugin SHARED janapy_plugin.cc)
 include_directories(${PYTHON_INCLUDE_DIRS} ${PYBIND11_INCLUDE_DIR} ../../common)
-target_link_libraries(janapy_plugin PRIVATE ${PYTHON_LIBRARIES} pybind11::embed jana2)
+link_libraries(${PYTHON_LIBRARIES} pybind11::embed jana2)
 
-#---------------------------------------------------------------------------------------
-# ROOT is optional
-find_package(ROOT)
-if(${ROOT_FOUND})
-    include(${ROOT_USE_FILE})
-    target_compile_definitions(janapy_plugin PUBLIC HAVE_ROOT)
-    include_directories(${ROOT_INCLUDE_DIRS})
-    link_libraries(${ROOT_LIBRARIES})
-endif()
-#---------------------------------------------------------------------------------------
+add_library(janapy_plugin SHARED janapy_plugin.cc)
 
 set_target_properties(janapy_plugin PROPERTIES PREFIX "" SUFFIX ".so" LIBRARY_OUTPUT_NAME "janapy")
 install(TARGETS janapy_plugin DESTINATION plugins)
 
-#set(Python_ADDITIONAL_VERSIONS 3.7 3.6)
-#find_package(PythonInterp 3.6)
-#find_package(PythonLibs 3.6)
 
-#if (PYTHONINTERP_FOUND AND PYTHONLIBS_FOUND)
-#
-#    add_library(janapy SHARED janapy.cc)
-#    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")  # see https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-visibility-than-the-type-of-its-field-someclass-member-wattributes
-#    #add_link_options("-undefined dynamic_lookup")
-#    target_include_directories(janapy PUBLIC ${PYTHON_INCLUDE_DIRS})
-#    target_link_libraries(janapy jana2 ${PYTHON_LIBRARIES})
-#    set_target_properties(janapy PROPERTIES PREFIX "" SUFFIX ".so")
-#    install(TARGETS janapy DESTINATION plugins)
-#
-#else()
-#
-#    message(WARNING "Skipping compilation of janapy.so")
-#
-#    if (NOT PYTHONINTERP_FOUND)
-#        message(WARNING "Unable to find PythonInterp")
-#    endif()
-#
-#    if (NOT PYTHONLIBS_FOUND)
-#        message(WARNING "Unable to find PythonLibs")
-#    endif()
-#
-#endif()
 
 
 

--- a/src/python/plugins/janapy/CMakeLists.txt
+++ b/src/python/plugins/janapy/CMakeLists.txt
@@ -4,6 +4,17 @@ add_library(janapy_plugin SHARED janapy_plugin.cc)
 include_directories(${PYTHON_INCLUDE_DIRS} ${PYBIND11_INCLUDE_DIR} ../../common)
 target_link_libraries(janapy_plugin PRIVATE ${PYTHON_LIBRARIES} pybind11::embed jana2)
 
+#---------------------------------------------------------------------------------------
+# ROOT is optional
+find_package(ROOT)
+if(${ROOT_FOUND})
+    include(${ROOT_USE_FILE})
+    target_compile_definitions(janapy_plugin PUBLIC HAVE_ROOT)
+    include_directories(${ROOT_INCLUDE_DIRS})
+    link_libraries(${ROOT_LIBRARIES})
+endif()
+#---------------------------------------------------------------------------------------
+
 set_target_properties(janapy_plugin PROPERTIES PREFIX "" SUFFIX ".so" LIBRARY_OUTPUT_NAME "janapy")
 install(TARGETS janapy_plugin DESTINATION plugins)
 


### PR DESCRIPTION
This includes several changes primarily to the Python API.

1. ROOT support in CMake promoted to the top-level CMakeLists.txt file and made to align with optional Python support there by implementing a USE_ROOT option. For ROOT though, the option is ON by default.

2. JStringification class added to libraries/JANA/Utils. Large parts of this code were moved from the janacontrol plugin so they could also be used by the janapy plugin.

3. JPluginLoader modified to loop over list of plugins to attach so that a plugin can add to the list while it is being attached. (I think I was kind of clever to use a lambda to do this.)

4. Implement prefetching of objects in JEventProcessorPY.

5. Implement Get method in Python JEventProcessor so it can get objects in the form of dictionaries with strings.

6. Disabled finalizing the Python embedded interpreter since this was cause seg. faults due to calls to JANA objects being made after JApplication shut down and deleted everything.