### PR TITLE
Latest round of issue fixes

### DIFF
--- a/src/examples/BlockExample/main.cc
+++ b/src/examples/BlockExample/main.cc
@@ -12,7 +12,7 @@
 #include "BlockExampleProcessor.h"
 
 
-int main(int argc, char* argv[]) {
+int main() {
 
 	JApplication app;
 

--- a/src/libraries/JANA/CLI/JSignalHandler.h
+++ b/src/libraries/JANA/CLI/JSignalHandler.h
@@ -36,7 +36,7 @@ void create_named_pipe(const std::string& path_to_named_pipe) {
 
 void send_to_named_pipe(const std::string& path_to_named_pipe, const std::string& data) {
 
-    int fd = open(g_path_to_named_pipe.c_str(), O_WRONLY);
+    int fd = open(path_to_named_pipe.c_str(), O_WRONLY);
     if (fd >=0) {
         write(fd, data.c_str(), data.length()+1);
         close(fd);
@@ -138,7 +138,7 @@ void handle_usr2(int) {
     produce_thread_report();
 }
 
-void handle_sigsegv(int signal_number, siginfo_t* signal_info, void* context) {
+void handle_sigsegv(int /*signal_number*/, siginfo_t* /*signal_info*/, void* /*context*/) {
     produce_overall_report();
 }
 

--- a/src/libraries/JANA/Calibrations/JCalibration.cc
+++ b/src/libraries/JANA/Calibrations/JCalibration.cc
@@ -78,7 +78,7 @@ JCalibration::~JCalibration()
 //---------------------------------
 // PutCalib
 //---------------------------------
-bool JCalibration::PutCalib(string namepath, int32_t run_min, int32_t run_max, uint64_t event_min, uint64_t event_max, string &author, map<string, string> &svals, string comment)
+bool JCalibration::PutCalib(string /*namepath*/, int32_t /*run_min*/, int32_t /*run_max*/, uint64_t /*event_min*/, uint64_t /*event_max*/, string &/*author*/, map<string, string> &/*svals*/, string /*comment*/)
 {
     LOG<<"PutCalib(string namepath, int run_min, int run_max, int event_min, int event_max, string &author, map<string, string> &svals, string &comment="") not implemented!"<<LOG_END;
     return true;
@@ -87,7 +87,7 @@ bool JCalibration::PutCalib(string namepath, int32_t run_min, int32_t run_max, u
 //---------------------------------
 // PutCalib
 //---------------------------------
-bool JCalibration::PutCalib(string namepath, int32_t run_min, int32_t run_max, uint64_t event_min, uint64_t event_max, string &author, vector< map<string, string> > &svals, string comment)
+bool JCalibration::PutCalib(string /*namepath*/, int32_t /*run_min*/, int32_t /*run_max*/, uint64_t /*event_min*/, uint64_t /*event_max*/, string &/*author*/, vector< map<string, string> > &/*svals*/, string /*comment*/)
 {
     LOG<<"PutCalib(string namepath, int run_min, int run_max, int event_min, int event_max, string &author, vector< map<string, string> > &svals, string &comment="") not implemented!"<<LOG_END;
     return true;

--- a/src/libraries/JANA/Calibrations/JCalibrationFile.cc
+++ b/src/libraries/JANA/Calibrations/JCalibrationFile.cc
@@ -72,7 +72,7 @@ JCalibrationFile::~JCalibrationFile()
 //---------------------------------
 // GetCalib
 //---------------------------------
-bool JCalibrationFile::GetCalib(string namepath, map<string, string> &svals, uint64_t event_number)
+bool JCalibrationFile::GetCalib(string namepath, map<string, string> &svals, uint64_t /*event_number*/)
 {
     /// Open file specified by namepath (and the url passed to us in the
     /// constructor) and read in the calibration constants in plain
@@ -135,7 +135,7 @@ bool JCalibrationFile::GetCalib(string namepath, map<string, string> &svals, uin
 //---------------------------------
 // GetCalib
 //---------------------------------
-bool JCalibrationFile::GetCalib(string namepath, vector<string> &svals, uint64_t event_number)
+bool JCalibrationFile::GetCalib(string namepath, vector<string> &svals, uint64_t /*event_number*/)
 {
     /// Open file specified by namepath (and the url passed to us in the
     /// constructor) and read in the calibration constants in plain
@@ -201,7 +201,7 @@ bool JCalibrationFile::GetCalib(string namepath, vector<string> &svals, uint64_t
 //---------------------------------
 // GetCalib
 //---------------------------------
-bool JCalibrationFile::GetCalib(string namepath, vector< map<string, string> > &svals, uint64_t event_number)
+bool JCalibrationFile::GetCalib(string namepath, vector< map<string, string> > &svals, uint64_t /*event_number*/)
 {
     /// Open file specified by namepath (and the url passed to us in the
     /// constructor) and read in a table of calibration constants in plain
@@ -282,7 +282,7 @@ bool JCalibrationFile::GetCalib(string namepath, vector< map<string, string> > &
 //---------------------------------
 // GetCalib
 //---------------------------------
-bool JCalibrationFile::GetCalib(string namepath, vector< vector<string> > &svals, uint64_t event_number)
+bool JCalibrationFile::GetCalib(string namepath, vector< vector<string> > &svals, uint64_t /*event_number*/)
 {
     /// Open file specified by namepath (and the url passed to us in the
     /// constructor) and read in a table of calibration constants in plain
@@ -366,7 +366,7 @@ bool JCalibrationFile::GetCalib(string namepath, vector< vector<string> > &svals
 //---------------------------------
 // PutCalib
 //---------------------------------
-bool JCalibrationFile::JCalibrationFile::PutCalib(string namepath, int32_t run_min, int32_t run_max, uint64_t event_min, uint64_t event_max, string &author, map<string, string> &svals, string comment)
+bool JCalibrationFile::JCalibrationFile::PutCalib(string namepath, int32_t run_min, int32_t run_max, uint64_t /*event_min*/, uint64_t /*event_max*/, string &author, map<string, string> &svals, string comment)
 {
     // Open the item file creating the directory path if needed and
     // writing a header to it.
@@ -389,7 +389,7 @@ bool JCalibrationFile::JCalibrationFile::PutCalib(string namepath, int32_t run_m
 //---------------------------------
 // PutCalib
 //---------------------------------
-bool JCalibrationFile::JCalibrationFile::PutCalib(string namepath, int32_t run_min, int32_t run_max, uint64_t event_min, uint64_t event_max, string &author, vector< map<string, string> > &svals, string comment)
+bool JCalibrationFile::JCalibrationFile::PutCalib(string namepath, int32_t run_min, int32_t run_max, uint64_t /*event_min*/, uint64_t /*event_max*/, string &author, vector< map<string, string> > &svals, string comment)
 {
     // We need at least one element to make this worthwhile
     if(svals.size()<1)return true;

--- a/src/libraries/JANA/Compatibility/JGeometryMYSQL.cc
+++ b/src/libraries/JANA/Compatibility/JGeometryMYSQL.cc
@@ -26,7 +26,7 @@ JGeometryMYSQL::~JGeometryMYSQL()
 //---------------------------------
 // Get
 //---------------------------------
-bool JGeometryMYSQL::Get(string path, string &sval)
+bool JGeometryMYSQL::Get(string /*path*/, string &/*sval*/)
 {
 
     // Looks like we failed to find the requested item. Let the caller know.
@@ -36,7 +36,7 @@ bool JGeometryMYSQL::Get(string path, string &sval)
 //---------------------------------
 // Get
 //---------------------------------
-bool JGeometryMYSQL::Get(string path, map<string, string> &svals)
+bool JGeometryMYSQL::Get(string /*path*/, map<string, string> &/*svals*/)
 {
     // Looks like we failed to find the requested item. Let the caller know.
     return false;
@@ -45,7 +45,7 @@ bool JGeometryMYSQL::Get(string path, map<string, string> &svals)
 //---------------------------------
 // GetMultiple
 //---------------------------------
-bool JGeometryMYSQL::GetMultiple(string xpath, vector<string> &vsval)
+bool JGeometryMYSQL::GetMultiple(string /*xpath*/, vector<string> &/*vsval*/)
 {
     return false;
 }
@@ -53,7 +53,7 @@ bool JGeometryMYSQL::GetMultiple(string xpath, vector<string> &vsval)
 //---------------------------------
 // GetMultiple
 //---------------------------------
-bool JGeometryMYSQL::GetMultiple(string xpath, vector<map<string, string> >&vsvals)
+bool JGeometryMYSQL::GetMultiple(string /*xpath*/, vector<map<string, string> >&/*vsvals*/)
 {
     return false;
 }
@@ -61,7 +61,7 @@ bool JGeometryMYSQL::GetMultiple(string xpath, vector<map<string, string> >&vsva
 //---------------------------------
 // GetXPaths
 //---------------------------------
-void JGeometryMYSQL::GetXPaths(vector<string> &paths, ATTR_LEVEL_t level, const string &filter)
+void JGeometryMYSQL::GetXPaths(vector<string> &/*paths*/, ATTR_LEVEL_t /*level*/, const string &/*filter*/)
 {
 
 }

--- a/src/libraries/JANA/Compatibility/JGeometryXML.cc
+++ b/src/libraries/JANA/Compatibility/JGeometryXML.cc
@@ -169,6 +169,8 @@ void JGeometryXML::Init(string xmlfile, string xml)
 
 
 #if !HAVE_XERCES
+    (void) xmlfile; // Suppress unused parameter warning
+    (void) xml;     // Suppress unused parameter warning
     jerr<<endl;
     jerr<<"This JANA library was compiled without XERCESC support. To enable"<<endl;
     jerr<<"XERCESC, install it on your system and set your XERCESCROOT enviro."<<endl;
@@ -428,6 +430,8 @@ bool JGeometryXML::GetMultiple(string xpath, vector<string> &vsval)
     pthread_setcancelstate(oldstate, NULL);
     pthread_setcanceltype(oldtype, NULL);
 
+#else
+    (void) xpath; // Suppress unused parameter warning
 #endif
 
     // Looks like we failed to find the requested item. Let the caller know.
@@ -472,7 +476,8 @@ bool JGeometryXML::GetMultiple(string xpath, vector<map<string, string> >&vsvals
 
     pthread_setcancelstate(oldstate, NULL);
     pthread_setcanceltype(oldtype, NULL);
-
+#else
+    (void) xpath; // Suppress unused parameter warning
 #endif
 
     // Looks like we failed to find the requested item. Let the caller know.
@@ -495,6 +500,8 @@ void JGeometryXML::GetXPaths(vector<string> &xpaths, ATTR_LEVEL_t level, const s
 
 #if HAVE_XERCES
     AddNodeToList((DOMNode*)doc->getDocumentElement(), "", xpaths, level);
+#else
+    (void) level; // Suppress unused parameter warning
 #endif // XERCESC
 
     // If no filter is specified then return now.

--- a/src/libraries/JANA/Engine/JArrowProcessingController.cc
+++ b/src/libraries/JANA/Engine/JArrowProcessingController.cc
@@ -238,7 +238,7 @@ std::unique_ptr<const JArrowPerfSummary> JArrowProcessingController::measure_int
 
         summary.avg_latency_ms = (total_message_count == 0)
                                ? std::numeric_limits<double>::infinity()
-                               : summary.avg_latency_ms = total_latency_ms/total_message_count;
+                               : total_latency_ms/total_message_count;
 
         summary.last_latency_ms = (last_message_count == 0)
                                 ? std::numeric_limits<double>::infinity()

--- a/src/libraries/JANA/Engine/JBlockDisentanglerArrow.h
+++ b/src/libraries/JANA/Engine/JBlockDisentanglerArrow.h
@@ -51,7 +51,7 @@ public:
 		JArrowMetrics::Status status;
 		JArrowMetrics::duration_t latency;
 		JArrowMetrics::duration_t overhead; // TODO: Populate these
-		size_t message_count = 0;
+		// size_t message_count = 0;
 
 		int requested_events = this->get_chunksize() * m_max_events_per_block; // chunksize is measured in blocks
 		int reserved_events = m_event_queue->reserve(requested_events, location_id);
@@ -68,12 +68,13 @@ public:
 
 		auto output_queue_status = m_event_queue->push(event_buffer, reserved_events, location_id);
 
-		if (reserved_events == 0 || input_queue_status == JMailbox<T*>::Status::Congested || input_queue_status == JMailbox<T*>::Status::Full) {
+		if (reserved_events == 0 ||
+                    input_queue_status == JMailbox<T*>::Status::Congested ||
+                    output_queue_status == JMailbox<Event>::Status::Full ||
+                    input_queue_status == JMailbox<T*>::Status::Empty
+                   ) {
 			status = JArrowMetrics::Status::ComeBackLater;
 		}
-		// else if (input_queue_status == JMailbox<T*>::Status::Finished) {
-		// 	status = JArrowMetrics::Status::Finished;
-		// }
 		else {
 			status = JArrowMetrics::Status::KeepGoing;
 		}

--- a/src/libraries/JANA/Engine/JDebugProcessingController.cc
+++ b/src/libraries/JANA/Engine/JDebugProcessingController.cc
@@ -160,7 +160,7 @@ std::unique_ptr<const JPerfSummary> JDebugProcessingController::measure_performa
     m_perf_metrics.split(m_total_events_processed);
     auto ps = std::unique_ptr<JPerfSummary>(new JPerfSummary());
     m_perf_metrics.summarize(*ps);
-    return std::move(ps);
+    return ps;
 }
 
 

--- a/src/libraries/JANA/Engine/JTopologyBuilder.h
+++ b/src/libraries/JANA/Engine/JTopologyBuilder.h
@@ -50,7 +50,6 @@ public:
 		size_t event_source_chunksize = 40;
 		size_t event_processor_chunksize = 1;
 		size_t location_count = 1;
-                bool enable_call_graph_recording = false;
                 bool enable_stealing = false;
 		bool limit_total_events_in_flight = true;
 		int affinity = 2;

--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -176,7 +176,9 @@ inline JFactoryT<T>* JEvent::GetFactory(const std::string& tag, bool throw_on_mi
     auto factory = mFactorySet->GetFactory<T>(resolved_tag);
     if (factory == nullptr) {
         if (throw_on_missing) {
-            throw JException("Could not find JFactoryT<" + JTypeInfo::demangle<T>() + "> with tag=" + tag);
+            JException ex("Could not find JFactoryT<" + JTypeInfo::demangle<T>() + "> with tag=" + tag);
+            ex.show_stacktrace = false;
+            throw ex;
         }
     };
     return factory;
@@ -265,10 +267,14 @@ template<class T> const T* JEvent::GetSingleStrict(const std::string& tag) const
     auto iterators = GetFactory<T>(tag, true)->GetOrCreate(this->shared_from_this(), mApplication, mRunNumber);
     mCallGraph.FinishFactoryCall();
     if (std::distance(iterators.first, iterators.second) == 0) {
-        throw JException("GetSingle failed due to missing %d", NAME_OF(T));
+        JException ex("GetSingle failed due to missing %d", NAME_OF(T));
+        ex.show_stacktrace = false;
+        throw ex;
     }
     else if (std::distance(iterators.first, iterators.second) > 1) {
-        throw JException("GetSingle failed due to too many %d", NAME_OF(T));
+        JException ex("GetSingle failed due to too many %d", NAME_OF(T));
+        ex.show_stacktrace = false;
+        throw ex;
     }
     return *iterators.first;
 }
@@ -295,7 +301,9 @@ inline std::vector<JFactoryT<T>*> JEvent::GetFactoryAll(bool throw_on_missing) c
     auto factories = mFactorySet->GetAllFactories<T>();
     if (factories.size() == 0) {
         if (throw_on_missing) {
-            throw JException("Could not find any JFactoryT<" + JTypeInfo::demangle<T>() + "> (from any tag)");
+            JException ex("Could not find any JFactoryT<" + JTypeInfo::demangle<T>() + "> (from any tag)");
+            ex.show_stacktrace = false;
+            throw ex;
         }
     };
     return factories;

--- a/src/libraries/JANA/JException.h
+++ b/src/libraries/JANA/JException.h
@@ -45,7 +45,7 @@ public:
 
     /// Convenience method for formatting complete error data
     inline friend std::ostream& operator<<(std::ostream& os, JException const& ex) {
-        os << "Exception: " << ex.message << std::endl << std::endl;
+        os << "Exception: " << ex.message << std::endl;
         if (ex.plugin_name.length() != 0) {
             os << "  Plugin:         " << ex.plugin_name << std::endl;
         }
@@ -56,7 +56,7 @@ public:
             os << "  Factory name:   " << ex.factory_name << std::endl;
             os << "  Factory tag:    " << ex.factory_tag << std::endl;
         }
-        if (ex.stacktrace.length() != 0) {
+        if (ex.stacktrace.length() != 0 && ex.show_stacktrace) {
             os << "  Backtrace:" << std::endl << std::endl << ex.stacktrace << std::endl << std::endl;
         }
         return os;
@@ -69,6 +69,7 @@ public:
     std::string factory_tag;
     std::string stacktrace;
     std::exception_ptr nested_exception;
+    bool show_stacktrace=true;
 
 };
 

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -142,6 +142,8 @@ public:
             assert(casted != nullptr);
             mData.push_back(casted);
         }
+        mStatus = Status::Inserted;
+        mCreationStatus = CreationStatus::Inserted;
     }
 
     /// Please use the typed setters instead whenever possible
@@ -151,14 +153,23 @@ public:
         mData.push_back(casted);
         mStatus = Status::Inserted;
         mCreationStatus = CreationStatus::Inserted;
-        // TODO: assert correct mStatus precondition
     }
 
     void Set(const std::vector<T*>& aData) {
-        ClearData();
-        mData = aData;
-        mStatus = Status::Inserted;
-        mCreationStatus = CreationStatus::Inserted;
+        if (aData == mData) {
+            // The user populated mData directly instead of populating a temporary vector and passing it to us.
+            // Doing this breaks the JFactory::Status invariant unless they remember to call Set() afterwards.
+            // Ideally, they would use a temporary vector and not access mData at all, but they are used to this
+            // from JANA1 and I haven't found a cleaner solution that gives them what they want yet.
+            mStatus = Status::Inserted;
+            mCreationStatus = CreationStatus::Inserted;
+        }
+        else {
+            ClearData();
+            mData = aData;
+            mStatus = Status::Inserted;
+            mCreationStatus = CreationStatus::Inserted;
+        }
     }
 
     void Set(std::vector<T*>&& aData) {

--- a/src/libraries/JANA/Services/JPluginLoader.cc
+++ b/src/libraries/JANA/Services/JPluginLoader.cc
@@ -113,7 +113,7 @@ void JPluginLoader::attach_plugins(JComponentManager* jcm) {
                     LOG_DEBUG(m_logger) << "Found!" << LOG_END;
                     try {
                         jcm->next_plugin(plugin);
-                        attach_plugin(jcm, fullpath.c_str());
+                        attach_plugin(fullpath.c_str());
                         paths_checked << "Loaded successfully" << std::endl;
                         found_plugin = true;
                         break;
@@ -149,7 +149,7 @@ void JPluginLoader::attach_plugins(JComponentManager* jcm) {
 }
 
 
-void JPluginLoader::attach_plugin(JComponentManager* jcm, std::string soname) {
+void JPluginLoader::attach_plugin(std::string soname) {
 
     /// Attach a plugin by opening the shared object file and running the
     /// InitPlugin_t(JApplication* app) global C-style routine in it.
@@ -174,8 +174,6 @@ void JPluginLoader::attach_plugin(JComponentManager* jcm, std::string soname) {
 
     // Look for an InitPlugin symbol
     typedef void InitPlugin_t(JApplication* app);
-    //typedef void InitPlugin_t(JComponentManager* jcm, JServiceLocator* sl);
-    // TODO: Convert InitPlugin sig to (builder, servicelocator) -> void
     InitPlugin_t* initialize_proc = (InitPlugin_t*) dlsym(handle, "InitPlugin");
     if (initialize_proc) {
         LOG_INFO(m_logger) << "Initializing plugin \"" << soname << "\"" << LOG_END;

--- a/src/libraries/JANA/Services/JPluginLoader.h
+++ b/src/libraries/JANA/Services/JPluginLoader.h
@@ -27,7 +27,7 @@ public:
     void add_plugin(std::string plugin_name);
     void add_plugin_path(std::string path);
     void attach_plugins(JComponentManager* jcm);
-    void attach_plugin(JComponentManager* jcm, std::string plugin_name);
+    void attach_plugin(std::string plugin_name);
 
 private:
 

--- a/src/libraries/JANA/Services/JPluginLoader.h
+++ b/src/libraries/JANA/Services/JPluginLoader.h
@@ -34,6 +34,7 @@ private:
     std::vector<std::string> m_plugins_to_include;
     std::vector<std::string> m_plugins_to_exclude;
     std::vector<std::string> m_plugin_paths;
+    std::string m_plugin_paths_str;
     std::map<std::string, void*> m_sohandles; // key=plugin name  val=dlopen handle
 
     bool m_verbose = false;

--- a/src/libraries/JANA/Services/JServiceLocator.h
+++ b/src/libraries/JANA/Services/JServiceLocator.h
@@ -15,6 +15,7 @@
 #include <assert.h>
 #include <memory>
 #include <mutex>
+#include "JANA/Utils/JTypeInfo.h"
 
 
 class JServiceLocator;
@@ -78,7 +79,9 @@ public:
 
         auto iter = underlying.find(std::type_index(typeid(T)));
         if (iter == underlying.end()) {
-            throw JException("Service not found!");
+            std::ostringstream oss;
+            oss << "Service not found: '" << JTypeInfo::demangle<T>() << "'. Did you forget to include a plugin?" << std::endl;
+            throw JException(oss.str());
         }
         auto& pair = iter->second;
         auto& wired = pair.second;

--- a/src/libraries/JANA/Utils/JCpuInfo.cc
+++ b/src/libraries/JANA/Utils/JCpuInfo.cc
@@ -98,7 +98,7 @@ size_t GetNumaNodeID(size_t cpu_id) {
         return numa_node_of_cpu(cpu_id);
     }
 #else //HAVE_NUMA
-	cpu_id = 0; // suppress compiler warning.
+        (void) cpu_id; // suppress compiler warning.
         return 0;
 #endif //HAVE_NUMA
 }

--- a/src/plugins/janadot/JEventProcessorJANADOT.cc
+++ b/src/plugins/janadot/JEventProcessorJANADOT.cc
@@ -102,7 +102,7 @@ void JEventProcessorJANADOT::Init()
 //------------------------------------------------------------------
 // BeginRun
 //------------------------------------------------------------------
-void JEventProcessorJANADOT::BeginRun(const std::shared_ptr<const JEvent>& event)
+void JEventProcessorJANADOT::BeginRun(const std::shared_ptr<const JEvent>& /*event*/)
 {
 	// Nothing to do here
 }

--- a/src/programs/tests/JEventTests.cc
+++ b/src/programs/tests/JEventTests.cc
@@ -110,7 +110,14 @@ TEST_CASE("JEventInsertTests") {
 
         // GetFactory<T> can conveniently throw an exception if factory is missing.
         // This is useful when said data is required
-        REQUIRE_THROWS(event->GetFactory<FakeJObject>("absent_tag", true));
+        try {
+            event->GetFactory<FakeJObject>("absent_tag", true);
+            REQUIRE(0 == 1); // Shouldn't reach this point
+        }
+        catch (const JException& ex) {
+            // Hide the stack trace by default if the error can be trivially traced back to a JFactory
+            REQUIRE(ex.show_stacktrace == false);
+        }
     }
 
     // -----------------

--- a/src/programs/tests/JFactoryDefTagsTests.cc
+++ b/src/programs/tests/JFactoryDefTagsTests.cc
@@ -35,7 +35,7 @@ struct Fac2 : public JFactoryT<Obj> {
         SetTag("tagB");
     }
 
-    void Process(const std::shared_ptr<const JEvent> &event) override {
+    void Process(const std::shared_ptr<const JEvent>& /*event*/) override {
         auto obj = new Obj;
         obj->x = 1;
         obj->y = 1;

--- a/src/programs/tests/JFactoryTests.cc
+++ b/src/programs/tests/JFactoryTests.cc
@@ -139,7 +139,7 @@ TEST_CASE("JFactoryTests") {
     }
 
     struct Issue135Factory : public JFactoryT<JFactoryTestDummyObject> {
-        void Process(const std::shared_ptr<const JEvent>& event) override {
+        void Process(const std::shared_ptr<const JEvent>&) override {
             mData.emplace_back(new JFactoryTestDummyObject(3));
             mData.emplace_back(new JFactoryTestDummyObject(4));
             mData.emplace_back(new JFactoryTestDummyObject(5));

--- a/src/programs/tests/JServiceLocatorTests.cc
+++ b/src/programs/tests/JServiceLocatorTests.cc
@@ -9,6 +9,21 @@
 #include "JServiceLocatorTests.h"
 
 
+TEST_CASE("JServiceLocatorMissingServiceTest") {
+    JServiceLocator sut;
+    sut.wire_everything();
+    REQUIRE_THROWS(sut.get<ParameterSvc>());
+    /*
+    try {
+        sut.get<ParameterSvc>();
+        REQUIRE(0 == 1); // Never gets here because it throws
+    }
+    catch (JException ex) {
+        std::cout << ex << std::endl;
+    }
+    */
+}
+
 TEST_CASE("JServiceLocator chicken-and-egg tests") {
 
     JServiceLocator sl;

--- a/src/programs/tests/TopologyTests.cc
+++ b/src/programs/tests/TopologyTests.cc
@@ -26,7 +26,7 @@ JArrowMetrics::Status step(JArrow* arrow) {
         return status;
 }
 
-void log_status(JArrowTopology& topology) {
+void log_status(JArrowTopology& /*topology*/) {
 
 }
 


### PR DESCRIPTION
Addresses the following issues, which are mostly usability improvements:

- #134: Plugin path is now a config parameter and not just an environment variable
- #130: When a JService is missing, JServiceLocator provides a better error message
- #131: When a JFactory is missing, JEvent suppresses the stack trace from the error message
- #135: When a JFactory calls Set() after updating mData directly, the contents of mData no longer mysteriously disappear

This also fixes a variety of warnings which appear on gcc11 which did not appear on gcc4.8.5. 