### PR TITLE
Fix typo in Tutorial.md

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -137,7 +137,8 @@ extern "C" {
         app->Add(new QuickTutorialProcessor);
         app->Add(new RandomSource("random", app));    // <- ADD THIS LINE
     }
-}```
+}
+```
 
 And finally, rebuild ...
 ```


### PR DESCRIPTION
Fix the typo which causes the below effect.

![Screenshot from 2022-08-23 23-50-55](https://user-images.githubusercontent.com/40411327/186324540-0bfe056e-5156-4930-9341-b79c44c5ea2d.png)