### PR TITLE
JANAConfig.cmake.in: rework to use the cmake targets

### DIFF
--- a/src/libraries/JANA/JANAConfig.cmake.in
+++ b/src/libraries/JANA/JANAConfig.cmake.in
@@ -1,21 +1,9 @@
 @PACKAGE_INIT@
 
-# https://cliutils.gitlab.io/modern-cmake/chapters/install/installing.html
-# include(CMakeFindDependencyMacro)
-# find_dependency(MYDEP REQUIRED)
-
-set(JANA_ROOT_DIR ${JANA_DIR}/../../../)
-
-find_path(JANA_INCLUDE_DIR NAMES "JANA/JApplication.h"
-                           PATHS ${JANA_ROOT_DIR}/include)
-
-find_library(JANA_LIBRARY NAMES "JANA"
-                          PATHS ${JANA_ROOT_DIR}/lib)
-
-set(JANA_INCLUDE_DIRS ${JANA_INCLUDE_DIR})
-set(JANA_LIBRARIES ${JANA_LIBRARY})
-set(JANA_LIB ${JANA_LIBRARY})
+find_package(Threads REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/JANATargets.cmake")
 
-
+get_target_property(JANA_INCLUDE_DIRS JANA::jana2 INCLUDE_DIRECTORIES)
+set(JANA_LIBRARIES JANA::jana2)
+set(JANA_LIB JANA::jana2)


### PR DESCRIPTION
The current cmake file does what FindJANA2.cmake would do - exports
only the specific jana library. This prevents downstream consumers
from inheriting jana target's dependencies such as ROOT.

Example linker error from EICrecon on macOS:

    Undefined symbols for architecture x86_64:
      "TVersionCheck::TVersionCheck(int)", referenced from:
          __GLOBAL__sub_I_JApplication.cc in libJANA.a(JApplication.cc.o)
          __GLOBAL__sub_I_JInspector.cc in libJANA.a(JInspector.cc.o)
          __GLOBAL__sub_I_JPluginLoader.cc in libJANA.a(JPluginLoader.cc.o)
          __GLOBAL__sub_I_JArrowTopology.cc in libJANA.a(JArrowTopology.cc.o)
          __GLOBAL__sub_I_JAutoActivator.cc in libJANA.a(JAutoActivator.cc.o)
          __GLOBAL__sub_I_JComponentManager.cc in libJANA.a(JComponentManager.cc.o)
          __GLOBAL__sub_I_JEventSourceArrow.cc in libJANA.a(JEventSourceArrow.cc.o)
          ...
    ld: symbol(s) not found for architecture x86_64
    clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
    make[2]: *** [detectors/BTRK/CMakeFiles/BTRK_plugin.dir/build.make:114: detectors/BTRK/BTRK.so] Error 1
    make[1]: *** [CMakeFiles/Makefile2:417: detectors/BTRK/CMakeFiles/BTRK_plugin.dir/all] Error 2