### PR TITLE
JBacktrace.h: free after use

### DIFF
--- a/src/libraries/JANA/Utils/JBacktrace.h
+++ b/src/libraries/JANA/Utils/JBacktrace.h
@@ -60,6 +60,8 @@ inline std::ostream& make_backtrace(std::ostream& os) {
 
             os << std::string(i+5, ' ') + "`- " << name << " (" << std::hex << backtrace_buffer[i] << std::dec << ")" << std::endl;
         }
+        
+        free(symbols);
     }
     catch (...) {
         // If this fails (e.g. bad alloc), just keep going


### PR DESCRIPTION
"The return value of backtrace_symbols is a pointer obtained via the malloc function, and it is the responsibility of the caller to free that pointer. Note that only the return value need be freed, not the individual strings." (https://www.gnu.org/software/libc/manual/html_node/Backtraces.html and example therein)

Fix is untested (I'm in a container and can't easily rebuild jana2 at the moment).