### PR TITLE
fix: warn when existing plugin fails to load

### DIFF
--- a/src/libraries/JANA/Services/JPluginLoader.cc
+++ b/src/libraries/JANA/Services/JPluginLoader.cc
@@ -139,7 +139,7 @@ void JPluginLoader::attach_plugins(JComponentManager* jcm) {
                         break;
                     } catch (...) {
                         paths_checked << "Loading failure: " << dlerror() << std::endl;
-                        LOG_DEBUG(m_logger) << "Loading failure: " << dlerror() << LOG_END;
+                        LOG_WARN(m_logger) << "Loading failure: " << dlerror() << LOG_END;
                         continue;
                     }
                 }


### PR DESCRIPTION
Spent some time banging my head against the wall today, until I realized that JANA2 was silently falling through to other paths in the JANA_PLUGIN_PATH. In my particular case, modifications to a plugin had introduced an undefined symbol, an error that resulted in a plugin with the same name in another directory in JANA_PLUGIN_PATH to be loaded. This now at least emits a warning, but otherwise doesn't change behavior.