### PR TITLE
JVersion fixes

### DIFF
--- a/src/libraries/JANA/CLI/CMakeLists.txt
+++ b/src/libraries/JANA/CLI/CMakeLists.txt
@@ -67,6 +67,7 @@ else()
     set(JVERSION_MODIFIED 1)
 endif()
 
+message(STATUS "Generating JVersion.h")
 configure_file(JVersion.h.in JVersion.h)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/JVersion.h DESTINATION include/JANA/CLI)

--- a/src/libraries/JANA/CLI/CMakeLists.txt
+++ b/src/libraries/JANA/CLI/CMakeLists.txt
@@ -3,6 +3,10 @@
 # Generate JVersion.h
 
 # Force CMake to reconfigure itself whenever git's HEAD pointer changes
+# Note that HEAD usually points to the branch name, not the commit hash.
+# This will correctly force CMake to reconfigure itself when you check out an existing branch, tag, or commit.
+# It will not force CMake to reconfigure if you are adding successive commits to a branch.
+# For that, you have to manually reconfigure CMake.
 set_property(
         DIRECTORY
         APPEND
@@ -13,6 +17,7 @@ set_property(
 execute_process(
         COMMAND git log -1 --format=%H
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        RESULT_VARIABLE JVERSION_GIT_RESULT
         OUTPUT_VARIABLE JVERSION_COMMIT_HASH
         OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -31,12 +36,6 @@ execute_process(
         OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-if(JVERSION_RELEASE_COMMIT_HASH EQUAL JVERSION_COMMIT_HASH)
-    set(JVERSION_RELEASE 1)
-else()
-    set(JVERSION_RELEASE 0)
-endif()
-
 execute_process(
         COMMAND git status --porcelain
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
@@ -44,10 +43,28 @@ execute_process(
         OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-if(JVERSION_MODIFIED_FILES)
-    set(JVERSION_MODIFIED 1)
+
+# If our call to git log returned a non-zero exit code, we don't have git information and shouldn't pretend we do
+if(JVERSION_GIT_RESULT EQUAL 0)
+    set(JVERSION_UNKNOWN 0)
 else()
+    set(JVERSION_UNKNOWN 1)
+endif()
+
+# We figure out whether we are actually the release commit (according to git) by comparing the commit hashes
+if(JVERSION_RELEASE_COMMIT_HASH STREQUAL JVERSION_COMMIT_HASH)
+    set(JVERSION_RELEASE 1)
+else()
+    set(JVERSION_RELEASE 0)
+endif()
+
+# Even if `git log` indicates we are on the latest release, there might have been some changes
+# made on top that haven't been committed yet
+#
+if(JVERSION_MODIFIED_FILES STREQUAL "")
     set(JVERSION_MODIFIED 0)
+else()
+    set(JVERSION_MODIFIED 1)
 endif()
 
 configure_file(JVersion.h.in JVersion.h)

--- a/src/libraries/JANA/CLI/JMain.cc
+++ b/src/libraries/JANA/CLI/JMain.cc
@@ -46,8 +46,10 @@ void PrintVersion() {
     /// Prints JANA version information to stdout, for use by the CLI.
 
     std::cout << "JANA2 version:  " << JVersion::GetVersion() << std::endl;
-    std::cout << "Commit hash:    " << JVersion::GetCommitHash() << std::endl;
-    std::cout << "Commit date:    " << JVersion::GetCommitDate() << std::endl;
+    if (!JVersion::is_unknown) {
+        std::cout << "Commit hash:    " << JVersion::GetCommitHash() << std::endl;
+        std::cout << "Commit date:    " << JVersion::GetCommitDate() << std::endl;
+    }
 }
 
 JApplication* CreateJApplication(UserOptions& options) {

--- a/src/libraries/JANA/CLI/JVersion.h.in
+++ b/src/libraries/JANA/CLI/JVersion.h.in
@@ -14,6 +14,7 @@ struct JVersion {
     static const int patch = @jana2_VERSION_PATCH@;
     static const std::string last_commit_hash;
     static const std::string last_commit_date;
+    static const bool is_unknown = @JVERSION_UNKNOWN@;
     static const bool is_release = @JVERSION_RELEASE@;
     static const bool is_modified = @JVERSION_MODIFIED@;
 
@@ -27,7 +28,10 @@ struct JVersion {
     static std::string GetVersion() {
         std::stringstream ss;
         ss << major << "." << minor << "." << patch;
-        if (is_modified) {
+        if (is_unknown) {
+            ss << " (git status unknown)";
+        }
+        else if (is_modified) {
             ss << " (modified)";
         }
         else if (is_release) {

--- a/src/libraries/JANA/CLI/JVersion.h.in
+++ b/src/libraries/JANA/CLI/JVersion.h.in
@@ -29,10 +29,11 @@ struct JVersion {
         std::stringstream ss;
         ss << major << "." << minor << "." << patch;
         if (is_unknown) {
-            ss << " (git status unknown)";
+            // ss << " (git status unknown)";
+            // If .git is not present, degrade gracefully. Don't lead the user to believe that there is an error
         }
         else if (is_modified) {
-            ss << " (modified)";
+            ss << " (uncommitted changes)";
         }
         else if (is_release) {
             ss << " (release)";

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <vector>
 #include <map>
+#include <cmath>
 
 #include <JANA/JLogger.h>
 #include <JANA/JException.h>


### PR DESCRIPTION
JVersion.h gave misleading information when built from a zip archive. 

This PR fixes it so that if no git information is present, it will only print the version number. Otherwise it prints the commit hash and commit date, along with the indicator

- `(release)`: This artifact was built from exactly the commit tagged with this release number
- `(development)`: This artifact was built from a commit OTHER than the release commit
- `(uncommitted changes)`:  This artifact includes changes not committed at all
