### PR TITLE
JTypeInfo.h: include <cstdint> for fixed width integers

### DIFF
--- a/src/libraries/JANA/Utils/JTypeInfo.h
+++ b/src/libraries/JANA/Utils/JTypeInfo.h
@@ -6,6 +6,7 @@
 #ifndef _JTypeInfo_h_
 #define _JTypeInfo_h_
 
+#include <cstdint>
 #include <cxxabi.h>
 #include <string>
 


### PR DESCRIPTION
Ref: https://en.cppreference.com/w/cpp/types/integer. This may have gotten included transitively before, but it doesn't anymore on my system.