### PR TITLE
Fix the exported cmake target 

### DIFF
--- a/src/libraries/JANA/CMakeLists.txt
+++ b/src/libraries/JANA/CMakeLists.txt
@@ -146,19 +146,20 @@ target_include_directories(jana2 PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 
 target_link_libraries(jana2 ${CMAKE_DL_LIBS} Threads::Threads)
 
+# static library, always there
+add_library(jana2_static_lib STATIC $<TARGET_OBJECTS:jana2>)
+set_target_properties(jana2_static_lib PROPERTIES PREFIX "lib" OUTPUT_NAME "JANA")
+
+# optionally build shared lib
 if (BUILD_SHARED_LIBS)
     message("-- Build into both shared and static libs")
     add_library(jana2_shared_lib SHARED $<TARGET_OBJECTS:jana2>)
     set_target_properties(jana2_shared_lib PROPERTIES PREFIX "lib" OUTPUT_NAME "JANA")
-    install(TARGETS jana2_shared_lib DESTINATION lib)
+    install(TARGETS jana2_shared_lib EXPORT jana2_targets DESTINATION lib)
     set(INSTALL_RPATH_USE_LINK_PATH True)
 else()
     message("-- Build into static lib only")
 endif()
-
-# static library, always there
-add_library(jana2_static_lib STATIC $<TARGET_OBJECTS:jana2>)
-set_target_properties(jana2_static_lib PROPERTIES PREFIX "lib" OUTPUT_NAME "JANA")
 
 # Install library
 install(TARGETS jana2_static_lib EXPORT jana2_targets DESTINATION lib)

--- a/src/libraries/JANA/JANAConfig.cmake.in
+++ b/src/libraries/JANA/JANAConfig.cmake.in
@@ -4,15 +4,32 @@ find_package(Threads REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/JANATargets.cmake")
 
-get_target_property(JANA_INCLUDE_DIRS JANA::jana2 INCLUDE_DIRECTORIES)
-set(JANA_LIBRARIES JANA::jana2)
-set(JANA_LIB JANA::jana2)
 
-# FIXME: This avoid the issue with only JANA_INCLUDE_DIRS
-# FIXME: being defined and having a value "NOT_FOUND".
-# FIXME: It also provides legacy support for JANA_LIBRARY
-set(JANA_INCLUDE_DIR @CMAKE_INSTALL_PREFIX@/include)
-set(JANA_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include)
-set(JANA_LIBRARY JANA::jana2)
+# Provide user with shared libraries by default if JANA was built with them. 
+# Otherwise, provide them with the static version. They can always specify themselves
+# using the JANA::jana2_shared_lib and JANA::jana2_static_lib targets explicitly.
+# n.b. this would be cleaner if we could use an ALIAS, but that would require cmake
+# 3.18 or greater and we want to support legacy versions at this point.
+set(BUILD_SHARED_LIBS @BUILD_SHARED_LIBS@)
+if (${BUILD_SHARED_LIBS})
+    get_target_property(JANA_INCLUDE_DIRS JANA::jana2_shared_lib INTERFACE_INCLUDE_DIRECTORIES)
+    set(JANA_LIBRARIES JANA::jana2_shared_lib)
+else()
+    get_target_property(JANA_INCLUDE_DIRS JANA::jana2_static_lib INTERFACE_INCLUDE_DIRECTORIES)
+    set(JANA_LIBRARIES JANA::jana2_static_lib)
+endif()
+
+# There are some issues with the include directories being passed through as a property
+# of the imported targets. This shows up as JANA_INCLUDE_DIRS being set to
+# "JANA_INCLUDE_DIRS-NOTFOUND". As a workaround, if "NOTFOUND" is included in
+# JANA_INCLUDE_DIRS then overwrite it here with what it should have been set to.
+if(${JANA_INCLUDE_DIRS} MATCHES "NOTFOUND")
+    set(JANA_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include)
+endif()
+
+# Backwards compatibility
+set(JANA_INCLUDE_DIR ${JANA_INCLUDE_DIRS})
+set(JANA_LIBRARY ${JANA_LIBRARIES}) 
+set(JANA_LIB ${JANA_LIBRARIES}) 
 
 


### PR DESCRIPTION
This addresses the JANA::jana2 not found issue when using JANA in a 3rd party cmake project.

When the shared library target was added, the name of the original library target was changed from "jana" to "jana_static_lib". This got propagated to the `JANAConfig.cmake` file that is generated during the build for use by downstream cmake projects that use JANA meaning the `JANA:jana_static_lib` target was defined, but the `JANA::jana2` one was not.

This PR will set `JANA_LIBRARIES` to either `JANA::jana_shared_lib` or `JANA::jana_static_lib` depending on whether JANA builds the shared lib.