### PR TITLE
Error handling fixes

### DIFF
--- a/src/libraries/JANA/CLI/JSignalHandler.h
+++ b/src/libraries/JANA/CLI/JSignalHandler.h
@@ -139,7 +139,9 @@ void handle_usr2(int) {
 }
 
 void handle_sigsegv(int /*signal_number*/, siginfo_t* /*signal_info*/, void* /*context*/) {
+    LOG_FATAL(*g_logger) << "Segfault detected! Printing backtraces and exiting." << LOG_END;
     produce_overall_report();
+    exit(static_cast<int>(JApplication::ExitCode::Segfault));
 }
 
 

--- a/src/libraries/JANA/CLI/JSignalHandler.h
+++ b/src/libraries/JANA/CLI/JSignalHandler.h
@@ -42,8 +42,9 @@ void send_to_named_pipe(const std::string& path_to_named_pipe, const std::string
         close(fd);
     }
     else {
-        LOG_ERROR(*g_logger) << "Unable to open named pipe '"
-                             << g_path_to_named_pipe << "' for writing" << LOG_END;
+        LOG_WARN(*g_logger) << "Unable to open named pipe '" << g_path_to_named_pipe << "' for writing. \n"
+        << "  You can use a different named pipe for status info by setting the parameter `jana:status_fname`.\n"
+        << "  The status report will still show up in the log." << LOG_END;
     }
 }
 

--- a/src/libraries/JANA/CLI/JSignalHandler.h
+++ b/src/libraries/JANA/CLI/JSignalHandler.h
@@ -62,7 +62,7 @@ std::string produce_overall_report() {
 
     // Include detailed report from JApplication
     auto t = time(nullptr);
-    ss << "JANA STATUS REPORT: " << ctime(&t) << std::endl;
+    ss << "JANA status report: " << ctime(&t) << std::endl;
     ss << g_app->GetComponentSummary() << std::endl;
 
     // Include backtraces from each individual thread
@@ -106,8 +106,7 @@ std::string produce_overall_report() {
 }
 
 void send_overall_report_to_named_pipe() {
-    LOG_INFO(*g_logger) << "Caught USR1 signal! Sending status report to named pipe. \n"
-                        << "  `cat " << g_path_to_named_pipe << "` to view report..." << LOG_END;
+    LOG_WARN(*g_logger) << "Caught USR1 signal! Sending status report to named pipe. `cat " << g_path_to_named_pipe << "` to view." << LOG_END;
     send_to_named_pipe(g_path_to_named_pipe, produce_overall_report());
 }
 

--- a/src/libraries/JANA/Engine/JArrowTopology.h
+++ b/src/libraries/JANA/Engine/JArrowTopology.h
@@ -51,8 +51,8 @@ struct JArrowTopology {
     size_t event_processor_chunksize = 1;
     size_t location_count = 1;
     bool enable_stealing = false;
-    int affinity = 2;
-    int locality = 0;
+    int affinity = 0; // By default, don't pin the CPU at all
+    int locality = 0; // By default, assume no NUMA domains
 
     JLogger m_logger;
 

--- a/src/libraries/JANA/Engine/JTopologyBuilder.h
+++ b/src/libraries/JANA/Engine/JTopologyBuilder.h
@@ -24,7 +24,7 @@ class JTopologyBuilder : public JService {
     bool m_enable_call_graph_recording = false;
     bool m_enable_stealing = false;
     bool m_limit_total_events_in_flight = true;
-    int m_affinity = 2;
+    int m_affinity = 0;
     int m_locality = 0;
     JLogger m_arrow_logger;
 

--- a/src/libraries/JANA/Utils/JProcessorMapping.cc
+++ b/src/libraries/JANA/Utils/JProcessorMapping.cc
@@ -77,7 +77,7 @@ void JProcessorMapping::initialize(AffinityStrategy affinity, LocalityStrategy l
         else {
             // On machines with no NUMA domains, lscpu returns "" instead of "0"
             int count = sscanf(buffer, "%zu,%zu,,%zu", &row.cpu_id, &row.core_id, &row.socket_id);
-            row.numa_domain_id = 0;
+            row.numa_domain_id = row.socket_id;
             if (count == 3) {
                 switch (m_locality_strategy) {
                     case LocalityStrategy::CpuLocal:        row.location_id = row.cpu_id; break;
@@ -100,7 +100,7 @@ void JProcessorMapping::initialize(AffinityStrategy affinity, LocalityStrategy l
     int status = 0;
     waitpid(pid, &status, 0);  // Wait for child to exit and acknowledge. This prevents child from becoming a zombie.
 
-    if (WIFEXITED(status)) {
+    if (!WIFEXITED(status)) {
         m_error_msg = "lscpu child process returned abnormally";
         return;
     }

--- a/src/libraries/JANA/Utils/JProcessorMapping.cc
+++ b/src/libraries/JANA/Utils/JProcessorMapping.cc
@@ -3,6 +3,8 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
 #include "JProcessorMapping.h"
+
+#include <JANA/Utils/JTablePrinter.h>
 #include <iomanip>
 #include <unistd.h>
 #include <sys/wait.h>
@@ -171,21 +173,19 @@ std::ostream& operator<<(std::ostream& os, const JProcessorMapping& m) {
     }
 
     if (m.m_initialized) {
-        os << "  +--------+----------+-------+--------+-----------+--------+" << std::endl
-           << "  | worker | location |  cpu  |  core  | numa node | socket |" << std::endl
-           << "  +--------+----------+-------+--------+-----------+--------+" << std::endl;
+        JTablePrinter table;
+        table.AddColumn("worker", JTablePrinter::Justify::Right);
+        table.AddColumn("location", JTablePrinter::Justify::Right);
+        table.AddColumn("cpu", JTablePrinter::Justify::Right);
+        table.AddColumn("core", JTablePrinter::Justify::Right);
+        table.AddColumn("numa node", JTablePrinter::Justify::Right);
+        table.AddColumn("socket", JTablePrinter::Justify::Right);
 
         size_t worker_id = 0;
         for (const JProcessorMapping::Row& row : m.m_mapping) {
-            os <<  "  | " << std::right << std::setw(6) << worker_id++;
-            os << " | " << std::setw(8) << row.location_id;
-            os << " | " << std::setw(5) << row.cpu_id;
-            os << " | " << std::setw(6) << row.core_id;
-            os << " | " << std::setw(9) << row.numa_domain_id;
-            os << " | " << std::setw(6) << row.socket_id << " |" << std::endl;
+            table | worker_id++ | row.location_id | row.cpu_id | row.core_id | row.numa_domain_id | row.socket_id;
         }
-
-        os << "  +--------+----------+-------+--------+-----------+--------+" << std::endl;
+        table.Render(os);
     }
     else if (!m.m_error_msg.empty()) {
         os << "  Error: " << m.m_error_msg << std::endl;


### PR DESCRIPTION
This fixes a number of bugs that have surfaced, and cleans up the log output so as not to confuse users. 

- Correctly waits on the `lscpu` child process, to avoid leaving a zombie (https://github.com/eic/EICrecon/issues/310)
- No longer spawns the `lscpu` child process by default, unless the user wants NUMA awareness
- Cleans up the error and log messages re NUMA awareness so as not to confuse users
- Has the segfault handler exit immediately rather than waiting for a reader on the named pipe for status info (Issue #158)
- Improves a confusing error message regarding opening named pipe for status info (Issue #164)
