### PR TITLE
Fix issue with reading in config file with very long lines.

### DIFF
--- a/src/libraries/JANA/Services/JParameterManager.cc
+++ b/src/libraries/JANA/Services/JParameterManager.cc
@@ -202,10 +202,11 @@ void JParameterManager::ReadConfigFile(std::string filename) {
     }
 
     // Loop over lines
-    char line[1024];
+    char line[8192];
     while (!ifs.eof()) {
         // Read in next line ignoring comments
-        ifs.getline(line, 1024);
+        bzero(line, 8192);
+        ifs.getline(line, 8190);
         if (strlen(line) == 0) continue;
         if (line[0] == '#') continue;
         string str(line);


### PR DESCRIPTION
This addresses an issue seen when reading in a config. file dumped by an `eicrecon` job where the processes gets stuck in an infinite loop.

This increases the buffer size used for reading in a single line from 1kB to 8kB and initializes the buffer with all zeros. This ensures that if the line overflows the buffer, there is guaranteed to be a terminating null, preventing the infinite loop.
