### PR TITLE
No sources bug fix

### DIFF
--- a/src/libraries/JANA/Engine/JArrowProcessingController.cc
+++ b/src/libraries/JANA/Engine/JArrowProcessingController.cc
@@ -35,6 +35,15 @@ void JArrowProcessingController::initialize() {
 
 }
 
+/// @brief This will run the JArrowTopology and create N JWorker objects, each with thier own threads.
+///
+/// This will first call JTopology::run(size_t) to initialize the topology and
+/// prepare it for workers. It will then create `nthreads` JWorker objects and call
+/// their JWorker::start() methods causing them to create their own threads and
+/// start running their JWorker::loop() methods. This will return after the worker
+/// threads are launched.
+///
+/// @param [in] nthreads The number of worker threads to start
 void JArrowProcessingController::run(size_t nthreads) {
     LOG_INFO(m_logger) << "run(): Launching " << nthreads << " workers" << LOG_END;
     // topology->run needs to happen _before_ threads are started so that threads don't quit due to lack of assignments

--- a/src/libraries/JANA/Engine/JEventSourceArrow.cc
+++ b/src/libraries/JANA/Engine/JEventSourceArrow.cc
@@ -48,6 +48,10 @@ void JEventSourceArrow::execute(JArrowMetrics& result, size_t location_id) {
                 in_status = JEventSource::ReturnStatus::TryAgain;
                 break;
             }
+
+            // If there are no sources available then we are automatically finished.
+            if( m_sources.empty() ) in_status = JEventSource::ReturnStatus::Finished;
+            
             while (m_current_source < m_sources.size()) {
                 in_status = m_sources[m_current_source]->DoNext(event);
 

--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -144,6 +144,24 @@ void JApplication::Initialize() {
     m_initialized = true;
 }
 
+/// @brief Run the application, launching 1 or more threads to do the work.
+///
+/// This will initialize the application, attaching plugins etc. and launching
+/// threads to process events/time slices. This will then either return immediately
+/// (if wait_until_finish=false) or enter a lazy loop checking the progress
+/// of the data processing (if wait_until_finish=true).
+///
+/// In the `wait_until_finished` mode, this will run continuously until 
+/// the JProcessingController indicates it is finished or stopped or 
+/// some other condition exists that would cause it to end early. Under
+/// normal conditions, the data processing stops when polling JProcessingController::is_finished()
+/// indicates the JArrowTopology is in the `JArrowTopology::Status::Finished`
+/// state. This will occur when all event sources have been exhausted and
+/// all events have been processed such that all JWorkers have stopped.
+///
+/// See JProcessingController::run() for more details.
+///
+/// @param [in] wait_until_finished If true (default) do not return until the work has completed.
 void JApplication::Run(bool wait_until_finished) {
 
     Initialize();


### PR DESCRIPTION
This addresses issue #197 where the application would run indefinitely if no event sources are given to it rather than stop right away.