### PR TITLE
Fix compiler warnings about sprintf

### DIFF
--- a/src/libraries/JANA/Calibrations/JCalibration.cc
+++ b/src/libraries/JANA/Calibrations/JCalibration.cc
@@ -216,7 +216,7 @@ void JCalibration::DumpCalibrationsToFiles(string basedir)
     // Create base directory for writing calibrations into
     mode_t mode=S_IRWXU | S_IRWXG | S_IRWXO;
     char str[256];
-    sprintf(str, "calib%d/", GetRun());
+    snprintf(str, 256, "calib%d/", GetRun());
     basedir += string(str);
     mkdir(basedir.c_str(), mode);
 

--- a/src/libraries/JANA/Calibrations/JLargeCalibration.cc
+++ b/src/libraries/JANA/Calibrations/JLargeCalibration.cc
@@ -554,8 +554,12 @@ string JLargeCalibration::Get_MD5(string fullpath) {
     md5_byte_t digest[16];
     md5_finish(&pms, digest);
 
-    char hex_output[16 * 2 + 1];
-    for (int di = 0; di < 16; ++di) sprintf(hex_output + di * 2, "%02x", digest[di]);
+    const size_t str_len = 16 * 2 + 1;
+    char hex_output[str_len];
+    for (int di = 0; di < 16; ++di){
+        size_t buff_left = str_len -  di * 2;
+        snprintf(hex_output + di * 2, buff_left, "%02x", digest[di]);
+    }
 
     return string(hex_output);
 }

--- a/src/libraries/JANA/Compatibility/JGeometryXML.cc
+++ b/src/libraries/JANA/Compatibility/JGeometryXML.cc
@@ -1113,8 +1113,12 @@ std::string JGeometryXML::EntityResolver::GetMD5_checksum(void)
     md5_byte_t digest[16];
     md5_finish(&pms, digest);
 
-    char hex_output[16*2 + 1];
-    for(int di = 0; di < 16; ++di) sprintf(hex_output + di * 2, "%02x", digest[di]);
+    const size_t str_len = 16*2 + 1;
+    char hex_output[str_len];
+    for(int di = 0; di < 16; ++di) {
+        size_t buff_left = str_len - di * 2;
+        snprintf(hex_output + di * 2, buff_left, "%02x", digest[di]);
+    }
 
     return hex_output;
 }

--- a/src/libraries/JANA/Compatibility/JGeometryXML.h
+++ b/src/libraries/JANA/Compatibility/JGeometryXML.h
@@ -145,14 +145,14 @@ class JGeometryXML:public JGeometry{
                  //  Constructors and Destructor
                  ErrorHandler(){}
                  ~ErrorHandler(){}
-                 bool handleError(const xercesc::DOMError& domError){jerr<<"Got Error!!"<<std::endl; return false;}
+                 bool handleError(const xercesc::DOMError& /*domError*/){jerr<<"Got Error!!"<<std::endl; return false;}
              void resetErrors(){}
       
             // Purely virtual methods
 #if XERCES3
-      void warning(const xercesc::SAXParseException& exc){}
-      void error(const xercesc::SAXParseException& exc){}
-      void fatalError(const xercesc::SAXParseException& exc){}
+      void warning(const xercesc::SAXParseException& /*exc*/){}
+      void error(const xercesc::SAXParseException& /*exc*/){}
+      void fatalError(const xercesc::SAXParseException& /*exc*/){}
 #endif  // XERCES3
 
             private :

--- a/src/libraries/JANA/Utils/JTypeInfo.h
+++ b/src/libraries/JANA/Utils/JTypeInfo.h
@@ -92,7 +92,7 @@ inline std::string to_string_with_si_prefix(float val) {
         units = "m";
     }
     char str[256];
-    sprintf(str, "%3.1f %s", val, units);
+    snprintf(str, 256, "%3.1f %s", val, units);
     return std::string(str);
 }
 

--- a/src/plugins/JTestRoot/JTestRootProcessor.cc
+++ b/src/plugins/JTestRoot/JTestRootProcessor.cc
@@ -26,7 +26,7 @@ void JTestRootProcessor::Process(const std::shared_ptr<const JEvent> &event) {
     std::lock_guard<std::mutex>lock(m_mutex);
 
     // At this point we can do something with the Cluster objects
-    for (auto cluster : clusters) {
-         //Use cluster object (e.g. fill histogram or write object to output file)
-    }
+    // for (auto cluster : clusters) {
+    //      //Use cluster object (e.g. fill histogram or write object to output file)
+    // }
 }

