### PR TITLE
Add Fetch feature to janacontrol.

### DIFF
--- a/src/plugins/janacontrol/src/JControlEventProcessor.h
+++ b/src/plugins/janacontrol/src/JControlEventProcessor.h
@@ -5,9 +5,18 @@
 #define _JControlEventProcessor_h_
 
 #include <map>
+#include <set>
+#include <sstream>
 #include <JANA/JEventProcessor.h>
 #include <JANA/Services/JComponentManager.h>
 #include <JANA/Utils/JStringification.h>
+
+template <typename T>
+std::string ToString(const T &t){
+    std::stringstream ss;
+    ss << t;
+    return ss.str();
+}
 
 /// The JControlEventProcessor class is used by the janacontrol plugin, primarily
 /// to help with its debugging feature. It can be used to stall event processing
@@ -41,6 +50,13 @@ public:
     void Finish() override;
 
     void SetDebugMode(bool debug_mode);
+    bool GetDebugMode(void){return _debug_mode;}
+    void SetFetchFactories(std::set<std::string> &factorytags);
+    bool GetFetchFlag(void){return _fetch_flag;}
+    void FetchObjects(std::shared_ptr<const JEvent> jevent);
+    void FetchObjectsNow(void);
+    auto GetLastFetchResult(void){return _fetch_object_summaries;}
+    auto GetLastFetchMetadata(void){return _fetch_metadata;}
     void NextEvent(void);
     void GetObjectStatus( std::map<JFactorySummary, std::size_t> &factory_object_counts );
     void GetObjects(const std::string &factory_name, const std::string &factory_tag, const std::string &object_name, std::map<std::string, JObjectSummary> &objects);
@@ -50,6 +66,10 @@ public:
 protected:
     bool _debug_mode    = false;
     bool _wait          = true;
+    bool _fetch_flag    = false;
+    std::set<std::string> _fetch_factorytags;
+    std::map<std::string, std::string> _fetch_metadata;
+    std::map<std::string, std::map<std::string, JObjectSummary> > _fetch_object_summaries;
     std::shared_ptr<const JEvent> _jevent;
     std::shared_ptr<JStringification> jstringification;
 };

--- a/src/plugins/janacontrol/src/JControlZMQ.cc
+++ b/src/plugins/janacontrol/src/JControlZMQ.cc
@@ -53,12 +53,6 @@ using namespace std;
 //#define JSONADD(K) ss<<",\n\""<<K<<"\":"
 //#define JSONADS(K,V) ss<<",\n\""<<K<<"\":\""<<V<<"\""
 
