### PR TITLE
Fixes to BlockExample

### DIFF
--- a/src/examples/BlockExample/BlockExampleProcessor.cc
+++ b/src/examples/BlockExample/BlockExampleProcessor.cc
@@ -16,14 +16,12 @@ void BlockExampleProcessor::Init() {
 }
 
 void BlockExampleProcessor::Process(const std::shared_ptr<const JEvent> &event) {
-    LOG << "BlockExampleProcessor::Process, Event #" << event->GetEventNumber() << LOG_END;
-    
+
     auto objs = event->Get<MyObject>();
     std::lock_guard<std::mutex>lock(m_mutex);
 
-	for (const MyObject* obj : objs) {
-        LOG << obj->datum << LOG_END;
-    }
+    LOG << "EventProcessor: event #" << event->GetEventNumber() << " containing " << objs[0]->datum << LOG_END;
+
 }
 
 void BlockExampleProcessor::Finish() {

--- a/src/examples/BlockExample/BlockExampleSource.h
+++ b/src/examples/BlockExample/BlockExampleSource.h
@@ -14,14 +14,14 @@
 class BlockExampleSource : public JBlockedEventSource<MyBlock> {
 
 	int m_block_number = 1;
-	JLogger m_logger;
+	JLogger m_logger {JLogger::Level::DEBUG};
 
 	virtual void Initialize() {
 		LOG_INFO(m_logger) <<  "Initializing JBlockedEventSource" << LOG_END;
 	}
 
 	virtual Status NextBlock(MyBlock& block) {
-		LOG_DEBUG(m_logger) <<  "JBlockedEventSource::NextBlock" << LOG_END;
+		LOG_DEBUG(m_logger) <<  "BlockSource: Emitting block " << m_block_number << LOG_END;
 
 		if (m_block_number >= 10) {
 			return Status::FailFinished;
@@ -36,21 +36,21 @@ class BlockExampleSource : public JBlockedEventSource<MyBlock> {
 
 	virtual std::vector<std::shared_ptr<JEvent>> DisentangleBlock(MyBlock& block, JEventPool& pool) {
 
-		LOG_DEBUG(m_logger) <<  "JBlockedEventSource::DisentangleBlock" << LOG_END;
+		LOG_DEBUG(m_logger) <<  "BlockDisentangler: Disentangling block " << block.block_number << LOG_END;
 		std::vector<std::shared_ptr<JEvent>> events;
 		bool result = pool.get_many(events, block.data.size());
 
 		if (result == false) {
 
-		    // TODO: Change this method signature so that we are automatically given the correct number of events
-		    //       instead of having to interact with the JEventPool ourselves.
+			// TODO: Change this method signature so that we are automatically given the correct number of events
+			//       instead of having to interact with the JEventPool ourselves.
 
-		    throw JException("Unable to obtain events from pool! Set jana:limit_events_in_flight=false");
+			throw JException("Unable to obtain events from pool! Set jana:limit_events_in_flight=false");
 		}
-		std::vector<std::shared_ptr<JEvent>> output_events;
 
 		size_t i = 0;
 		for (auto datum : block.data) {
+			LOG_DEBUG(m_logger) << "BlockDisentangler: extracted event containing " << datum << LOG_END;
 			events[i++]->Insert(new MyObject(datum));
 		}
 		return events;

--- a/src/examples/BlockExample/BlockExampleSource.h
+++ b/src/examples/BlockExample/BlockExampleSource.h
@@ -38,10 +38,20 @@ class BlockExampleSource : public JBlockedEventSource<MyBlock> {
 
 		LOG_DEBUG(m_logger) <<  "JBlockedEventSource::DisentangleBlock" << LOG_END;
 		std::vector<std::shared_ptr<JEvent>> events;
+		bool result = pool.get_many(events, block.data.size());
+
+		if (result == false) {
+
+		    // TODO: Change this method signature so that we are automatically given the correct number of events
+		    //       instead of having to interact with the JEventPool ourselves.
+
+		    throw JException("Unable to obtain events from pool! Set jana:limit_events_in_flight=false");
+		}
+		std::vector<std::shared_ptr<JEvent>> output_events;
+
+		size_t i = 0;
 		for (auto datum : block.data) {
-			auto event = pool.get(0);  // TODO: Make location be transparent to end user
-			event->Insert(new MyObject(datum));
-			events.push_back(event);
+			events[i++]->Insert(new MyObject(datum));
 		}
 		return events;
 	}

--- a/src/examples/BlockExample/main.cc
+++ b/src/examples/BlockExample/main.cc
@@ -48,6 +48,7 @@ std::shared_ptr<JArrowTopology> configure_block_topology(std::shared_ptr<JArrowT
 
 int main() {
     JApplication app;
+    app.SetParameterValue("jana:limit_total_events_in_flight", false);  // Otherwise we run out and segfault!!!
     app.GetService<JTopologyBuilder>()->set_configure_fn(configure_block_topology);
     app.SetParameterValue("log:trace", "JWorker");
     app.Run(true);

--- a/src/examples/BlockExample/main.cc
+++ b/src/examples/BlockExample/main.cc
@@ -19,6 +19,10 @@ std::shared_ptr<JArrowTopology> configure_block_topology(std::shared_ptr<JArrowT
     auto block_queue = new JMailbox<MyBlock*>;
     auto event_queue = new JMailbox<std::shared_ptr<JEvent>>;
 
+    // topology->queues.push_back(block_queue);
+    // FIXME: block_queue is a (very minor) memory leak
+    topology->queues.push_back(event_queue);
+
     auto block_source_arrow = new JBlockSourceArrow<MyBlock>("block_source", source, block_queue);
     auto block_disentangler_arrow = new JBlockDisentanglerArrow<MyBlock>("block_disentangler", source, block_queue, event_queue, topology->event_pool);
     auto processor_arrow = new JEventProcessorArrow("processors", event_queue, nullptr, topology->event_pool);
@@ -35,6 +39,10 @@ std::shared_ptr<JArrowTopology> configure_block_topology(std::shared_ptr<JArrowT
     block_source_arrow->attach(block_disentangler_arrow);
     block_disentangler_arrow->attach(processor_arrow);
 
+    block_source_arrow->set_running_arrows(&topology->running_arrow_count);
+    block_disentangler_arrow->set_running_arrows(&topology->running_arrow_count);
+    processor_arrow->set_running_arrows(&topology->running_arrow_count);
+
     // If you want to add additional processors loaded from plugins, do this like so:
     for (auto proc : topology->component_manager->get_evt_procs()) {
         processor_arrow->add_processor(proc);
@@ -47,10 +55,12 @@ std::shared_ptr<JArrowTopology> configure_block_topology(std::shared_ptr<JArrowT
 }
 
 int main() {
-    JApplication app;
+    // auto parms = new JParameterManager;
+    // parms->SetParameter("log:trace", "JWorker,JScheduler,JArrowProcessingController,JArrowTopology");
+    JApplication app; //(parms);
     app.SetParameterValue("jana:limit_total_events_in_flight", false);  // Otherwise we run out and segfault!!!
+    app.SetParameterValue("nthreads", 3); // So that we see some interesting ordering in our log
     app.GetService<JTopologyBuilder>()->set_configure_fn(configure_block_topology);
-    app.SetParameterValue("log:trace", "JWorker");
     app.Run(true);
 }
 


### PR DESCRIPTION
Briefly, what does this PR introduce?

BlockExample was broken in several important ways. 

- It wasn't terminating (issue #196). There was an obvious logic error (corrected in PR #206), but this masked a bigger problem where we changed our topology shutdown logic in an earlier release but didn't update BlockExample. The root cause of this is a lack of automated testing for BlockExample. Adding test cases for BlockedExample to our CI is a separate PR (#203) which ironically is held up by these very breakages.

- It sometimes segfaulted while retrieving events from the event pool (issue #207). This was due to the fact that this operation can fail when `jana:limit_total_events_in_flight=true`. The 'real' fix is to change the signature of JBlockedEventSource::DisentangleBlock, however, we shall hold off on this change for now until we coordinate with the JANA4ML4FPGA project. Until then, just remember to set `jana:limit_total_events_in_flight=false`. 

- The event pool only supported retrieving events one at a time, even when we knew a priori that we needed a block of 40 (issue #193). Because this operation locks a mutex each time, this is technically a performance bug. We rectify this by adding `JEventPool::get_many()` and `JEventPool::put_many`.
 