### PR TITLE
Add option "BUILD_SHARED_LIBS" to control built lib type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ option(USE_PYTHON "Include Python dependency. This requires python-devel and pyt
 option(USE_ASAN "Compile with address sanitizer" OFF)
 option(USE_TSAN "Compile with thread sanitizer" OFF)
 option(USE_CUDA "Compile CUDA-involved examples (Needed for examples/SubeventCUDAExample)." OFF)
+option(BUILD_SHARED_LIBS "Build into both shared and static libs." ON)
 
 
 if (${USE_ROOT})
@@ -150,6 +151,11 @@ if (${USE_CUDA})
     message(STATUS "USE_CUDA    On")
 else()
     message(STATUS "USE_CUDA    Off")
+endif()
+if (${BUILD_SHARED_LIBS})
+    message(STATUS "BUILD_SHARED_LIBS    On")
+else()
+    message(STATUS "BUILD_SHARED_LIBS    Off")
 endif()
 message(STATUS "-----------------------")
 

--- a/src/libraries/JANA/CMakeLists.txt
+++ b/src/libraries/JANA/CMakeLists.txt
@@ -137,7 +137,7 @@ if (NOT ${USE_XERCES})
     message(STATUS "Skipping support for libJANA's JGeometryXML because USE_XERCES=Off")
 endif()
 
-add_library(jana2 STATIC ${JANA2_SOURCES})
+add_library(jana2 OBJECT ${JANA2_SOURCES})
 
 find_package(Threads REQUIRED)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -145,10 +145,23 @@ target_include_directories(jana2 PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 # So that we can find the generated JVersion.h before install
 
 target_link_libraries(jana2 ${CMAKE_DL_LIBS} Threads::Threads)
-set_target_properties(jana2 PROPERTIES PREFIX "lib" OUTPUT_NAME "JANA")
+
+if (BUILD_SHARED_LIBS)
+    message("-- Build into both shared and static libs")
+    add_library(jana2_shared_lib SHARED $<TARGET_OBJECTS:jana2>)
+    set_target_properties(jana2_shared_lib PROPERTIES PREFIX "lib" OUTPUT_NAME "JANA")
+    install(TARGETS jana2_shared_lib DESTINATION lib)
+    set(INSTALL_RPATH_USE_LINK_PATH True)
+else()
+    message("-- Build into static lib only")
+endif()
+
+# static library, always there
+add_library(jana2_static_lib STATIC $<TARGET_OBJECTS:jana2>)
+set_target_properties(jana2_static_lib PROPERTIES PREFIX "lib" OUTPUT_NAME "JANA")
 
 # Install library
-install(TARGETS jana2 EXPORT jana2_targets DESTINATION lib)
+install(TARGETS jana2_static_lib EXPORT jana2_targets DESTINATION lib)
 
 # Install JANATargets.cmake
 install(EXPORT jana2_targets FILE JANATargets.cmake NAMESPACE JANA:: DESTINATION lib/cmake/JANA)

--- a/src/libraries/JANA/Utils/JPerfUtils.cc
+++ b/src/libraries/JANA/Utils/JPerfUtils.cc
@@ -60,7 +60,7 @@ uint64_t write_memory(std::vector<char>& buffer, uint64_t bytes, double spread) 
     return sampled*2;
 }
 
-inline void init_generator() {
+void init_generator() {
     if (!generator) {
         std::hash<std::thread::id> hasher;
         long now = std::chrono::steady_clock::now().time_since_epoch().count();


### PR DESCRIPTION
Use `-DBUILD_SHARED_LIB=OFF` to compile JANA into a static lib only, otherwise it will compile into both types.
Set `INSTALL_RPATH_USE_LINK_PATH` to `TRUE` so we do not need to add `$JANA_HOME/lib` into `$LD_LIBRARY_PATH`.
