### PR TITLE
Add RegisterParameter and associated unit tests.

### DIFF
--- a/.github/workflows/ccpp-linux.yml
+++ b/.github/workflows/ccpp-linux.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
 
     # See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on for available platforms
     runs-on: ${{ matrix.os }}

--- a/src/libraries/JANA/JApplication.h
+++ b/src/libraries/JANA/JApplication.h
@@ -113,6 +113,9 @@ public:
     template <typename T>
     JParameter* SetDefaultParameter(std::string name, T& val, std::string description="");
 
+    template <typename T>
+    T RegisterParameter(std::string name, const T default_val, std::string description="");
+
     // Locating services
 
     /// Use this in EventSources, Factories, or EventProcessors. Do not call this
@@ -171,6 +174,11 @@ JParameter* JApplication::SetParameterValue(std::string name, T val) {
 template <typename T>
 JParameter* JApplication::SetDefaultParameter(std::string name, T& val, std::string description) {
     return m_params->SetDefaultParameter(name.c_str(), val, description);
+}
+
+template <typename T>
+T JApplication::RegisterParameter(std::string name, const T default_val, std::string description) {
+    return m_params->RegisterParameter(name.c_str(), default_val, description);
 }
 
 template <typename T>

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -94,6 +94,9 @@ public:
     template<typename T>
     JParameter* SetDefaultParameter(std::string name, T& val, std::string description = "");
 
+    template <typename T>
+    T RegisterParameter(std::string name, const T default_val, std::string description = "");
+
     void FilterParameters(std::map<std::string,std::string> &parms, std::string filter="");
 
     void ReadConfigFile(std::string name);
@@ -265,6 +268,26 @@ JParameter* JParameterManager::SetDefaultParameter(std::string name, T& val, std
     val = Parse<T>(param->GetValue());
     param->SetIsUsed(true);
     return param;
+}
+
+/// @brief Retrieve a configuration parameter, if necessary creating it with the provided default value.
+///
+/// @param [in] name            The parameter name. Must not contain spaces.
+/// @param [in,out] default_val Value to set the desired default value to (returned if no value yet set for parameter).
+/// @param [in] description     Optional description, e.g. units, set or range of valid values, etc.
+/// @return                     Current value of parameter
+///
+/// @details This is a convenience method that wraps SetDefaultParameter. The difference
+/// is that this has the default passed by value (not by reference) and the value of the parameter is returned
+/// by value. This allows a slightly different form for declaring configuration parameters with a default value.
+/// e.g.
+///     auto thresh = jpp->RegisterParameter("SystemA:threshold", 1.3, "threshold in MeV");
+///
+template <typename T>
+inline T JParameterManager::RegisterParameter(std::string name, const T default_val, std::string description){
+    T val = default_val;
+    SetDefaultParameter(name.c_str(), val, description);
+    return val;
 }
 
 

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -206,6 +206,31 @@ TEST_CASE("JParameterManager_VectorParams") {
         auto param = jpm.GetParameter("test", outputs);
         REQUIRE(param->GetValue() == "22,49.2,42");
     }
+}
+
+TEST_CASE("JParameterManager::RegisterParameter") {
+
+    JParameterManager jpm;
+
+    SECTION("Set/Get") {
+        int x_default = 44;
+        auto x_actual = jpm.RegisterParameter("testing:dummy_var", x_default);
+        REQUIRE(x_actual == x_default);
+    }
+
+    SECTION("Set/Get templated float") {
+        auto y_actual = jpm.RegisterParameter("testing:dummy_var2", 22.0);
+        REQUIRE(y_actual == 22.0);
+    }
+
+    SECTION("Set/Get default") {
+        jpm.SetParameter("testing:dummy_var", 22);
+        auto x_actual = jpm.RegisterParameter("testing:dummy_var", 44);  // this should set the default value to 44 while keeping value at 22
+        auto x_default_str = jpm.FindParameter("testing:dummy_var")->GetDefault();
+        auto x_default = jpm.Parse<int>(x_default_str);
+        REQUIRE(x_actual == 22);
+        REQUIRE(x_default == 44);
+    }
 
 }
 


### PR DESCRIPTION
This addresses issue #188 . 

It adds a RegisterParameter method to both JApplication and JParameterManager (the former just wraps the latter). Unit tests have also been added.

This does not mark SetDefaultParameter as deprecated at this time.