### PR TITLE
feat: run workflows against newer targets on linux, and include ZeroMQ, XercesC, Python deps

### DIFF
--- a/.github/workflows/ccpp-linux.yml
+++ b/.github/workflows/ccpp-linux.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI ubuntu-18.04
+name: C/C++ CI ubuntu
 
 on:
   push:

--- a/.github/workflows/ccpp-linux.yml
+++ b/.github/workflows/ccpp-linux.yml
@@ -9,9 +9,13 @@ on:
 jobs:
   build:
 
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+
     # See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on for available platforms
-    runs-on: ubuntu-18.04
-    
+    runs-on: ${{ matrix.os }}
+
     # Run cmake, make, and make install as separate steps
     # Note that every step starts out in the $GITHUB_WORKSPACE
     # directory.

--- a/.github/workflows/ccpp-linux.yml
+++ b/.github/workflows/ccpp-linux.yml
@@ -28,7 +28,11 @@ jobs:
       run: |
         mkdir -p $GITHUB_WORKSPACE/build
         cd $GITHUB_WORKSPACE/build
-        cmake ../ -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/Linux -DUSE_ROOT=Off
+        cmake ../ -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/Linux \
+          -DUSE_PYTHON=ON \
+          -DUSE_ROOT=OFF \
+          -DUSE_XERCES=ON \
+          -DUSE_ZEROMQ=ON
     - name: make
       run: |
         cd $GITHUB_WORKSPACE/build

--- a/.github/workflows/ccpp-linux.yml
+++ b/.github/workflows/ccpp-linux.yml
@@ -21,6 +21,9 @@ jobs:
     # directory.
     steps:
     - uses: actions/checkout@v2
+    - name: deps
+      run: |
+        sudo apt-get install -y libzmq3-dev libxerces-c-dev python3-dev
     - name: cmake
       run: |
         mkdir -p $GITHUB_WORKSPACE/build

--- a/.github/workflows/ccpp-linux.yml
+++ b/.github/workflows/ccpp-linux.yml
@@ -31,7 +31,7 @@ jobs:
         cmake ../ -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/Linux \
           -DUSE_PYTHON=ON \
           -DUSE_ROOT=OFF \
-          -DUSE_XERCES=ON \
+          -DUSE_XERCES=ON -DXercesC_DIR=/usr \
           -DUSE_ZEROMQ=ON
     - name: make
       run: |


### PR DESCRIPTION
This does not pick up gcc12 yet (#121) but picks up other more recent dependency versions that are relied upon.

~~Note: these new checks won't run for a pull_request onto master, since the workflows of the target branch take priority (if I recall). See github.com/wdconinc/JANA2/actions for successful runs.~~