### PR TITLE
fix: remove malignant alignas

### DIFF
--- a/src/libraries/JANA/Utils/JResourcePool.h
+++ b/src/libraries/JANA/Utils/JResourcePool.h
@@ -40,11 +40,6 @@
  *
  **********************************************************************************************************************/
 
-// Apple compiler does not currently support alignas. Make this an empty definition if it is not already defined.
-#ifndef alignas
-#define alignas(A)
-#endif
-
 template <typename DType> class JResourcePool
 {
     //TYPE TRAIT REQUIREMENTS


### PR DESCRIPTION
Removing this `alignas` override fixes https://github.com/JeffersonLab/JANA2/issues/238, and may resolve a number of mysterious issues in EICrecon over the past year:
- from boost small_vector requiring initialization before JANA2,
- to Acts crashing when support for avx/avx2 is compiled in, which we narrowed down to https://github.com/paulgessinger/acts/blob/main/Core/include/Acts/Utilities/Any.hpp#L490-L503 and even discussed with Acts developers,
- to Eigen asserts failing with pointers to http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html,
- or just plain segfaults.

I can confirm that removing the `alignas` override fixes one reproducible Eigen assert failure in a local copy. Removing `alignas` is also confirmed to avoids our need to include `boost/container/small_vector.hpp` before including JANA2 headers. (We fixed the avx/avx2 issue with Acts already by increasing separation between JANA2 factories and tracking algorithms.)