--- a/src/plugins/janacontrol/src/JControlZMQ.cc
+++ b/src/plugins/janacontrol/src/JControlZMQ.cc
@@ -144,7 +144,7 @@ void JControlZMQ::ServerLoop()
 
     // Bind to port number specified in constructor. Most likely this came from JANA_ZMQ_PORT config. parameter
     char bind_str[256];
-	sprintf( bind_str, "tcp://*:%d", _port );
+	snprintf( bind_str, 256, "tcp://*:%d", _port );
 	void *responder = zmq_socket( _zmq_context, ZMQ_REP );
 	auto ret = zmq_bind( responder, bind_str);
 	if( ret != 0 ){

--- a/src/plugins/janacontrol/src/JControlZMQ.cc
+++ b/src/plugins/janacontrol/src/JControlZMQ.cc
@@ -354,7 +354,7 @@ void JControlZMQ::HostStatusPROC(std::map<std::string,float> &vals)
 //---------------------------------
 // HostStatusPROCLinux
 //---------------------------------
-void JControlZMQ::HostStatusPROCLinux(std::map<std::string,float> &vals)
+void JControlZMQ::HostStatusPROCLinux(std::map<std::string,float> & /*vals*/ )
 {
 #ifdef __linux__
     /// Get host info using the /proc mechanism on Linux machines.

--- a/src/plugins/janacontrol/src/JControlZMQ.cc
+++ b/src/plugins/janacontrol/src/JControlZMQ.cc
@@ -354,7 +354,7 @@ void JControlZMQ::HostStatusPROC(std::map<std::string,float> &vals)
 //---------------------------------
 // HostStatusPROCLinux
 //---------------------------------
-void JControlZMQ::HostStatusPROCLinux(std::map<std::string,float> & /*vals*/ )
+void JControlZMQ::HostStatusPROCLinux(std::map<std::string,float> & vals )
 {
 #ifdef __linux__
     /// Get host info using the /proc mechanism on Linux machines.
@@ -451,6 +451,8 @@ void JControlZMQ::HostStatusPROCLinux(std::map<std::string,float> & /*vals*/ )
     getrusage(RUSAGE_SELF, &usage);
     double mem_usage = (double)(usage.ru_maxrss)/1024.0; // convert to MB
     vals["ram_used_this_proc_GB"] = (double)mem_usage*1.0E-3;
+#else
+    _DBG_<<"Calling HostStatusPROCLinux on non-Linux machine. " << vals.size() << std::endl; // vals.size() is just to prevent compiler warning
 #endif // __linux__
 }
 

--- a/src/plugins/janadot/JEventProcessorJANADOT.cc
+++ b/src/plugins/janadot/JEventProcessorJANADOT.cc
@@ -237,7 +237,7 @@ void JEventProcessorJANADOT::Finish()
 		double my_ms = stats.from_factory_ms + stats.from_source_ms + stats.from_cache_ms;
 		double percent = 100.0*my_ms/total_ms;
 		char percentstr[32];
-		sprintf(percentstr, "%5.1f%%", percent);
+		snprintf(percentstr, 32, "%5.1f%%", percent);
 		
 		string timestr=MakeTimeString(stats.from_factory_ms);
 		
@@ -299,7 +299,7 @@ void JEventProcessorJANADOT::Finish()
 
 		double percent = 100.0*time_spent_in_factory/total_ms;
 		char percentstr[32];
-		sprintf(percentstr, "%5.1f%%", percent);
+		snprintf(percentstr, 32, "%5.1f%%", percent);
 		
 		string fillcolor;
 		string shape;

--- a/src/plugins/janaview/JEventProcessor_janaview.cc
+++ b/src/plugins/janaview/JEventProcessor_janaview.cc
@@ -55,7 +55,7 @@ bool FactoryNameSort(JFactory *a,JFactory *b){
 // C-callable routine that can be used with pthread_create to launch
 // a thread that creates the ROOT GUI and handles all ROOT GUI interactions
 //-------------------
-void* JanaViewRootGUIThread(void *arg)
+void* JanaViewRootGUIThread(void */*arg*/)
 {
 //	JEventProcessor_janaview *jproc = (JEventProcessor_janaview*)arg;
 
@@ -134,8 +134,8 @@ void JEventProcessor_janaview::Process(const std::shared_ptr<const JEvent>& even
 
 	// static bool processed_first_event = false;
 
-	this->loop = loop;
-	this->eventnumber = eventnumber;
+	this->loop = event;
+	this->eventnumber = event->GetEventNumber();
 	
 	JEventSource *source = event->GetJEventSource();
 	JVMF->UpdateInfo(source->GetResourceName(), event->GetRunNumber(), event->GetEventNumber());
@@ -278,7 +278,7 @@ void JEventProcessor_janaview::MakeCallGraph(string nametag)
 	// of their callees
 	do{
 		bool nothing_changed = true;
-		map<string, CGobj*>::iterator iter = cgobjs.begin();
+		// map<string, CGobj*>::iterator iter = cgobjs.begin();
 
 		for(auto p : cgobjs){	
 			CGobj *caller_obj = p.second;

--- a/src/plugins/janaview/jv_mainframe.cc
+++ b/src/plugins/janaview/jv_mainframe.cc
@@ -209,7 +209,7 @@ void jv_mainframe::DoSelectObjectType(Int_t id)
 	lbObjects->RemoveAll();
 	for(uint32_t i=0; i<vobjs.size(); i++){
 		char str[256];
-		sprintf(str, "0x%016lx %s", (unsigned long)vobjs[i], ((JObject*)vobjs[i])->className().c_str());
+		snprintf(str, 256, "0x%016lx %s", (unsigned long)vobjs[i], ((JObject*)vobjs[i])->className().c_str());
 		lbObjects->AddEntry(str, i+1);
 	}
 	
@@ -242,7 +242,7 @@ void jv_mainframe::DoSelectObject(Int_t id)
 	obj->GetT(aobjs);
 	for(uint32_t i=0; i<aobjs.size(); i++){
 		char str[256];
-		sprintf(str, "0x%016lx %s", (unsigned long)aobjs[i], aobjs[i]->className().c_str());
+		snprintf(str, 256, "0x%016lx %s", (unsigned long)aobjs[i], aobjs[i]->className().c_str());
 		lbAssociatedObjects->AddEntry(str, i+1);
 	}
 	Redraw(lbAssociatedObjects);
@@ -252,7 +252,7 @@ void jv_mainframe::DoSelectObject(Int_t id)
 	JEP->GetAssociatedTo(obj, a2objs);
 	for(uint32_t i=0; i<a2objs.size(); i++){
 		char str[256];
-		sprintf(str, "0x%016lx %s", (unsigned long)a2objs[i], a2objs[i]->className().c_str());
+		snprintf(str, 256, "0x%016lx %s", (unsigned long)a2objs[i], a2objs[i]->className().c_str());
 		lbAssociatedToObjects->AddEntry(str, i+1);
 	}
 	Redraw(lbAssociatedToObjects);
@@ -387,9 +387,9 @@ void jv_mainframe::UpdateInfo(string source, int run, int event)
 	lSource->SetText(source.c_str());
 
 	char str[256];
-	sprintf(str, "%d     ", run);
+	snprintf(str, 256, "%d     ", run);
 	lRun->SetText(str);
-	sprintf(str, "%d            ", event);
+	snprintf(str, 256, "%d            ", event);
 	lEvent->SetText(str);
 	
 	Redraw(lSource);
@@ -439,7 +439,7 @@ void jv_mainframe::UpdateObjectTypeList(vector<JVFactoryInfo> &facinfo)
 void jv_mainframe::UpdateObjectValues(JObject *obj)
 {
 	char title[256];
-	sprintf(title, "0x%016lx : %s", (unsigned long)obj, obj->className().c_str());
+	snprintf(title, 256, "0x%016lx : %s", (unsigned long)obj, obj->className().c_str());
 	lObjectValue->SetTitle(title);
 	lObjectValue->Resize();
 

--- a/src/plugins/janaview/jv_mainframe.cc
+++ b/src/plugins/janaview/jv_mainframe.cc
@@ -13,7 +13,7 @@
 //---------------------------------
 // jv_mainframe    (Constructor)
 //---------------------------------
-jv_mainframe::jv_mainframe(const TGWindow *p, UInt_t w, UInt_t h,  bool build_gui):TGMainFrame(p,w,h, kMainFrame | kVerticalFrame)
+jv_mainframe::jv_mainframe(const TGWindow *p, UInt_t w, UInt_t h,  bool /*build_gui*/):TGMainFrame(p,w,h, kMainFrame | kVerticalFrame)
 {
 	CreateGUI();
 	
@@ -313,7 +313,7 @@ void jv_mainframe::DoDoubleClickAssociatedToObject(Int_t id)
 //-------------------
 // DoCallGraphClicked
 //-------------------
-void jv_mainframe::DoCallGraphClicked(Int_t event, Int_t x, Int_t y, TObject *selected)
+void jv_mainframe::DoCallGraphClicked(Int_t event, Int_t x, Int_t y, TObject */*selected*/)
 {
 	if( event != kButton1Up ) return;
 	
@@ -544,7 +544,7 @@ TGLabel* jv_mainframe::AddLabel(TGCompositeFrame* frame, string text, Int_t mode
 //-------------------
 // AddNamedLabel
 //-------------------
-TGLabel* jv_mainframe::AddNamedLabel(TGCompositeFrame* frame, string title, Int_t mode, ULong_t hints)
+TGLabel* jv_mainframe::AddNamedLabel(TGCompositeFrame* frame, string title, Int_t mode, ULong_t /*hints*/)
 {
 	TGHorizontalFrame *f = new TGHorizontalFrame(frame);
 	AddLabel(f, title, kTextRight);

--- a/src/plugins/streamDet/INDRAMessage.h
+++ b/src/plugins/streamDet/INDRAMessage.h
@@ -107,7 +107,7 @@ public:
 
     void set_end_of_stream() { as_indra_message()->flags = 1; }
     void set_event_number(size_t event_number) { as_indra_message()->record_counter = event_number; }
-    static void set_run_number(size_t run_number) { ; }
+    static void set_run_number(size_t /* run_number */) { ; }
 
     ////////////////////////////////////////////////////////////////////////////////////////
     /// Everything in this section is used by user-defined JFactories and JEventProcessors to access
@@ -179,6 +179,7 @@ inline std::ostream& operator<< (std::ostream& os, const DASEventMessage& messag
     std::string subSocket = message.get_sub_socket();
     ss << "INDRA Message received on " << subSocket
        << " -> Event " << eventNum
+       << ", mess. freq. = " << msgFreq
        << ", buffer size = " << buffSize
        << ", payload = ";
     for (int i = 0; i < 10 && i < (int) length; ++i) {

--- a/src/python/common/JEventProcessorPY.h
+++ b/src/python/common/JEventProcessorPY.h
@@ -135,7 +135,7 @@ class JEventProcessorPY {
             // nullptr so that it does not hold on the the JEvent after we return
             // from this method. We use this trick to ensure it happens even if an
             // exception is thrown from pymProcess().
-            std::shared_ptr<int> mEvent_free(nullptr, [=](int *ptr){ mEvent = nullptr;});
+            std::shared_ptr<int> mEvent_free(nullptr, [=](int */*ptr*/){ mEvent = nullptr;});
             mEvent = aEvent; // remember this JEvent so it can be used in calls to Get()
 
             pymProcess();

--- a/src/python/plugins/janapy/janapy_plugin.cc
+++ b/src/python/plugins/janapy/janapy_plugin.cc
@@ -38,7 +38,7 @@ void InitPlugin(JApplication *app){
     while( !PY_INITIALIZED ) std::this_thread::sleep_for (std::chrono::milliseconds(100));
 }
 
-void FinalizePlugin(JApplication *app){
+void FinalizePlugin(JApplication */*app*/){
     // Finalize the python interpreter
     if( PY_INITIALIZED ) {
         // Wait upt to 2 seconds for interpreter to not be in use before finalizing it.


### PR DESCRIPTION
On macos with Apple clang 14.0.0, there were warnings about sprintf being deprecated as unsafe with a suggestion to replace it with snprintf. This makes those substitutions.

This also includes several other non-substantive changes to address compiler warnings. Primarily unused parameters.

This now builds clean of warnings on macos with Apple clang14.0.0 when using:

CMAKE_CXX_STANDARD=17
USE_ROOT=1
USE_PYTHON=1
USE_ZEROMQ=1
USE_XERCES=1

CMAKE_CXX_STANDARD=20
USE_PYTHON=1
USE_ZEROMQ=1
USE_XERCES=1

I was unable to test with c++20 and ROOT since root 6.28.00 failed to build with c++20.

In both cases above, `janatests` ran successfully