### PR TITLE
DatamodelGlue.h: support PODIO 00-17+

### DIFF
--- a/src/examples/PodioExample/DatamodelGlue.h
+++ b/src/examples/PodioExample/DatamodelGlue.h
@@ -75,7 +75,7 @@ void visitPodioType(const std::string& podio_typename, F& helper, ArgsT... args)
 template <typename Visitor>
 struct VisitExampleDatamodel {
     void operator()(Visitor& visitor, const podio::CollectionBase &collection) {
-        std::string podio_typename = collection.getTypeName();
+        const auto podio_typename = collection.getTypeName();
         if (podio_typename == "EventInfoCollection") {
             return visitor(static_cast<const EventInfoCollection &>(collection));
         } else if (podio_typename == "ExampleHitCollection") {


### PR DESCRIPTION
`auto` supports both `std::string` and `std::string_view` return types

cc https://github.com/AIDASoft/podio/pull/402, https://github.com/AIDASoft/podio/pull/404