### PR TITLE
fix: include typeinfo to use typeid in gcc12

### DIFF
--- a/src/libraries/JANA/Utils/JCpuInfo.cc
+++ b/src/libraries/JANA/Utils/JCpuInfo.cc
@@ -4,6 +4,7 @@
 
 #include <unistd.h>
 #include <thread>
+#include <typeinfo>
 
 // Note that Apple complicates things some. In particular with the
 // addition of Apple silicon (M1 chip) which does not seem to have


### PR DESCRIPTION
Note `typeid` calls further down in the file.