### PR TITLE
Fix janadot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 3.9)
-project(jana2 VERSION 2.0.7)
+cmake_minimum_required(VERSION 3.16)
+cmake_policy(SET CMP0074 NEW) # find_package() uses <PackageName>_ROOT implicit hints
+
+project(jana2 VERSION 2.0.8)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)   # Enable -fPIC for all targets
 
@@ -16,13 +18,32 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 # Require the user to specify CMAKE_INSTALL_PREFIX directly. DO NOT AUTOMATICALLY INSTALL to /usr/local!
 # Remember that we ultimately want CMAKE_INSTALL_PREFIX=$ENV{JANA_HOME}
 if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-#        message(STATUS "Installing to ${CMAKE_INSTALL_PREFIX}")
+    message(STATUS "Installing to ${CMAKE_INSTALL_PREFIX} .")
 elseif(DEFINED ENV{JANA_HOME})
+    message(STATUS "Installing to $ENV{JANA_HOME} ..")
     set(CMAKE_INSTALL_PREFIX $ENV{JANA_HOME} CACHE PATH "Comment explaining this nonsense" FORCE)
 else()
-    #    message(WARNING "Missing CMAKE_INSTALL_PREFIX=$JANA_HOME => Defaulting to ./install")
+    message(STATUS "Missing CMAKE_INSTALL_PREFIX=$JANA_HOME => Defaulting to ${CMAKE_BINARY_DIR}/install")
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "Comment explaining this nonsense" FORCE)
 endif()
+
+
+# Useful for debugging. Copied from:
+# https://stackoverflow.com/questions/9298278/cmake-print-out-all-accessible-variables-in-a-script
+function(dump_cmake_variables)
+    get_cmake_property(_variableNames VARIABLES)
+    list (SORT _variableNames)
+    foreach (_variableName ${_variableNames})
+        if (ARGV0)
+            unset(MATCHED)
+            string(REGEX MATCH ${ARGV0} MATCHED ${_variableName})
+            if (NOT MATCHED)
+                continue()
+            endif()
+        endif()
+        message(STATUS "${_variableName}=${${_variableName}}")
+    endforeach()
+endfunction()
 
 
 #----------------------

