### PR TITLE
Allow for JEvent to not have a JEventSource pointer set.

### DIFF
--- a/src/libraries/JANA/Engine/JEventProcessorArrow.cc
+++ b/src/libraries/JANA/Engine/JEventProcessorArrow.cc
@@ -54,7 +54,7 @@ void JEventProcessorArrow::execute(JArrowMetrics& result, size_t location_id) {
         }
         else {
             // This IS the last arrow in the topology. Notify the event source and return event to the pool.
-            x->GetJEventSource()->DoFinish(*x);
+            if( auto es = x->GetJEventSource() ) es->DoFinish(*x);
             m_pool->put(x, location_id);
         }
     }


### PR DESCRIPTION
This fixes a bug in where a seg. fault occurs when a `JEvent` does not have its `JEventSource` pointer set. This occurs when using a blocked event topology where the `JBlockedEventSource` is not a `JEventSource` and so the pointer in `JEvent` is left set to nullptr.