### PR TITLE
JEventSource returns status code instead of throwing exception

### DIFF
--- a/src/examples/DstExample/DstExample.cc
+++ b/src/examples/DstExample/DstExample.cc
@@ -17,7 +17,7 @@ void InitPlugin(JApplication* app) {
 
     LOG << "Loading DstExample" << LOG_END;
     app->Add(new DstExampleProcessor);
-    app->Add(new DstExampleSource("dummy", app));
+    app->Add(new DstExampleSource);
     app->Add(new JFactoryGeneratorT<DstExampleFactory>());
 }
 }

--- a/src/examples/DstExample/DstExampleSource.h
+++ b/src/examples/DstExample/DstExampleSource.h
@@ -15,13 +15,17 @@ class DstExampleSource : public JEventSource {
     /// Add member variables here
 
 public:
+    DstExampleSource();
+
     DstExampleSource(std::string resource_name, JApplication* app);
 
     virtual ~DstExampleSource() = default;
 
     void Open() override;
 
-    void GetEvent(std::shared_ptr<JEvent>) override;
+    void Close() override;
+
+    Result Emit(JEvent&) override;
     
     static std::string GetDescription();
 

--- a/src/examples/EventGroupExample/BlockingGroupedEventSource.h
+++ b/src/examples/EventGroupExample/BlockingGroupedEventSource.h
@@ -26,6 +26,7 @@ public:
 
     BlockingGroupedEventSource(std::string res_name, JApplication* app) : JEventSource(std::move(res_name), app) {
         // TODO: Get EventGroupManager from ServiceLocator instead
+        SetCallbackStyle(CallbackStyle::ExpertMode);
         m_pending_group_id = 1;
     };
 
@@ -49,13 +50,13 @@ public:
     /// GetEvent polls the queue of submitted TridasEvents and feeds them into JEvents along with a
     /// JEventGroup. A downstream EventProcessor may report the event as being finished. Once all
     /// events in the eventgroup are finished, the corresponding call to SubmitAndWait will unblock.
-    void GetEvent(std::shared_ptr<JEvent> event) override {
+    Result Emit(JEvent& event) override {
 
         std::pair<TridasEvent*, JEventGroup*> next_event;
         {
             std::lock_guard<std::mutex> lock(m_pending_mutex);
             if (m_pending_events.empty()) {
-                throw RETURN_STATUS::kTRY_AGAIN;
+                return Result::FailureTryAgain;
             }
             else {
                 next_event = m_pending_events.front();
@@ -64,16 +65,18 @@ public:
         }
 
         // Hydrate JEvent with both the TridasEvent and the group pointer.
-        event->Insert(next_event.first);  // TridasEvent
-        event->Insert(next_event.second); // JEventGroup
+        event.Insert(next_event.first);  // TridasEvent
+        event.Insert(next_event.second); // JEventGroup
 
         // Tell JANA not to assume ownership of these objects!
-        event->GetFactory<TridasEvent>()->SetFactoryFlag(JFactory::JFactory_Flags_t::NOT_OBJECT_OWNER);
-        event->GetFactory<JEventGroup>()->SetFactoryFlag(JFactory::JFactory_Flags_t::NOT_OBJECT_OWNER);
+        event.GetFactory<TridasEvent>()->SetFactoryFlag(JFactory::JFactory_Flags_t::NOT_OBJECT_OWNER);
+        event.GetFactory<JEventGroup>()->SetFactoryFlag(JFactory::JFactory_Flags_t::NOT_OBJECT_OWNER);
 
         // JANA always needs an event number and a run number, so extract these from the Tridas data somehow
-        event->SetEventNumber(next_event.first->event_number);
-        event->SetRunNumber(next_event.first->run_number);
+        event.SetEventNumber(next_event.first->event_number);
+        event.SetRunNumber(next_event.first->run_number);
+
+        return Result::Success;
     }
 };
 

--- a/src/examples/MetadataExample/RandomTrackSource.h
+++ b/src/examples/MetadataExample/RandomTrackSource.h
@@ -23,7 +23,7 @@ public:
 
     void Open() override;
 
-    void GetEvent(std::shared_ptr<JEvent>) override;
+    Result Emit(JEvent&) override;
     
     static std::string GetDescription();
 

--- a/src/examples/SubeventCUDAExample/SubeventCUDAExample.cu
+++ b/src/examples/SubeventCUDAExample/SubeventCUDAExample.cu
@@ -77,19 +77,21 @@ struct MyProcessor : public JSubeventProcessor<MyInput, MyOutput> {
 
 
 struct SimpleSource : public JEventSource {
-    SimpleSource(std::string name) : JEventSource(name) {};
+    SimpleSource() {
+        SetCallbackStyle(CallbackStyle::ExpertMode); 
+    };
 
-    void GetEvent(std::shared_ptr <JEvent> event) override {
-        auto evt = event->GetEventNumber();
+    Result Emit(JEvent& event) override {
+        auto evt = event.GetEventNumber();
         std::vector < MyInput * > inputs;
         inputs.push_back(new MyInput(22, 3.6, evt, 0));
         inputs.push_back(new MyInput(23, 3.5, evt, 1));
         inputs.push_back(new MyInput(24, 3.4, evt, 2));
         inputs.push_back(new MyInput(25, 3.3, evt, 3));
         inputs.push_back(new MyInput(26, 3.2, evt, 4));
-        event->Insert(inputs);
+        event.Insert(inputs);
         LOG << "Emitting event " << event->GetEventNumber() << LOG_END;
-        // throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
+        return Result::Success;
     }
 };
 

--- a/src/examples/SubeventExample/SubeventExample.cc
+++ b/src/examples/SubeventExample/SubeventExample.cc
@@ -39,18 +39,20 @@ struct MyProcessor : public JSubeventProcessor<MyInput, MyOutput> {
 
 
 struct SimpleSource : public JEventSource {
-    SimpleSource(std::string name) : JEventSource(name) {};
-    void GetEvent(std::shared_ptr<JEvent> event) override {
-        auto evt = event->GetEventNumber();
+    SimpleSource() : JEventSource() { 
+        SetCallbackStyle(CallbackStyle::ExpertMode); 
+    };
+    Result Emit(JEvent& event) override {
+        auto evt = event.GetEventNumber();
         std::vector<MyInput*> inputs;
         inputs.push_back(new MyInput(22,3.6,evt,0));
         inputs.push_back(new MyInput(23,3.5,evt,1));
         inputs.push_back(new MyInput(24,3.4,evt,2));
         inputs.push_back(new MyInput(25,3.3,evt,3));
         inputs.push_back(new MyInput(26,3.2,evt,4));
-        event->Insert(inputs);
-        LOG << "Emitting event " << event->GetEventNumber() << LOG_END;
-        // throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
+        event.Insert(inputs);
+        LOG << "Emitting event " << event.GetEventNumber() << LOG_END;
+        return Result::Success;
     }
 };
 
@@ -93,7 +95,7 @@ int main() {
     app.SetTimeoutEnabled(false);
     app.SetTicker(false);
 
-    auto source = new SimpleSource("simpleSource");
+    auto source = new SimpleSource();
     source->SetNEvents(10);  // limit ourselves to 10 events. Note that the 'jana:nevents' param won't work
                              // here because we aren't using JComponentManager to manage the EventSource
 

--- a/src/examples/TimesliceExample/MyFileReader.h
+++ b/src/examples/TimesliceExample/MyFileReader.h
@@ -14,13 +14,16 @@ struct MyFileReader : public JEventSource {
 
     MyFileReader() {
         SetTypeName(NAME_OF_THIS);
+        SetCallbackStyle(CallbackStyle::ExpertMode);
     }
 
     void Open() override { }
 
-    void GetEvent(std::shared_ptr<JEvent> event) override {
+    void Close() override { }
 
-        auto event_nr = event->GetEventNumber();
+    Result Emit(JEvent&) override {
+
+        auto event_nr = event.GetEventNumber();
 
         auto hits_out  = std::make_unique<ExampleHitCollection>();
 
@@ -29,7 +32,7 @@ struct MyFileReader : public JEventSource {
         hits_out->push_back(ExampleHit(event_nr, 0, 49, 49, 49, 1));
         hits_out->push_back(ExampleHit(event_nr, 0, 7.6, 7.6, 7.6, 2));
 
-        LOG_DEBUG(GetLogger()) << "MySource: Emitted " << GetLevel() << " " << event->GetEventNumber() << "\n"
+        LOG_DEBUG(GetLogger()) << "MySource: Emitted " << GetLevel() << " " << event.GetEventNumber() << "\n"
             << TabulateHits(hits_out.get())
             << LOG_END;
 
@@ -39,12 +42,13 @@ struct MyFileReader : public JEventSource {
         if (GetLevel() == JEventLevel::Timeslice) {
             TimesliceInfoCollection info;
             info.push_back(TimesliceInfo(event_nr, 0)); // event nr, run nr
-            event->InsertCollection<TimesliceInfo>(std::move(info), "ts_info");
+            event.InsertCollection<TimesliceInfo>(std::move(info), "ts_info");
         }
         else {
             EventInfoCollection info;
             info.push_back(EventInfo(event_nr, 0, 0)); // event nr, timeslice nr, run nr
-            event->InsertCollection<EventInfo>(std::move(info), "evt_info");
+            event.InsertCollection<EventInfo>(std::move(info), "evt_info");
         }
+        return Result::Success;
     }
 };

--- a/src/examples/Tutorial/RandomSource.h
+++ b/src/examples/Tutorial/RandomSource.h
@@ -14,13 +14,17 @@ class RandomSource : public JEventSource {
     int m_max_emit_freq_hz = 100;
 
 public:
+    RandomSource();
+
     RandomSource(std::string resource_name, JApplication* app);
 
     virtual ~RandomSource() = default;
 
     void Open() override;
 
-    void GetEvent(std::shared_ptr<JEvent>) override;
+    Result Emit(JEvent&) override;
+
+    void Close() override;
     
     static std::string GetDescription();
 

--- a/src/libraries/JANA/Engine/JEventSourceArrow.cc
+++ b/src/libraries/JANA/Engine/JEventSourceArrow.cc
@@ -32,11 +32,11 @@ void JEventSourceArrow::process(Event* event, bool& success, JArrowMetrics::Stat
 
         auto source_status = m_sources[m_current_source]->DoNext(*event);
 
-        if (source_status == JEventSource::ReturnStatus::Finished) {
+        if (source_status == JEventSource::Result::FailureFinished) {
             m_current_source++;
             // TODO: Adjust nskip and nevents for the new source
         }
-        else if (source_status == JEventSource::ReturnStatus::TryAgain){
+        else if (source_status == JEventSource::Result::FailureTryAgain){
             // This JEventSource isn't finished yet, so we obtained either Success or TryAgainLater
             success = false;
             arrow_status = JArrowMetrics::Status::ComeBackLater;

--- a/src/libraries/JANA/JEventProcessor.h
+++ b/src/libraries/JANA/JEventProcessor.h
@@ -71,7 +71,7 @@ public:
         // Also we don't have 
         // a Preprocess(), so we don't technically need Init() here even
         
-        if (m_callback_style != CallbackStyle::Declarative) {
+        if (m_callback_style != CallbackStyle::DeclarativeMode) {
             DoReduce(e); // This does all the locking!
         }
     }
@@ -101,7 +101,7 @@ public:
             for (auto* input : m_inputs) {
                 input->GetCollection(*e);
             }
-            if (m_callback_style == CallbackStyle::Declarative) {
+            if (m_callback_style == CallbackStyle::DeclarativeMode) {
                 Process(e->GetRunNumber(), e->GetEventNumber(), e->GetEventIndex());
             }
             else {

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -246,13 +246,13 @@ public:
                 event->GetJCallGraphRecorder()->SetInsertDataOrigin( previous_origin );
 
                 if (result == Result::Success) {
+                    m_event_count += 1; 
                     // We end up here if we read an entry in our file or retrieved a message from our socket,
                     // and believe we could obtain another one immediately if we wanted to
                     for (auto* output : m_outputs) {
                         output->InsertCollection(*event);
                     }
-                    m_event_count += 1; 
-                    if (m_event_count < first_evt_nr) {
+                    if (m_event_count <= first_evt_nr) {
                         // We immediately throw away this whole event because of nskip 
                         // (although really we should be handling this with Seek())
                         return Result::FailureTryAgain;

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -54,7 +54,7 @@ public:
     virtual void Open() {}
 
 
-    // `Emit` is called by JANA in order to emit a fresh event into the stream, when using CallbackStyle::Classic. 
+    // `Emit` is called by JANA in order to emit a fresh event into the stream, when using CallbackStyle::ExpertMode. 
     // It is very similar to GetEvent(), except the user returns a Result status code instead of throwing an exception.
     // Exceptions are reserved for unrecoverable errors. It accepts an out parameter JEvent. If there is another 
     // entry in the file, or another message waiting at the socket, the user reads the data into the JEvent and returns
@@ -214,7 +214,7 @@ public:
 
         std::lock_guard<std::mutex> lock(m_mutex); // In general, DoNext must be synchronized.
         
-        if (m_callback_style == CallbackStyle::Compatibility) {
+        if (m_callback_style == CallbackStyle::LegacyMode) {
             return DoNextCompatibility(event);
         }
 

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -21,6 +21,8 @@ class JFactory;
 class JEventSource : public jana::omni::JComponent, public jana::omni::JHasOutputs {
 
 public:
+    
+    enum class Result { Success, FailureTryAgain, FailureFinished };
 
     /// ReturnStatus describes what happened the last time a GetEvent() was attempted.
     /// If GetEvent() reaches an error state, it should throw a JException instead.
@@ -54,6 +56,17 @@ public:
     virtual void Open() {}
 
 
+    // `Emit` is called by JANA in order to emit a fresh event into the stream, when using CallbackStyle::Classic. 
+    // It is very similar to GetEvent(), except the user returns a Result status code instead of throwing an exception.
+    // Exceptions are reserved for unrecoverable errors. It accepts an out parameter JEvent. If there is another 
+    // entry in the file, or another message waiting at the socket, the user reads the data into the JEvent and returns
+    // Result::Success, at which point JANA pushes the JEvent onto the downstream queue. If there is no data waiting yet,
+    // the user returns Result::FailureTryAgain, at which point JANA recycles the JEvent to the pool. If there is no more
+    // data, the user returns Result::FailureFinished, at which point JANA recycles the JEvent to the pool and calls Close().
+
+    virtual Result Emit(JEvent&) { return Result::Success; };
+
+
     /// `Close` is called by JANA when it is finished accepting events from this event source. Here is where you should
     /// cleanly close files, sockets, etc. Although GetEvent() knows when (for instance) there are no more events in a
     /// file, the logic for closing needs to live here because there are other ways a computation may end besides
@@ -80,7 +93,7 @@ public:
     /// the event stream, the implementor should throw the corresponding `RETURN_STATUS`. The user should NEVER throw
     /// `RETURN_STATUS SUCCESS` because this will hurt performance. Instead, they should simply return normally.
 
-    virtual void GetEvent(std::shared_ptr<JEvent>) = 0;
+    virtual void GetEvent(std::shared_ptr<JEvent>) {};
 
     virtual void Preprocess(const JEvent&) {};
 
@@ -198,10 +211,98 @@ public:
             throw ex;
         }
     }
-
+    
     ReturnStatus DoNext(std::shared_ptr<JEvent> event) {
 
         std::lock_guard<std::mutex> lock(m_mutex); // In general, DoNext must be synchronized.
+        
+        if (m_callback_style == CallbackStyle::Compatibility) {
+            return DoNextCompatibility(event);
+        }
+
+        auto first_evt_nr = m_nskip;
+        auto last_evt_nr = m_nevents + m_nskip;
+
+        try {
+            if (m_status == Status::Uninitialized) {
+                DoInitialize(false);
+            }
+            if (m_status == Status::Initialized) {
+                if (m_nevents != 0 && (m_event_count == last_evt_nr)) {
+                    // We exit early (and recycle) because we hit our jana:nevents limit
+                    DoFinalize(false);
+                    return ReturnStatus::Finished; // ReturnStatus::Finished is a failure condition
+                }
+                // If we reach this point, we will need to actually read an event
+
+                // We configure the event
+                event->SetEventNumber(m_event_count); // Default event number to event count
+                event->SetJApplication(m_app);
+                event->SetJEventSource(this);
+                event->SetSequential(false);
+                event->GetJCallGraphRecorder()->Reset();
+
+                // Now we call the new-style interface
+                auto previous_origin = event->GetJCallGraphRecorder()->SetInsertDataOrigin( JCallGraphRecorder::ORIGIN_FROM_SOURCE);  // (see note at top of JCallGraphRecorder.h)
+                auto result = Emit(*event);
+                event->GetJCallGraphRecorder()->SetInsertDataOrigin( previous_origin );
+
+                if (result == Result::Success) {
+                    // We end up here if we read an entry in our file or retrieved a message from our socket,
+                    // and believe we could obtain another one immediately if we wanted to
+                    for (auto* output : m_outputs) {
+                        output->InsertCollection(*event);
+                    }
+                    m_event_count += 1; 
+                    if (m_event_count < first_evt_nr) {
+                        // We immediately throw away this whole event because of nskip 
+                        // (although really we should be handling this with Seek())
+                        return ReturnStatus::TryAgain; // Failure condition
+                    }
+                    return ReturnStatus::Success;
+                }
+                else if (result == Result::FailureFinished) {
+                    // We end up here if we tried to read an entry in a file, but found EOF
+                    // or if we received a message from a socket that contained no data and indicated no more data will be coming
+                    DoFinalize(false);
+                    return ReturnStatus::Finished;
+                }
+                else if (result == Result::FailureTryAgain) {
+                    // We end up here if we tried to read an entry in a file but it is on a tape drive and isn't ready yet
+                    // or if we polled the socket, found no new messages, but still expect messages later
+                    return ReturnStatus::TryAgain;
+                }
+                else {
+                    throw JException("Invalid JEventSource::Result value!");
+                }
+            }
+            else { // status == Finalized
+                return ReturnStatus::Finished;
+            }
+        }
+        catch (JException& ex) {
+            ex.plugin_name = m_plugin_name;
+            ex.component_name = m_type_name;
+            throw ex;
+        }
+        catch (std::exception& e){
+            auto ex = JException("Exception in JEventSource::Emit(): %s", e.what());
+            ex.nested_exception = std::current_exception();
+            ex.plugin_name = m_plugin_name;
+            ex.component_name = m_type_name;
+            throw ex;
+        }
+        catch (...) {
+            auto ex = JException("Unknown exception in JEventSource::Emit()");
+            ex.nested_exception = std::current_exception();
+            ex.plugin_name = m_plugin_name;
+            ex.component_name = m_type_name;
+            throw ex;
+        }
+    }
+
+    ReturnStatus DoNextCompatibility(std::shared_ptr<JEvent> event) {
+
         auto first_evt_nr = m_nskip;
         auto last_evt_nr = m_nevents + m_nskip;
 

--- a/src/libraries/JANA/JEventUnfolder.h
+++ b/src/libraries/JANA/JEventUnfolder.h
@@ -104,7 +104,7 @@ public:
             for (auto* input : m_inputs) {
                 input->PrefetchCollection(parent);
             }
-            if (m_callback_style != CallbackStyle::Declarative) {
+            if (m_callback_style != CallbackStyle::DeclarativeMode) {
                 Preprocess(parent);
             }
         }
@@ -137,7 +137,7 @@ public:
                     for (auto* resource : m_resources) {
                         resource->ChangeRun(parent.GetRunNumber(), m_app);
                     }
-                    if (m_callback_style == CallbackStyle::Declarative) {
+                    if (m_callback_style == CallbackStyle::DeclarativeMode) {
                         ChangeRun(parent.GetRunNumber());
                     }
                     else {

--- a/src/libraries/JANA/JMultifactory.h
+++ b/src/libraries/JANA/JMultifactory.h
@@ -64,9 +64,6 @@ class JMultifactory : public jana::omni::JComponent,
 
     JFactorySet mHelpers; // This has ownership UNTIL JFactorySet::Add() takes it over
 
-    std::once_flag m_is_initialized;
-    std::once_flag m_is_finished;
-    int32_t m_last_run_number = -1;
     // Remember where we are in the stream so that the correct sequence of callbacks get called.
     // However, don't worry about a Status variable. Every time Execute() gets called, so does Process().
     // The JMultifactoryHelpers will control calls to Execute().

--- a/src/libraries/JANA/Omni/JComponentFwd.h
+++ b/src/libraries/JANA/Omni/JComponentFwd.h
@@ -21,7 +21,7 @@ namespace omni {
 
 struct JComponent {
     enum class Status { Uninitialized, Initialized, Finalized };
-    enum class CallbackStyle { Compatibility, Classic, Declarative };
+    enum class CallbackStyle { LegacyMode, ExpertMode, DeclarativeMode };
 
     struct ParameterBase;
     struct ServiceBase;
@@ -31,7 +31,7 @@ protected:
     std::vector<ServiceBase*> m_services;
     
     JEventLevel m_level = JEventLevel::PhysicsEvent;
-    CallbackStyle m_callback_style = CallbackStyle::Compatibility;
+    CallbackStyle m_callback_style = CallbackStyle::LegacyMode;
     std::string m_prefix;
     std::string m_plugin_name;
     std::string m_type_name;

--- a/src/libraries/JANA/Streaming/JDiscreteJoin.h
+++ b/src/libraries/JANA/Streaming/JDiscreteJoin.h
@@ -31,32 +31,32 @@ public:
             , m_transport(std::move(transport))
             , m_trigger(std::move(trigger))
     {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
     }
 
     void Open() override {
         m_transport->initialize();
     }
 
-    void GetEvent(std::shared_ptr<JEvent> event) override {
+    Result Emit(JEvent& event) override {
 
         auto item = new T();  // This is why T requires a zero-arg ctor
         auto result = m_transport->receive(*item);
         switch (result) {
             case JTransport::Result::FINISHED:
-                throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
+                return Result::FailureFinished;
             case JTransport::Result::TRY_AGAIN:
-                throw JEventSource::RETURN_STATUS::kTRY_AGAIN;
+                return Result::FailureTryAgain;
             case JTransport::Result::FAILURE:
-                throw JEventSource::RETURN_STATUS::kERROR;
-            default:
-                break;
+                throw JException("Transport failure!");
         }
         // At this point, we know that item contains a valid Sample<T>
 
-        event->SetEventNumber(m_next_id);
+        event.SetEventNumber(m_next_id);
         m_next_id += 1;
-        event->Insert<T>(item);
+        event.Insert<T>(item);
         std::cout << "Emit: " << *item << std::endl;
+        return Result::Success;
     }
 
     static std::string GetDescription() {

--- a/src/libraries/JANA/Streaming/JEventBuilder.h
+++ b/src/libraries/JANA/Streaming/JEventBuilder.h
@@ -36,6 +36,7 @@ public:
         , m_transport(std::move(transport))
         , m_trigger(std::move(trigger))
         , m_window(std::move(window)) {
+            SetCallbackStyle(CallbackStyle::ExpertMode);
     }
 
     void addJoin(std::unique_ptr<JDiscreteJoin<T>>&& join) {
@@ -52,25 +53,23 @@ public:
         return "JEventBuilder";
     }
 
-    void GetEvent(std::shared_ptr<JEvent> event) override {
+    Result Emit(JEvent&) override {
 
         auto item = new T();  // This is why T requires a zero-arg ctor
         auto result = m_transport->receive(*item);
         switch (result) {
             case JTransport::Result::FINISHED:
-                throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
+                return Result::FailureFinished;
             case JTransport::Result::TRY_AGAIN:
-                throw JEventSource::RETURN_STATUS::kTRY_AGAIN;
+                return Result::FailureTryAgain;
             case JTransport::Result::FAILURE:
-                throw JEventSource::RETURN_STATUS::kERROR;
-            default:
-                break;
+                throw JException("Transport failure!");
         }
         // At this point, we know that item contains a valid Sample<T>
 
-        event->SetEventNumber(m_next_id);
+        event.SetEventNumber(m_next_id);
         m_next_id += 1;
-        event->Insert<T>(item);
+        event.Insert<T>(item);
 
         /// This is really bad because we have to worry about downstream HitSource returning TryAgainLater
         /// and we really don't want to block here
@@ -78,6 +77,7 @@ public:
             join->GetEvent(event);
         }
         std::cout << "Emit: " << *item << std::endl;
+        return Result::Success;
     }
 
 

--- a/src/libraries/JANA/Streaming/JEventBuilder.h
+++ b/src/libraries/JANA/Streaming/JEventBuilder.h
@@ -53,7 +53,7 @@ public:
         return "JEventBuilder";
     }
 
-    Result Emit(JEvent&) override {
+    Result Emit(JEvent& event) override {
 
         auto item = new T();  // This is why T requires a zero-arg ctor
         auto result = m_transport->receive(*item);

--- a/src/plugins/JTest/JTestParser.h
+++ b/src/plugins/JTest/JTestParser.h
@@ -30,6 +30,7 @@ public:
 
     JTestParser() {
         SetTypeName(NAME_OF_THIS);
+        SetCallbackStyle(CallbackStyle::ExpertMode);
     }
 
     static std::string GetDescription() {
@@ -44,7 +45,7 @@ public:
         app->SetDefaultParameter("jtest:parser_bytes_spread", m_write_spread, "Spread of bytes written during parsing");
     }
 
-    void GetEvent(std::shared_ptr<JEvent> event) {
+    Result Emit(JEvent& event) {
 
         if ((m_events_generated % 40) == 0) {
             // "Read" new entangled event every 40 events
@@ -58,12 +59,13 @@ public:
         // Emit a shared pointer to the entangled event buffer
         auto eec = new JTestEntangledEventData;
         eec->buffer = m_latest_entangled_buffer;
-        event->Insert<JTestEntangledEventData>(eec);
+        event.Insert<JTestEntangledEventData>(eec);
 
         m_events_generated++;
 
-        event->SetEventNumber(m_events_generated);
-        event->SetRunNumber(1);
+        event.SetEventNumber(m_events_generated);
+        event.SetRunNumber(1);
+        return Result::Success;
     }
 
 };

--- a/src/plugins/JTestRoot/JTestRoot.cc
+++ b/src/plugins/JTestRoot/JTestRoot.cc
@@ -19,7 +19,7 @@ void InitPlugin(JApplication* app) {
     InitJANAPlugin(app);
 
     LOG << "Loading JTestRoot" << LOG_END;
-    app->Add(new JTestRootEventSource("dummy_root_object_source", app));
+    app->Add(new JTestRootEventSource);
     app->Add(new JTestRootProcessor);
     app->Add(new JFactoryGeneratorT<JFactory_Cluster>);
 }

--- a/src/plugins/JTestRoot/JTestRootEventSource.cc
+++ b/src/plugins/JTestRoot/JTestRootEventSource.cc
@@ -15,11 +15,12 @@
 #include <JANA/JEvent.h>
 #include <JANA/Utils/JPerfUtils.h>
 
-JTestRootEventSource::JTestRootEventSource(std::string resource_name, JApplication* app) : JEventSource(resource_name, app) {
+JTestRootEventSource::JTestRootEventSource() {
     SetTypeName(NAME_OF_THIS); // Provide JANA with class name
+    SetCallbackStyle(CallbackStyle::ExpertMode);
 }
 
-void JTestRootEventSource::GetEvent(std::shared_ptr <JEvent> event) {
+JEventSource::Result JTestRootEventSource::Emit(JEvent& event) {
     /// Generate an event by inserting objects into "event".
     /// (n.b. a normal event source would read these from a file or stream)
 
@@ -28,8 +29,8 @@ void JTestRootEventSource::GetEvent(std::shared_ptr <JEvent> event) {
 
     // Configure event and run numbers
     static size_t current_event_number = 1;
-    event->SetEventNumber(current_event_number++);
-    event->SetRunNumber(222);
+    event.SetEventNumber(current_event_number++);
+    event.SetRunNumber(222);
 
     // Generate hit objects. We use random numbers to give some variation
     // and make things look a little more realistic
@@ -44,5 +45,7 @@ void JTestRootEventSource::GetEvent(std::shared_ptr <JEvent> event) {
     }
 
     // Add Hit objects to event
-    event->Insert(hits);
+    event.Insert(hits);
+    return Result::Success;
 }
+

--- a/src/plugins/JTestRoot/JTestRootEventSource.h
+++ b/src/plugins/JTestRoot/JTestRootEventSource.h
@@ -15,7 +15,7 @@ public:
     JTestRootEventSource(std::string resource_name, JApplication* app);
     virtual ~JTestRootEventSource() = default;
 
-    void GetEvent(std::shared_ptr<JEvent>) override;
+    Result Emit(JEvent& event) override;
 
 protected:
     std::default_random_engine generator;

--- a/src/plugins/streamDet/DecodeDASSource.cc
+++ b/src/plugins/streamDet/DecodeDASSource.cc
@@ -12,15 +12,10 @@
 // DecodeDASSource    (Constructor)
 //---------------------------------
 DecodeDASSource::DecodeDASSource(std::string source_name, JApplication* app) : JEventSource(source_name, app) {
-
+    SetCallbackStyle(CallbackStyle::ExpertMode);
 }
 
 DecodeDASSource::~DecodeDASSource() {
-
-    // Close the file/stream here.
-    std::cout << "Closing " << GetName() << std::endl;
-    ifs.close();
-
 }
 
 void DecodeDASSource::Open() {
@@ -31,7 +26,13 @@ void DecodeDASSource::Open() {
 
 }
 
-void DecodeDASSource::GetEvent(std::shared_ptr<JEvent> event) {
+void DecodeDASSource::Close() {
+    // Close the file/stream here.
+    std::cout << "Closing " << GetName() << std::endl;
+    ifs.close();
+}
+
+JEventSource::Result DecodeDASSource::Emit(JEvent& event) {
 
     // TODO: Put these somewhere that makes sense
     size_t MAX_CHANNELS = 80;
@@ -53,16 +54,14 @@ void DecodeDASSource::GetEvent(std::shared_ptr<JEvent> event) {
                 }
             }
             // populate the jevent with the adc samples
-            event->Insert(hits);
-            event->SetEventNumber(current_event_nr++);
-            return;
+            event.Insert(hits);
+            event.SetEventNumber(current_event_nr++);
+            return Result::Success;
         }
         // close file stream when the end of file is reached
         std::cout << "Reached end of file/stream " << GetName() << std::endl;
-        ifs.close();
     }
-    // signal jana to terminate
-    throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
+    return Result::FailureFinished;
 
 }
 

--- a/src/plugins/streamDet/DecodeDASSource.h
+++ b/src/plugins/streamDet/DecodeDASSource.h
@@ -16,13 +16,14 @@ class DecodeDASSource : public JEventSource {
 public:
 
     // constructors and destructors
-    DecodeDASSource(std::string source_name, JApplication* app);
+    DecodeDASSource();
     ~DecodeDASSource() override;
 
     // define public methods
     static std::string GetDescription() { return "streamDet event source (direct ADC serialization mode)"; }
     void Open() final;
-    void GetEvent(std::shared_ptr<JEvent>) final;
+    void Close() final;
+    Result Emit(JEvent&) final;
 
 private:
 

--- a/src/programs/unit_tests/BarrierEventTests.h
+++ b/src/programs/unit_tests/BarrierEventTests.h
@@ -17,23 +17,27 @@ class BarrierSource : public JEventSource {
 
 public:
 
+    BarrierSource() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+
     void Open() override {
     }
 
-    void GetEvent(std::shared_ptr<JEvent> event) override {
+    Result Emit(JEvent& event) override {
         event_count++;
 
         if (event_count >= 100) {
-            throw RETURN_STATUS::kNO_MORE_EVENTS;
+            return Result::FailureFinished;
         }
 
         LOG << "Emitting event " << event_count << LOG_END;
-        event->SetEventNumber(event_count);
+        event.SetEventNumber(event_count);
 
         if (event_count % 10 == 0) {
-            event->SetSequential(true);
+            event.SetSequential(true);
         }
-
+        return Result::Success;
     }
 };
 

--- a/src/programs/unit_tests/CMakeLists.txt
+++ b/src/programs/unit_tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TEST_SOURCES
     MultiLevelTopologyTests.cc
     UnfoldTests.cc
     JComponentTests.cc
+    Components/JEventSourceTests.cc
     )
 
 if (${USE_PODIO})

--- a/src/programs/unit_tests/Components/JEventSourceTests.cc
+++ b/src/programs/unit_tests/Components/JEventSourceTests.cc
@@ -1,0 +1,73 @@
+
+#include "catch.hpp"
+
+#include <JANA/JEventSource.h>
+
+struct MyEventSource : public JEventSource {
+    int open_count = 0;
+    int emit_count = 0;
+    int close_count = 0;
+    size_t events_in_file = 5;
+
+    void Open() override {
+        LOG_INFO(GetLogger()) << "Open() called" << LOG_END;
+        open_count++;
+    }
+    Result Emit(JEvent&) override {
+        emit_count++;
+
+        if (GetEventCount() >= events_in_file) {
+            LOG_INFO(GetLogger()) << "Emit() called, returning FailureFinished" << LOG_END;
+            return Result::FailureFinished;
+        }
+        LOG_INFO(GetLogger()) << "Emit() called, returning Success" << LOG_END;
+        return Result::Success;
+    }
+    void Close() override {
+        LOG_INFO(GetLogger()) << "Close() called" << LOG_END;
+        close_count++;
+    }
+};
+
+TEST_CASE("JEventSource_ExpertMode_EmitCount") {
+
+    auto sut = new MyEventSource;
+    sut->SetCallbackStyle(MyEventSource::CallbackStyle::ExpertMode);
+    sut->SetTypeName("MyEventSource");
+
+    JApplication app;
+    app.SetParameterValue("log:global", "off");
+    app.SetParameterValue("log:info", "MyEventSource");
+    app.Add(sut);
+
+    SECTION("ShutsSelfOff") {
+        LOG << "Running test: JEventSource_ExpertMode_EmitCount :: ShutsSelfOff" << LOG_END;
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 6);       // Emit called 5 times successfully and fails on the 6th
+        REQUIRE(sut->GetEventCount() == 5);  // Emits 5 events successfully (including skipped)
+        REQUIRE(sut->close_count == 1);
+    }
+
+    SECTION("LimitedByNEvents") {
+        LOG << "Running test: JEventSource_ExpertMode_EmitCount :: LimitedByNEvents" << LOG_END;
+        app.SetParameterValue("jana:nevents", 3);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 3);        // Emit called 3 times successfully
+        REQUIRE(sut->GetEventCount() == 3);   // Nevents limit discovered outside Emit
+        REQUIRE(sut->close_count == 1);
+    }
+
+    SECTION("LimitedByNSkip") {
+        LOG << "Running test: JEventSource_ExpertMode_EmitCount :: LimitedByNSkip" << LOG_END;
+        app.SetParameterValue("jana:nskip", 3);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 6);        // Emit called 5 times successfully and fails on the 6th
+        REQUIRE(sut->GetEventCount() == 5);   // 5 events successfully emitted, 3 of which were (presumably) skipped
+        REQUIRE(sut->close_count == 1);
+    }
+}
+
+

--- a/src/programs/unit_tests/ExactlyOnceTests.h
+++ b/src/programs/unit_tests/ExactlyOnceTests.h
@@ -16,15 +16,19 @@ struct SimpleSource : public JEventSource {
     std::atomic_int close_count {0};
     std::atomic_int event_count {0};
 
+    SimpleSource() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
 
     void Open() override {
         open_count += 1;
     }
 
-    void GetEvent(std::shared_ptr<JEvent>) override {
+    Result Emit(JEvent&) override {
         if (++event_count == 5) {
-            throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
+            return Result::FailureFinished;
         }
+        return Result::Success;
     }
     void Close() override {
         close_count += 1;

--- a/src/programs/unit_tests/GetObjectsTests.cc
+++ b/src/programs/unit_tests/GetObjectsTests.cc
@@ -10,11 +10,14 @@ struct Obj3 : public JObject { int data; };
 struct Obj4 : public JObject { int data; };
 
 class Src : public JEventSource {
-
-    void GetEvent(std::shared_ptr<JEvent> event) override {
+    Src() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+    Result Emit(JEvent& event) override {
         auto obj = new Obj1;
         obj->data = 21;
-        event->Insert(obj);
+        event.Insert(obj);
+        return Result::Success;
     }
     bool GetObjects(const std::shared_ptr<const JEvent>&, JFactory* fac) override {
         if (fac->GetObjectName() == "Obj2") {

--- a/src/programs/unit_tests/JEventProcessorSequentialTests.cc
+++ b/src/programs/unit_tests/JEventProcessorSequentialTests.cc
@@ -13,11 +13,6 @@ namespace jeventprocessorsequentialtests {
 // the linker will cheerfully not notice and you will get VERY weird errors.
 // Hence, we protect each Catch test with its own namespace.
 
-struct DummySource : public JEventSource {
-
-    // By default, this will emit empty events with event numbers 0,1,2...
-    void GetEvent(std::shared_ptr<JEvent>) override {}
-};
 
 struct MyRootProcessor : public JEventProcessorSequentialRoot {
     std::vector<std::pair<int, int>> access_log;
@@ -51,7 +46,7 @@ struct MyRootProcessor : public JEventProcessorSequentialRoot {
 TEST_CASE("JEventProcessorSequentialRootTests") {
 
     JApplication app;
-    app.Add(new DummySource);
+    app.Add(new JEventSource());
     app.SetParameterValue("nthreads", 4);
     app.SetParameterValue("jana:nevents", 4);
     app.SetParameterValue("jana:event_source_chunksize", 1);
@@ -138,7 +133,7 @@ struct MySeqProcessor : public JEventProcessorSequential {
 TEST_CASE("JEventProcessorSequentialTests") {
 
     JApplication app;
-    app.Add(new DummySource);
+    app.Add(new JEventSource());
     app.SetParameterValue("nthreads", 4);
     app.SetParameterValue("jana:nevents", 4);
     app.SetParameterValue("jana:event_source_chunksize", 1);

--- a/src/programs/unit_tests/JFactoryDefTagsTests.cc
+++ b/src/programs/unit_tests/JFactoryDefTagsTests.cc
@@ -102,13 +102,6 @@ TEST_CASE("MediumDefTags") {
 }
 
 namespace deftagstest {
-struct DummySource : public JEventSource {
-    DummySource() {
-        SetTypeName(NAME_OF_THIS);
-    };
-
-    void GetEvent(std::shared_ptr<JEvent>) override {};
-};
 
 struct DummyProcessor : public JEventProcessor {
     double E = 0.5;
@@ -135,7 +128,7 @@ TEST_CASE("LargeDefTags") {
     JApplication app;
     app.Add(new JFactoryGeneratorT<Fac1>);
     app.Add(new JFactoryGeneratorT<Fac2>);
-    app.Add(new DummySource);
+    app.Add(new JEventSource);
     auto proc = new DummyProcessor;
     app.Add(proc);
     app.SetParameterValue("jana:nevents", 3);

--- a/src/programs/unit_tests/JFactoryTests.h
+++ b/src/programs/unit_tests/JFactoryTests.h
@@ -69,7 +69,12 @@ struct JFactoryTestExceptingInInitFactory : public JFactoryT<JFactoryTestDummyOb
 
 struct JFactoryTestDummySource: public JEventSource {
 
-    void GetEvent(std::shared_ptr<JEvent>) override {
+    JFactoryTestDummySource() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+
+    Result Emit(JEvent&) override {
+        return Result::Success;
     };
 
     bool GetObjects(const std::shared_ptr<const JEvent>&, JFactory* aFactory) override {

--- a/src/programs/unit_tests/NEventNSkipTests.cc
+++ b/src/programs/unit_tests/NEventNSkipTests.cc
@@ -15,12 +15,17 @@ struct NEventNSkipBoundedSource : public JEventSource {
     std::atomic_int open_count{0};
     std::atomic_int close_count{0};
 
-    void GetEvent(std::shared_ptr<JEvent>) override {
+    NEventNSkipBoundedSource() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+
+    Result Emit(JEvent&) override {
         if (event_count >= event_bound) {
-            throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
+            return Result::FailureFinished;
         }
         event_count += 1;
         events_emitted.push_back(event_count);
+        return Result::Success;
     }
 
     void Open() override {

--- a/src/programs/unit_tests/ScaleTests.h
+++ b/src/programs/unit_tests/ScaleTests.h
@@ -12,9 +12,14 @@
 namespace scaletest {
 struct DummySource : public JEventSource {
 
-    void GetEvent(std::shared_ptr<JEvent>) override {
+    DummySource() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+
+    Result Emit(JEvent&) override {
         consume_cpu_ms(20);
         std::this_thread::sleep_for(std::chrono::nanoseconds(1));
+        return Result::Success;
     }
 };
 

--- a/src/programs/unit_tests/SubeventTests.cc
+++ b/src/programs/unit_tests/SubeventTests.cc
@@ -144,15 +144,18 @@ TEST_CASE("Basic subevent arrow functionality") {
     }
 
     struct SimpleSource : public JEventSource {
-        void GetEvent(std::shared_ptr<JEvent> event) override {
+        SimpleSource() {
+            SetCallbackStyle(CallbackStyle::ExpertMode);
+        }
+        Result Emit(JEvent& event) override {
+            if (GetEventCount() == 10) return Result::FailureFinished;
             std::vector<MyInput*> inputs;
             inputs.push_back(new MyInput(22,3.6));
             inputs.push_back(new MyInput(23,3.5));
             inputs.push_back(new MyInput(24,3.4));
             inputs.push_back(new MyInput(25,3.3));
-            event->Insert(inputs);
-            if (GetEventCount() == 10)
-                throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
+            event.Insert(inputs);
+            return Result::Success;
         }
     };
 

--- a/src/programs/unit_tests/TimeoutTests.h
+++ b/src/programs/unit_tests/TimeoutTests.h
@@ -20,12 +20,14 @@ struct SourceWithTimeout : public JEventSource {
 
         : timeout_on_event_nr(timeout_on_event_nr)
         , first_event_delay_ms(first_delay_ms)
-    { }
+    { 
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
 
     void Open() override {
     }
 
-    void GetEvent(std::shared_ptr<JEvent>) override {
+    Result Emit(JEvent&) override {
         event_count += 1;
         std::cout << "Processing event # " << event_count << std::endl;
         std::flush(std::cout);
@@ -35,7 +37,7 @@ struct SourceWithTimeout : public JEventSource {
         }
 
         if (event_count == 100) {
-            throw RETURN_STATUS::kNO_MORE_EVENTS;
+            return Result::FailureFinished;
         }
 
         if (event_count == timeout_on_event_nr) {
@@ -43,6 +45,7 @@ struct SourceWithTimeout : public JEventSource {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }; // Endless loop
         }
+        return Result::Success;
     }
 };
 

--- a/src/programs/unit_tests/UserExceptionTests.h
+++ b/src/programs/unit_tests/UserExceptionTests.h
@@ -17,7 +17,9 @@ struct FlakySource : public JEventSource {
     int event_count = 0;
 
     FlakySource(bool open_excepts, bool getevent_excepts)
-            : open_excepts(open_excepts), getevent_excepts(getevent_excepts) {}
+            : open_excepts(open_excepts), getevent_excepts(getevent_excepts) {
+                SetCallbackStyle(CallbackStyle::ExpertMode);
+            }
 
     void Open() override {
         if (open_excepts) {
@@ -25,15 +27,16 @@ struct FlakySource : public JEventSource {
         }
     }
 
-    void GetEvent(std::shared_ptr<JEvent>) override {
+    Result Emit(JEvent&) override {
 
         if (++event_count > 10) {
-            throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
+            return Result::FailureFinished;
         }
 
         if (getevent_excepts) {
             throw JException("Unable to getEvent!");
         }
+        return Result::Success;
     }
 };
 


### PR DESCRIPTION
`JEventSource::GetEvent` is now required to return the status code `ReturnStatus { Success, TryAgain, Finished }`, instead of throwing enums as exceptions. This fixes a number of problems with the current design:

* Using exceptions for flow control (particularly in non-exceptional situations such as EOF) are controversial at best; using enums as exceptions is not idiomatic C++. [1]
* The old RETURN_STATUS contained a number of ergonomic footguns, including:
  * Unclear whether or not to throw `RETURN_STATUS::kSUCCESS` if successful
  * Unclear when to throw `RETURN_STATUS::kBUSY` vs `RETURN_STATUS::kTRY_AGAIN`
  * Throwing `RETURN_STATUS::kERROR` yields no useful debugging information compared to throwing a JException in the same context. 
  * Unclear whether or not `RETURN_STATUS::kUNKNOWN` is a recoverable error or not. 

* This change will make it more consistent how JANA2 handles recoverable vs unrecoverable errors. Unrecoverable errors are always raised via JExceptions, which include helpful text, plugin/component information, and a stack trace, and always terminate execution. Recoverable errors are handled via status codes and/or state machine transitions, and never terminate execution.

* C++ exceptions impose a performance overhead that could slow down the whole system when polling an external event queue (this is shown by testing, see issue #212)


[1]: https://softwareengineering.stackexchange.com/questions/189222/are-exceptions-as-control-flow-considered-a-serious-antipattern-if-so-why