### PR TITLE
Fix JAutoActivator factory name parsing

### DIFF
--- a/src/libraries/JANA/Utils/JAutoActivator.h
+++ b/src/libraries/JANA/Utils/JAutoActivator.h
@@ -17,6 +17,7 @@ class JAutoActivator : public JEventProcessor {
 public:
     JAutoActivator();
     static bool IsRequested(std::shared_ptr<JParameterManager> params);
+    static std::pair<std::string, std::string> Split(std::string factory_name);
     void AddAutoActivatedFactory(string factory_name, string factory_tag);
     void Init() override;
     void Process(const std::shared_ptr<const JEvent>& event) override;

--- a/src/programs/tests/CMakeLists.txt
+++ b/src/programs/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TEST_SOURCES
     JEventProcessorSequentialTests.cc
     JFactoryDefTagsTests.cc
     SubeventTests.cc
+    JAutoactivableTests.cc
     )
 
 add_executable(janatests ${TEST_SOURCES})

--- a/src/programs/tests/JAutoactivableTests.cc
+++ b/src/programs/tests/JAutoactivableTests.cc
@@ -1,0 +1,40 @@
+
+// Copyright 2022, Jefferson Science Associates, LLC.
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#include "catch.hpp"
+#include <JANA/Utils/JAutoActivator.h>
+
+TEST_CASE("String splitting") {
+    auto pair = JAutoActivator::Split("all_just_objname");
+    REQUIRE(pair.first == "all_just_objname");
+    REQUIRE(pair.second == "");
+
+    pair = JAutoActivator::Split("objname:tag");
+    REQUIRE(pair.first == "objname");
+    REQUIRE(pair.second == "tag");
+
+    pair = JAutoActivator::Split("name::type:factag");
+    REQUIRE(pair.first == "name::type");
+    REQUIRE(pair.second == "factag");
+
+    pair = JAutoActivator::Split("name::type");
+    REQUIRE(pair.first == "name::type");
+    REQUIRE(pair.second == "");
+
+    pair = JAutoActivator::Split("name::type:tag:more_tag");
+    REQUIRE(pair.first == "name::type");
+    REQUIRE(pair.second == "tag:more_tag");
+
+    pair = JAutoActivator::Split("name::type:tag:more_tag::most_tag");
+    REQUIRE(pair.first == "name::type");
+    REQUIRE(pair.second == "tag:more_tag::most_tag");
+
+    pair = JAutoActivator::Split("::name::type:tag:more_tag::most_tag");
+    REQUIRE(pair.first == "::name::type");
+    REQUIRE(pair.second == "tag:more_tag::most_tag");
+
+    pair = JAutoActivator::Split(":I_guess_this_should_be_a_tag_idk");
+    REQUIRE(pair.first == "");
+    REQUIRE(pair.second == "I_guess_this_should_be_a_tag_idk");
+}


### PR DESCRIPTION
JAutoActivator was parsing the factory objname and tag by splitting on the first colon character. This doesn't work when the objname belongs to a namespace. It now splits on the first instance of a colon character that is not immediately followed by a second colon character. Since single colons are not valid inside C++ identifiers, this is the only behavior that makes sense as long as we continue to use colon as the delimiter.

This addresses issue #159.