### PR TITLE
Custom topologies can now access components loaded from plugins

### DIFF
--- a/src/examples/BlockExample/main.cc
+++ b/src/examples/BlockExample/main.cc
@@ -11,35 +11,45 @@
 #include "BlockExampleSource.h"
 #include "BlockExampleProcessor.h"
 
+std::shared_ptr<JArrowTopology> configure_block_topology(std::shared_ptr<JArrowTopology> topology) {
+
+    auto source = new BlockExampleSource;
+    auto processor = new BlockExampleProcessor;
+
+    auto block_queue = new JMailbox<MyBlock*>;
+    auto event_queue = new JMailbox<std::shared_ptr<JEvent>>;
+
+    auto block_source_arrow = new JBlockSourceArrow<MyBlock>("block_source", source, block_queue);
+    auto block_disentangler_arrow = new JBlockDisentanglerArrow<MyBlock>("block_disentangler", source, block_queue, event_queue, topology->event_pool);
+    auto processor_arrow = new JEventProcessorArrow("processors", event_queue, nullptr, topology->event_pool);
+
+    processor_arrow->add_processor(processor);
+
+    topology->arrows.push_back(block_source_arrow);
+    topology->arrows.push_back(block_disentangler_arrow);
+    topology->arrows.push_back(processor_arrow);
+
+    topology->sources.push_back(block_source_arrow);
+    topology->sinks.push_back(processor_arrow);
+
+    block_source_arrow->attach(block_disentangler_arrow);
+    block_disentangler_arrow->attach(processor_arrow);
+
+    // If you want to add additional processors loaded from plugins, do this like so:
+    for (auto proc : topology->component_manager->get_evt_procs()) {
+        processor_arrow->add_processor(proc);
+    }
+
+    // If you want to add additional sources loaded from plugins, you'll also need to set up a JEventSourceArrow.
+    // Look at JTopologyBuilder::create_default_topology() for an example.
+
+    return topology;
+}
 
 int main() {
-
-	JApplication app;
-        auto topology = app.GetService<JTopologyBuilder>()->create_empty();
-
-        auto source = new BlockExampleSource;
-	auto processor = new BlockExampleProcessor;
-
-	auto block_queue = new JMailbox<MyBlock*>;
-	auto event_queue = new JMailbox<std::shared_ptr<JEvent>>;
-
-	auto block_source_arrow = new JBlockSourceArrow<MyBlock>("block_source", source, block_queue);
-	auto block_disentangler_arrow = new JBlockDisentanglerArrow<MyBlock>("block_disentangler", source, block_queue, event_queue, topology->event_pool);
-	auto processor_arrow = new JEventProcessorArrow("processors", event_queue, nullptr, topology->event_pool);
-
-	processor_arrow->add_processor(processor);
-
-	topology->arrows.push_back(block_source_arrow);
-	topology->arrows.push_back(block_disentangler_arrow);
-	topology->arrows.push_back(processor_arrow);
-
-	topology->sources.push_back(block_source_arrow);
-	topology->sinks.push_back(processor_arrow);
-
-        block_source_arrow->attach(block_disentangler_arrow);
-        block_disentangler_arrow->attach(processor_arrow);
-
-	app.SetParameterValue("log:trace", "JWorker");
-	app.Run(true);
+    JApplication app;
+    app.GetService<JTopologyBuilder>()->set_configure_fn(configure_block_topology);
+    app.SetParameterValue("log:trace", "JWorker");
+    app.Run(true);
 }
 


### PR DESCRIPTION
Briefly, what does this PR introduce?

This fixes a design problem where custom topologies weren't able to access components loaded from plugins, due to the fact that the custom topology needs to be created before JApplication::Initialize() gets called, which includes plugin loading. We add a new setter that accepts a lambda for configuring a topology after the plugins have loaded.

What kind of change does this PR introduce?

- [x] Bug fix (https://github.com/JeffersonLab/JANA4ML4FPGA/issues/19)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

Does this PR change default behavior?
No