-template <typename T>
-std::string ToString(const T &t){
-    stringstream ss;
-    ss << t;
-    return ss.str();
-}
 
 template<class T>
 void JSONADD(stringstream &ss, string K, T V, int indent_level=0, bool first_element=false){
@@ -282,10 +276,13 @@ void JControlZMQ::ServerLoop()
         }else if( vals[0] == "get_object_count" ){
             //------------------ get_object_count
             ss << GetJANAObjectListJSON();
-        }else if( vals[0] == "get_objects" ){
+        }else if( vals[0] == "get_objects" ){  // get objects from single factory iff debug_mode is currently true
             //------------------ get_objects
             std::string factory_tag = vals.size()>=4 ? vals[3]:"";
             ss << GetJANAObjectsJSON( vals[1], vals[2], factory_tag );
+        }else if( vals[0] == "fetch_objects" ){ // get objects from multiple factories regardless of debug_mode state
+            //------------------ fetch_objects
+            ss << FetchJANAObjectsJSON( vals );
         }else{
 		    //------------------ Unknown Command
 			ss << "{message:\"Bad Command: " << vals[0] << "\"}";
@@ -677,6 +674,8 @@ std::string JControlZMQ::GetJANAObjectListJSON(){
 //---------------------------------
 std::string JControlZMQ::GetJANAObjectsJSON(const std::string &object_name, const std::string &factory_name, const std::string &factory_tag){
     /// Get the object contents (if possible) for the specified factory.
+    /// If this is called while not in debug_mode then it will return
+    /// no objects.
 
     // Get map of objects where key is address as hex string
     std::map<std::string, JObjectSummary> objects;
@@ -701,3 +700,65 @@ std::string JControlZMQ::GetJANAObjectsJSON(const std::string &object_name, cons
 //    cout << json << std::endl;
     return json;
 }
+
+//---------------------------------
+// FetchJANAObjectsJSON
+//---------------------------------
+std::string JControlZMQ::FetchJANAObjectsJSON(std::vector<std::string> &vals){
+    /// Fetch multiple objects from the next event to be processed or
+    /// from the current event if debug_mode is currently true.
+    /// This is intended to be used in a situation where the event processing
+    /// should be allowed to continue basically uninhibited and one simply
+    /// wants to spectate occasional events. E.g. a remote event monitor.
+    ///
+    /// Upon entry, vals will contain the full command which should look like
+    ///
+    ///   "fetch_objects" "factory:tag1" "factory:tag2" ...
+    ///
+    /// where "factory:tag" is the combined factory + tag string.
+
+    std::set<std::string> factorytags;
+    for( size_t i=1; i<vals.size(); i++ ) factorytags.insert( vals[i] );
+    _jproc->SetFetchFactories( factorytags ); // this automatically sets the fetch flag
+
+    // If we are in debug_mode then fetch the objects immediately for the 
+    // current event. Note that FetchObjectsNow will clear the fetch_flag
+    // so the wait loop below will exit immediately on the first iteration.
+    if( _jproc->GetDebugMode() ) _jproc->FetchObjectsNow();
+    
+    // Build map of values to create JSON record of. Add some redundant
+    // info so there is the option of verifying the exact origin of this
+    // by the consumer.
+    std::unordered_map<std::string, std::string> mvals;
+    mvals["program"] = "JANAcp";
+    mvals["host"] = _host;
+    mvals["PID"] = ToString(_pid);
+    
+    // Wait up to 3 seconds for the fetch to finish.
+    for(int i=0; i<1000; i++){
+        if( !_jproc->GetFetchFlag() ) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(3));
+    }
+
+    // run_number and event_number are recorded when the data is fetched
+    // from the event into the metadata. Append all FetchMetadata to
+    // record.
+    auto metadata = _jproc->GetLastFetchMetadata();
+    mvals.insert(metadata.begin(), metadata.end() );
+    
+     // Get the results of the fetch operation
+    auto results = _jproc->GetLastFetchResult();
+
+    // Convert all object summaries into JSON strings
+    std::unordered_map<std::string, std::string> mobjvals;
+    for( auto& [factorytag, objects] : results ){
+        mobjvals[factorytag] = JJSON_Create(objects, 3); // Create JSON of objects
+    }
+    mvals["objects"] = JJSON_Create(mobjvals);
+
+    // Create JSON string
+    std::string json = JJSON_Create(mvals);
+    return json;
+}
+
+

--- a/src/plugins/janacontrol/src/JControlZMQ.h
+++ b/src/plugins/janacontrol/src/JControlZMQ.h
@@ -28,6 +28,7 @@ public:
     std::string GetJANAFactoryListJSON();
     std::string GetJANAObjectListJSON();
     std::string GetJANAObjectsJSON(const std::string &object_name, const std::string &factory_name, const std::string &factory_tag);
+    std::string FetchJANAObjectsJSON(std::vector<std::string> &vals);
 
 private:
 


### PR DESCRIPTION
This adds a "Fetch" feature to the `janacontrol` plugin. This can be used to grab objects from a list of factories, guaranteeing that  they are from the same event, but without stopping event processing. This is motivated by an application in the TriDAS testing where JANA plugins are attached to a TriDAS process that needs to continuously process events. Monitoring the stream (e.g. with a single event viewer) is only possible if the stream is allowed to continuously flow uninhibited.

This PR includes changes only to the `janacontrol` plugin which itself is only built if USE_ZEROMQ=1 is set for the JANA build. Thus, most current users will be unaffected by this. Code does not currently exist to send the "fetch_objects" command or consume its results so this is largely untested at this point. Work on the consumer part may not happen for a while so this locks in work on the producer side in preparation for that and to ensure this work is not lost.
