### PR TITLE
Improve handling of multiple JEventSources

### DIFF
--- a/src/examples/SubeventCUDAExample/SubeventCUDAExample.cu
+++ b/src/examples/SubeventCUDAExample/SubeventCUDAExample.cu
@@ -136,7 +136,7 @@ int main() {
     app.SetTicker(false);
 
     auto source = new SimpleSource("simpleSource");
-    source->SetRange(0, 10); // limit ourselves to 10 events. Note that the 'jana:nevents' param won't work
+    source->SetNEvents(10); // limit ourselves to 10 events. Note that the 'jana:nevents' param won't work
     // here because we aren't using JComponentManager to manage the EventSource
 
     auto topology = app.GetService<JTopologyBuilder>()->create_empty();

--- a/src/examples/SubeventExample/SubeventExample.cc
+++ b/src/examples/SubeventExample/SubeventExample.cc
@@ -97,7 +97,7 @@ int main() {
     app.SetTicker(false);
 
     auto source = new SimpleSource("simpleSource");
-    source->SetRange(0, 10); // limit ourselves to 10 events. Note that the 'jana:nevents' param won't work
+    source->SetNEvents(10);  // limit ourselves to 10 events. Note that the 'jana:nevents' param won't work
                              // here because we aren't using JComponentManager to manage the EventSource
 
     auto topology = app.GetService<JTopologyBuilder>()->create_empty();

--- a/src/examples/SubeventExample/SubeventExample.cc
+++ b/src/examples/SubeventExample/SubeventExample.cc
@@ -102,7 +102,7 @@ int main() {
 
     auto topology = app.GetService<JTopologyBuilder>()->create_empty();
     auto source_arrow = new JEventSourceArrow("simpleSource",
-                                              source,
+                                              {source},
                                               &events_in,
                                               topology->event_pool);
     auto proc_arrow = new JEventProcessorArrow("simpleProcessor", &events_out, nullptr, topology->event_pool);

--- a/src/libraries/JANA/Engine/JEventSourceArrow.cc
+++ b/src/libraries/JANA/Engine/JEventSourceArrow.cc
@@ -48,23 +48,6 @@ void JEventSourceArrow::execute(JArrowMetrics& result, size_t location_id) {
                 in_status = JEventSource::ReturnStatus::TryAgain;
                 break;
             }
-            if (event->GetJEventSource() != m_source) {
-                // If we have multiple event sources, we need to make sure we are using
-                // event-source-specific factories on top of the default ones.
-                // This is obviously not the best way to handle this but I'll need to
-                // rejigger the whole thing anyway when we re-add parallel event sources.
-                auto factory_set = new JFactorySet();
-                auto src_fac_gen = m_source->GetFactoryGenerator();
-                if (src_fac_gen != nullptr) {
-                    src_fac_gen->GenerateFactories(factory_set);
-                }
-                factory_set->Merge(*event->GetFactorySet());
-                event->SetFactorySet(factory_set);
-                event->SetJEventSource(m_source);
-            }
-            event->SetSequential(false);
-            event->SetJApplication(m_source->GetApplication());
-            event->GetJCallGraphRecorder()->Reset();
             in_status = m_source->DoNext(event);
             if (in_status == JEventSource::ReturnStatus::Success) {
                 m_chunk_buffer.push_back(std::move(event));

--- a/src/libraries/JANA/Engine/JEventSourceArrow.h
+++ b/src/libraries/JANA/Engine/JEventSourceArrow.h
@@ -18,13 +18,14 @@ class JEventPool;
 
 class JEventSourceArrow : public JArrow {
 private:
-    JEventSource* m_source;
+    std::vector<JEventSource*> m_sources;
+    size_t m_current_source = 0;
     EventQueue* m_output_queue;
     std::shared_ptr<JEventPool> m_pool;
     std::vector<Event> m_chunk_buffer;
 
 public:
-    JEventSourceArrow(std::string name, JEventSource* source, EventQueue* output_queue, std::shared_ptr<JEventPool> pool);
+    JEventSourceArrow(std::string name, std::vector<JEventSource*> sources, EventQueue* output_queue, std::shared_ptr<JEventPool> pool);
     void initialize() final;
     void finalize() final;
     void execute(JArrowMetrics& result, size_t location_id) final;

--- a/src/libraries/JANA/Engine/JTopologyBuilder.h
+++ b/src/libraries/JANA/Engine/JTopologyBuilder.h
@@ -140,17 +140,15 @@ public:
         // 2. Oftentimes we want to call JApplication::Initialize() just to set up plugins and services, i.e. for testing.
         //    We don't want to force the user to create a dummy event source if they know they are never going to call JApplication::Run().
 
-        for (auto src: m_components->get_evt_srces()) {
+        // Create arrow for sources.
+        JArrow *arrow = new JEventSourceArrow("sources", m_components->get_evt_srces(), queue, m_topology->event_pool);
+        arrow->set_backoff_tries(0);
+        m_topology->arrows.push_back(arrow);
+        m_topology->sources.push_back(arrow);
+        arrow->set_chunksize(m_event_source_chunksize);
+        arrow->set_logger(m_arrow_logger);
+        arrow->set_running_arrows(&m_topology->running_arrow_count);
 
-            // create arrow for each source. Don't open until arrow.activate() called
-            JArrow *arrow = new JEventSourceArrow(src->GetName(), src, queue, m_topology->event_pool);
-            arrow->set_backoff_tries(0);
-            m_topology->arrows.push_back(arrow);
-            m_topology->sources.push_back(arrow);
-            arrow->set_chunksize(m_event_source_chunksize);
-            arrow->set_logger(m_arrow_logger);
-            arrow->set_running_arrows(&m_topology->running_arrow_count);
-        }
 
         auto proc_arrow = new JEventProcessorArrow("processors", queue, nullptr, m_topology->event_pool);
         proc_arrow->set_chunksize(m_event_processor_chunksize);

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -174,7 +174,7 @@ public:
                     return ReturnStatus::TryAgain;  // Reject this event and recycle it
                 } else if (m_nevents != 0 && (m_event_count == last_evt_nr)) {
                     // Declare ourselves finished due to nevents
-                    m_status = SourceStatus::Finished;
+                    DoFinalize(); // Close out the event source as soon as it declares itself finished
                     return ReturnStatus::Finished;
                 } else {
                     // Actually emit an event.
@@ -207,7 +207,7 @@ public:
         catch (RETURN_STATUS rs) {
 
             if (rs == RETURN_STATUS::kNO_MORE_EVENTS) {
-                m_status = SourceStatus::Finished;
+                DoFinalize();
                 return ReturnStatus::Finished;
             }
             else if (rs == RETURN_STATUS::kTRY_AGAIN || rs == RETURN_STATUS::kBUSY) {

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -144,7 +144,7 @@ public:
             throw(JException(e.what()));
         }
         catch (...) {
-            auto ex = JException("Unknown exception in JEventSource::Open()");
+            auto ex = JException("Unknown exception in JEventSource::Close()");
             ex.nested_exception = std::current_exception();
             ex.plugin_name = m_plugin_name;
             ex.component_name = GetType();
@@ -181,6 +181,7 @@ public:
                     // GetEvent() expects the following things from its incoming JEvent
                     event->SetEventNumber(m_event_count);
                     event->SetJApplication(m_application);
+                    event->SetJEventSource(this);
                     event->SetSequential(false);
                     event->GetJCallGraphRecorder()->Reset();
                     if (event->GetJEventSource() != this && m_factory_generator != nullptr) {
@@ -190,7 +191,6 @@ public:
                         m_factory_generator->GenerateFactories(factory_set);
                         factory_set->Merge(*event->GetFactorySet());
                         event->SetFactorySet(factory_set);
-                        event->SetJEventSource(this);
                     }
                     auto previous_origin = event->GetJCallGraphRecorder()->SetInsertDataOrigin( JCallGraphRecorder::ORIGIN_FROM_SOURCE);  // (see note at top of JCallGraphRecorder.h)
                     GetEvent(event);

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -277,6 +277,10 @@ public:
     //This should create default factories for all types available in the event source
     JFactoryGenerator* GetFactoryGenerator() const { return m_factory_generator; }
 
+    uint64_t GetNSkip() { return m_nskip; }
+    uint64_t GetNEvents() { return m_nevents; }
+
+
     /// SetTypeName is intended as a replacement to GetType(), which should be less confusing for the
     /// user. It should be called from the constructor. For convenience, we provide a
     /// NAME_OF_THIS macro so that the user doesn't have to type the class name as a string, which may
@@ -305,10 +309,10 @@ public:
     void SetPluginName(std::string plugin_name) { m_plugin_name = std::move(plugin_name); };
 
     // Meant to be called by JANA
-    void SetRange(uint64_t nskip, uint64_t nevents) {
-        m_nskip = nskip;
-        m_nevents = nevents;
-    };
+    void SetNEvents(uint64_t nevents) { m_nevents = nevents; };
+
+    // Meant to be called by JANA
+    void SetNSkip(uint64_t nskip) { m_nskip = nskip; };
 
 
 private:

--- a/src/libraries/JANA/Services/JComponentManager.cc
+++ b/src/libraries/JANA/Services/JComponentManager.cc
@@ -103,7 +103,11 @@ void JComponentManager::resolve_event_sources() {
     m_app->SetDefaultParameter("jana:nskip", m_nskip, "Number of events that sources should skip before starting emitting");
 
     for (auto source : m_evt_srces) {
-        source->SetRange(m_nskip, m_nevents);
+        // If nskip/nevents are set individually on JEventSources, respect those. Otherwise use global values.
+        // Note that this is not what we usually want when we have multiple event sources. It would make more sense to
+        // take the nskip/nevent slice across the stream of events emitted by each JEventSource in turn.
+        if (source->GetNSkip() == 0) source->SetNSkip(m_nskip);
+        if (source->GetNEvents() == 0) source->SetNEvents(m_nevents);
     }
 }
 

--- a/src/programs/tests/NEventNSkipTests.cc
+++ b/src/programs/tests/NEventNSkipTests.cc
@@ -146,9 +146,9 @@ TEST_CASE("JEventSourceArrow with multiple JEventSources") {
         source1->event_bound = 9;
         source2->event_bound = 13;
         source3->event_bound = 7;
-        source1->SetRange(2, 4);
-        source2->SetRange(0, 0);
-        source3->SetRange(0, 4);
+        source1->SetNSkip(2);
+        source1->SetNEvents(4);
+        source3->SetNEvents(4);
 
         app.SetParameterValue("nthreads", 4);
         app.Run(true);

--- a/src/programs/tests/SubeventTests.cc
+++ b/src/programs/tests/SubeventTests.cc
@@ -180,7 +180,7 @@ TEST_CASE("Basic subevent arrow functionality") {
 
         auto topology = app.GetService<JTopologyBuilder>()->create_empty();
         auto source_arrow = new JEventSourceArrow("simpleSource",
-                                                  new SimpleSource("simpleSource"),
+                                                  {new SimpleSource("simpleSource")},
                                                   &events_in,
                                                   topology->event_pool);
         auto proc_arrow = new JEventProcessorArrow("simpleProcessor", &events_out, nullptr, topology->event_pool);

--- a/src/programs/tests/TerminationTests.cc
+++ b/src/programs/tests/TerminationTests.cc
@@ -48,12 +48,16 @@ TEST_CASE("TerminationTests") {
 
     SECTION("Arrow engine, interrupted during JEventSource::Open()") {
 
+        // TODO: This test is kind of useless now that JEventSource::Open is called from
+        //       JEventSourceArrow::execute rather than JEventSourceArrow::initialize().
+        //       What we really want is an Arrow that has an initialize() that we override.
+        //       However to do that, we need to extend JESA and create a custom topology.
         app.SetParameterValue("jana:engine", 0);
         auto source = new InterruptedSource("InterruptedSource", &app);
         app.Add(source);
         app.Run(true);
-        REQUIRE(processor->processed_count == 0);
-        REQUIRE(processor->finish_call_count == 0);
+        REQUIRE(processor->processed_count == 1);  // TODO: Was 0, should become zero again
+        REQUIRE(processor->finish_call_count == 1);
         // Stop() tells JApplication to finish Initialize() but not to proceed with Run().
         // If we had called Quit() instead, it would have exited Initialize() immediately and ended the program.
 


### PR DESCRIPTION
Previously, multiple event sources would each be assigned separate JEventSourceArrows and be run at the same time. This PR changes JEventProcessorArrow so that it accepts a vector of JEventSources and runs them one after another until each completes or reaches the max `jana:nevents'.  This leads to fewer files/sockets being open simultaneously, better performance due to fewer calls to `JFactory::ChangeRun` etc,  less work for the scheduler, and a more easy-to-reason-about event stream. The old behavior is easy to bring back in the JTopologyBuilder if we ever want it. 

This addresses issue #146. 

It includes some refactorings:
- JEventSource::DoNext now handles all of the logic for setting up a JEvent prior to JEventSource::GetEvent. Previously some of this was mixed in with JEventSourceArrow. 
- JEventSource::DoNext() now calls JEventSource::Close() when JEventSource::GetEvent() declares itself finished. 
- JEventSource::SetRange() is replaced with JEventSource::SetNEvents and SetNSkip. The corresponding getters have been added. 

There is one small behavior modification:
- JEventSource::Open() is now always called from JEventSourceArrow::execute(), whereas before it was called from JEventSourceArrow::initialize(). This changes the behavior of JApplication::Quit() when called from inside JEventSource::Open, as well as Ctrl-C: Previously, no events would be emitted and Run() would return before even firing up the workers. Now, Quit() will trigger a graceful shutdown but won't immediately stop the source from emitting JEvents. This is less useful but more consistent and correct: if you want to handle an error condition in JEventSource::Open(), you should throw a JException instead.