--- a/src/libraries/JANA/CMakeLists.txt
+++ b/src/libraries/JANA/CMakeLists.txt
@@ -94,6 +94,7 @@ set(JANA2_SOURCES
     Utils/JTablePrinter.h
     Utils/JCallGraphRecorder.h
     Utils/JCallGraphRecorder.cc
+    Utils/JCallGraphEntryMaker.h
     Utils/JInspector.cc
     Utils/JInspector.h
 

--- a/src/libraries/JANA/Engine/JEventProcessorArrow.cc
+++ b/src/libraries/JANA/Engine/JEventProcessorArrow.cc
@@ -38,6 +38,7 @@ void JEventProcessorArrow::execute(JArrowMetrics& result, size_t location_id) {
     if (success) {
         LOG_DEBUG(m_logger) << "JEventProcessorArrow '" << get_name() << "': Starting event# " << x->GetEventNumber() << LOG_END;
         for (JEventProcessor* processor : m_processors) {
+            JCallGraphEntryMaker cg_entry(*x->GetJCallGraphRecorder(), processor->GetTypeName()); // times execution until this goes out of scope
             processor->DoMap(x);
         }
         LOG_DEBUG(m_logger) << "JEventProcessorArrow '" << get_name() << "': Finished event# " << x->GetEventNumber() << LOG_END;

--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -385,8 +385,9 @@ JFactoryT<T>* JEvent::GetSingle(const T* &t, const char *tag, bool exception_if_
     /// know if the call succeeded.
 
     std::vector<const T*> v;
-    JFactoryT<T> *fac = Get(v, tag);
+    auto fac = GetFactory<T>(tag, true); // throw exception if factory not found
     JCallGraphEntryMaker cg_entry(mCallGraph, fac); // times execution until this goes out of scope
+    Get(v, tag);
     if(v.size()!=1){
         t = NULL;
         if(exception_if_not_one) throw v.size();

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -165,7 +165,9 @@ public:
             if (m_status == SourceStatus::Opened) {
                 if (m_event_count < first_evt_nr) {
                     event->SetEventNumber(m_event_count); // Default event number to event count
+                    auto previous_origin = event->GetJCallGraphRecorder()->SetInsertDataOrigin( JCallGraphRecorder::ORIGIN_FROM_SOURCE);  // (see note at top of JCallGraphRecorder.h)
                     GetEvent(event);
+                    event->GetJCallGraphRecorder()->SetInsertDataOrigin( previous_origin );
                     m_event_count += 1;
                     return ReturnStatus::TryAgain;  // Reject this event and recycle it
                 } else if (m_nevents != 0 && (m_event_count == last_evt_nr)) {
@@ -173,7 +175,9 @@ public:
                     return ReturnStatus::Finished;
                 } else {
                     event->SetEventNumber(m_event_count); // Default event number to event count
+                    auto previous_origin = event->GetJCallGraphRecorder()->SetInsertDataOrigin( JCallGraphRecorder::ORIGIN_FROM_SOURCE);  // (see note at top of JCallGraphRecorder.h)
                     GetEvent(event);
+                    event->GetJCallGraphRecorder()->SetInsertDataOrigin( previous_origin );
                     m_event_count += 1;
                     return ReturnStatus::Success; // Don't reject this event!
                 }

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -142,8 +142,8 @@ public:
             assert(casted != nullptr);
             mData.push_back(casted);
         }
-        mStatus = Status::Inserted;
-        mCreationStatus = CreationStatus::Inserted;
+        mStatus = Status::Inserted;                  // n.b. This will be overwritten in GetOrCreate above
+        mCreationStatus = CreationStatus::Inserted;  // n.b. This will be overwritten in GetOrCreate above
     }
 
     /// Please use the typed setters instead whenever possible

--- a/src/libraries/JANA/Utils/JCallGraphEntryMaker.h
+++ b/src/libraries/JANA/Utils/JCallGraphEntryMaker.h
@@ -1,0 +1,38 @@
+//
+// Created by davidl on 11/9/22.
+//
+
+#pragma once
+
+#include <JANA/Utils/JCallGraphRecorder.h>
+#include <JANA/JFactory.h>
+
+/// Stack object to handle recording entry to call graph
+///
+/// This is used to add a new entry to a JCallGraph, recording the time when it is created
+/// and then again when it is deleted. The intent is to use it as a local stack variable
+/// so if the call being timed throws an exception, the destructor of this will still get
+/// run, guaranteeing the call stack entry is completed.
+///
+/// Objects of this type are used in JEvent::Get and JEventProcessingArrow::execute
+/// (and possibly other places).
+class JCallGraphEntryMaker{
+public:
+    JCallGraphEntryMaker(JCallGraphRecorder &callgraphrecorder, JFactory *factory) : m_call_graph(callgraphrecorder), m_factory(factory){
+        m_call_graph.StartFactoryCall(m_factory->GetObjectName(), m_factory->GetTag());
+    }
+    JCallGraphEntryMaker(JCallGraphRecorder &callgraphrecorder, std::string name) : m_call_graph(callgraphrecorder) {
+        // (This is used mainly for JEventProcessors and called from JEventProcessorArrow::execute )
+        m_call_graph.StartFactoryCall(name, "");
+    }
+
+    ~JCallGraphEntryMaker(){
+        m_call_graph.FinishFactoryCall( m_factory ? m_factory->GetDataSource():JCallGraphRecorder::DATA_NOT_AVAILABLE );
+    }
+
+protected:
+    JCallGraphRecorder &m_call_graph;
+    JFactory *m_factory=nullptr;
+};
+
+

--- a/src/libraries/JANA/Utils/JCallGraphRecorder.cc
+++ b/src/libraries/JANA/Utils/JCallGraphRecorder.cc
@@ -21,7 +21,7 @@ void JCallGraphRecorder::Reset() {
     m_error_call_stack.clear();
 }
 
-void JCallGraphRecorder::PrintErrorCallStack() {
+void JCallGraphRecorder::PrintErrorCallStack() const {
 
     // Create a list of the call strings while finding the longest one
     vector<string> routines;

--- a/src/plugins/JTest/JTestPlotter.h
+++ b/src/plugins/JTest/JTestPlotter.h
@@ -7,6 +7,7 @@
 
 #include <JANA/JApplication.h>
 #include <JANA/JEventProcessor.h>
+#include "JTestTracker.h"
 
 class JTestPlotter : public JEventProcessor {
 
@@ -37,6 +38,9 @@ public:
         // Read the track data
         auto td = aEvent->GetSingle<JTestTrackData>();
         read_memory(td->buffer);
+
+        // Read the extra data objects inserted by JTestTracker
+        aEvent->Get<JTestTracker::JTestTrackAuxilliaryData>();
 
         // Consume CPU
         consume_cpu_ms(m_cputime_ms, m_cputime_spread);

--- a/src/plugins/JTest/JTestTracker.h
+++ b/src/plugins/JTest/JTestTracker.h
@@ -20,6 +20,11 @@ class JTestTracker : public JFactoryT<JTestTrackData> {
 
 public:
 
+    struct JTestTrackAuxilliaryData{
+        int something = 1;
+        float something2 = 2;
+    };
+
     void Init() override {
 
         auto app = GetApplication();
@@ -43,6 +48,11 @@ public:
         auto td = new JTestTrackData;
         write_memory(td->buffer, m_write_bytes, m_write_spread);
         Insert(td);
+
+        // Insert some additional objects
+        std::vector<JTestTrackAuxilliaryData*> auxObjs;
+        for(int i=0;i<4;i++) auxObjs.push_back( new JTestTrackAuxilliaryData);
+        aEvent->Insert( auxObjs );
     }
 };
 

--- a/src/plugins/janadot/JEventProcessorJANADOT.h
+++ b/src/plugins/janadot/JEventProcessorJANADOT.h
@@ -70,9 +70,7 @@ class JEventProcessorJANADOT:public JEventProcessor
 
 
 	public:
-        JEventProcessorJANADOT() {
-            SetTypeName("JEventProcessorJANADOT");
-        }
+        JEventProcessorJANADOT();
 
         void Init() override;
         void BeginRun(const std::shared_ptr<const JEvent>& event) override;
@@ -84,6 +82,7 @@ class JEventProcessorJANADOT:public JEventProcessor
 			kDefault,
 			kProcessor,
 			kFactory,
+            kCache,
 			kSource
 		};
 
@@ -144,7 +143,7 @@ class JEventProcessorJANADOT:public JEventProcessor
 
 		map<CallLink, CallStats> call_links;
 		map<string, FactoryCallStats> factory_stats;
-		pthread_mutex_t mutex;
+		std::mutex mutex;
 		bool force_all_factories_active;
 		bool suppress_unused_factories;
 		map<string,vector<string> > groups;


### PR DESCRIPTION
This fixes a few issues with janadot. This required some changes to the JANA engine itself to properly record whether inserted events came from an event source or a factory. Specific changes:

- The CMake minimum version was bumped from 3.9 to 3.16. This was done so policy CMP0074 could be set which allows the use of <package>_ROOT environment variables to specify the location of packages for find_package. This actually only needed to be bumped to 3.12 for this, but there were some significant changes in 3.16 that could be useful later.

- The JANA version was bumped to v2.0.8 (this may really need to be bumped to v2.1.0 when we actually make a new release).

- The time recording of running factory algorithms was changed to use std::chrono::steady_clock instead of the old getitimer method.

- A JCallGrapheEntryMaker class was added to start and complete an entry in the JCallGraphRecorder. This fixes the issue of the call graph being incorrect if a factory or event source throws an exception.

- A new origin field was added to track whether inserted objects came from a source or factory.

- JEventProcess objects are now recorded by JCallGraphRecorder

- A bug was squashed where factories created via JEventInsert using an empty vector would leave the factory status as "uninitialized" causing the creationStatus to be overwritten.