### PR TITLE
fix: call backtrace_symbols with actual frame_count

### DIFF
--- a/src/libraries/JANA/Utils/JBacktrace.h
+++ b/src/libraries/JANA/Utils/JBacktrace.h
@@ -21,7 +21,7 @@ inline std::ostream& make_backtrace(std::ostream& os) {
         const int max_frames = 100;
         void* backtrace_buffer[max_frames];
         int frame_count = backtrace(backtrace_buffer, max_frames);
-        char** symbols = backtrace_symbols(backtrace_buffer, max_frames);
+        char** symbols = backtrace_symbols(backtrace_buffer, frame_count);
         // Skip the first two frames, because those are "make_backtrace" and "JException::JException"
         for (int i=2; i<frame_count; ++i) {
 


### PR DESCRIPTION
Per [backtrace_symbols(3)](https://man7.org/linux/man-pages/man3/backtrace_symbols.3.html), in particular the Example section, the following appears preferred (comments removed):
```cpp
           int nptrs;
           void *buffer[BT_BUF_SIZE];
           char **strings;

           nptrs = backtrace(buffer, BT_BUF_SIZE);
           printf("backtrace() returned %d addresses\n", nptrs);

           strings = backtrace_symbols(buffer, nptrs);
```
That is, use `backtrace_symbols(buffer, nptrs)` instead of `backtrace_symbols(buffer, BT_BUF_SIZE)`.

While this does not affect the actual running, it does affect valgrind output, with many false positives such as:
```
==46== Conditional jump or move depends on uninitialised value(s)
==46==    at 0x400B567: _dl_find_dso_for_object (dl-open.c:220)
==46==    by 0x515A8E7: _dl_addr (dl-addr.c:127)
==46==    by 0x5121882: backtrace_symbols (backtracesyms.c:48)
==46==    by 0x12C994: make_backtrace(std::ostream&) (JBacktrace.h:24)
==46==    by 0x12CE7A: JException::JException(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (JException.h:22)
==46==    by 0x176987: JWorker::JWorker(JArrowProcessingController*, JScheduler*, unsigned int, unsigned int, unsigned int, bool) (in /home/runner/work/EICrecon/EICrecon/bin/eicrecon)
==46==    by 0x155F7C: JArrowProcessingController::run(unsigned long) (in /home/runner/work/EICrecon/EICrecon/bin/eicrecon)
==46==    by 0x1418BC: JApplication::Run(bool) (in /home/runner/work/EICrecon/EICrecon/bin/eicrecon)
==46==    by 0x12ADC7: jana::Execute(JApplication*, jana::UserOptions&) (eicrecon_cli.cpp:389)
==46==    by 0x12450E: main (eicrecon.cc:55)
==46==  Uninitialised value was created by a stack allocation
==46==    at 0x12C955: make_backtrace(std::ostream&) (JBacktrace.h:17)
```

Looking at the [glib implementation](https://codebrowser.dev/glibc/glibc/debug/backtracesyms.c.html#36), we see that `__backtrace_symbols(void *const *array, int size)` calls `_dl_addr (array[cnt], ...)` for all `cnt` up to `size` passed to `backtrace_symbols`. That leads indeed to code potentially using uninitialized data.