### PR TITLE
Address issue #217: Test JParameterManager handling of strings containing whitespace

### DIFF
--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -317,16 +317,13 @@ TEST_CASE("JParameterManager_ArrayParams") {
     }
 }
 
-TEST_CASE("Jparameter: Issue-217: Mangling strings with whitespaces") {
+TEST_CASE("JParameterManager_Issue217StringsWithWhitespace") {
     JParameterManager jpm;
     SECTION("Reading a array of strings") {
         jpm.SetParameter("test", "(  abs(fmod(tower_1, 24) - fmod(tower_2, 24))  + min(      abs((sector_1 - sector_2) * (2 * 5) + (floor(tower_1 / 24) - floor(tower_2 / 24)) * 5 + fmod(tile_1, 5) - fmod(tile_2, 5)),      (32 * 2 * 5) - abs((sector_1 - sector_2) * (2 * 5) + (floor(tower_1 / 24) - floor(tower_2 / 24)) * 5 + fmod(tile_1, 5) - fmod(tile_2, 5))    )) == 1");
         std::string vals;
         jpm.GetParameter<std::string>("test", vals); 
         REQUIRE(vals == "(  abs(fmod(tower_1, 24) - fmod(tower_2, 24))  + min(      abs((sector_1 - sector_2) * (2 * 5) + (floor(tower_1 / 24) - floor(tower_2 / 24)) * 5 + fmod(tile_1, 5) - fmod(tile_2, 5)),      (32 * 2 * 5) - abs((sector_1 - sector_2) * (2 * 5) + (floor(tower_1 / 24) - floor(tower_2 / 24)) * 5 + fmod(tile_1, 5) - fmod(tile_2, 5))    )) == 1");
-        //REQUIRE(vals[1] == "simple");
-        // REQUIRE(vals[2] == "whitespace in middle");
-        // REQUIRE(vals[3] == " also with whitespace padding ");
     }
 }
 

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -317,4 +317,17 @@ TEST_CASE("JParameterManager_ArrayParams") {
     }
 }
 
+TEST_CASE("Jparameter: Issue-217: Mangling strings with whitespaces") {
+    JParameterManager jpm;
+    SECTION("Reading a array of strings") {
+        jpm.SetParameter("test", "(  abs(fmod(tower_1, 24) - fmod(tower_2, 24))  + min(      abs((sector_1 - sector_2) * (2 * 5) + (floor(tower_1 / 24) - floor(tower_2 / 24)) * 5 + fmod(tile_1, 5) - fmod(tile_2, 5)),      (32 * 2 * 5) - abs((sector_1 - sector_2) * (2 * 5) + (floor(tower_1 / 24) - floor(tower_2 / 24)) * 5 + fmod(tile_1, 5) - fmod(tile_2, 5))    )) == 1");
+        std::string vals;
+        jpm.GetParameter<std::string>("test", vals); 
+        REQUIRE(vals == "(  abs(fmod(tower_1, 24) - fmod(tower_2, 24))  + min(      abs((sector_1 - sector_2) * (2 * 5) + (floor(tower_1 / 24) - floor(tower_2 / 24)) * 5 + fmod(tile_1, 5) - fmod(tile_2, 5)),      (32 * 2 * 5) - abs((sector_1 - sector_2) * (2 * 5) + (floor(tower_1 / 24) - floor(tower_2 / 24)) * 5 + fmod(tile_1, 5) - fmod(tile_2, 5))    )) == 1");
+        //REQUIRE(vals[1] == "simple");
+        // REQUIRE(vals[2] == "whitespace in middle");
+        // REQUIRE(vals[3] == " also with whitespace padding ");
+    }
+}
+
 


### PR DESCRIPTION
Test case to show that the c++ command with white spaces provided as an input passes 