### PR TITLE
Address issue #233: Resolve floating-point JParameter stringification round-trip problems

### DIFF
--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -5,6 +5,7 @@
 #ifndef _JParameterManager_h_
 #define _JParameterManager_h_
 
+#include <limits>
 #include <string>
 #include <algorithm>
 #include <vector>
@@ -120,12 +121,6 @@ public:
     */
     template<typename T>
     static std::string Stringify(const T& value);
-    
-    template<typename T>
-    static std::string Stringify(const float value);
-
-    template<typename T>
-    static std::string Stringify(const double value);
     
     template<typename T>
     static std::string Stringify(const std::vector<T>& values);
@@ -369,35 +364,35 @@ inline void JParameterManager::Parse(const std::string& value, std::vector<T> &v
 template <typename T>
 inline std::string JParameterManager::Stringify(const T& value) {
     std::stringstream ss;
-    ss << std::setprecision(30) << value ; 
-    return ss.str();    
+    ss << value;
+    return ss.str();
 }
 
-// Template specialization for Stringifying a float  
-template <typename T>
-inline std::string JParameterManager::Stringify(const float value) {
+template <>
+inline std::string JParameterManager::Stringify(const float& value) {
     std::stringstream ss;
-    ss << value;
-    float tempVal;
-    Parse(ss.str(), tempVal);
-    if (!(value == tempVal)){
-        ss << std::setprecision(30) << tempVal;
-    }  
-    return ss.str();    
+    // Use enough precision to make sure that the "float -> string -> float" roundtrip is exact. 
+    // The stringstream << operator is smart enough to give us a clean representation when one is available.
+    ss << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
+    return ss.str();
+}
+template <>
+inline std::string JParameterManager::Stringify(const double& value) {
+    std::stringstream ss;
+    // Use enough precision to make sure that the "double -> string -> double" roundtrip is exact. 
+    // The stringstream << operator is smart enough to give us a clean representation when one is available.
+    ss << std::setprecision(std::numeric_limits<double>::max_digits10) << value;
+    return ss.str();
+}
+template <>
+inline std::string JParameterManager::Stringify(const long double& value) {
+    std::stringstream ss;
+    // Use enough precision to make sure that the "long double -> string -> long double" roundtrip is exact. 
+    // The stringstream << operator is smart enough to give us a clean representation when one is available.
+    ss << std::setprecision(std::numeric_limits<long double>::max_digits10) << value;
+    return ss.str();
 }
 
-// Template specialization for Stringifying a double 
-template <typename T>
-inline std::string JParameterManager::Stringify(const double value) {
-    std::stringstream ss;
-    ss << value;
-    double tempVal;
-    Parse(ss.str(), tempVal);
-    if (!(value == tempVal)){
-        ss << std::setprecision(30) << tempVal;
-    } 
-    return ss.str();    
-}
 // @brief Specialization for strings. The stream operator is not only redundant here, but it also splits the string (see Issue #191)
 template <>
 inline std::string JParameterManager::Stringify(const std::string& value) {
@@ -418,6 +413,7 @@ inline std::string JParameterManager::Stringify(const std::vector<T> &values) {
     }
     return ss.str();
 }
+
 
 // @brief Template for generically stringifying an array
 template <typename T, size_t N>

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -359,7 +359,12 @@ template <typename T>
 inline std::string JParameterManager::Stringify(const T& value) {
     std::stringstream ss;
     ss << value;
-    return ss.str();
+    if (ss.str() != (std::to_string((uintptr_t)value))) {
+        return ss.str();
+    }
+    else {
+        return ss.str()+".0";
+    }    
 }
 
 // @brief Specialization for strings. The stream operator is not only redundant here, but it also splits the string (see Issue #191)

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -430,20 +430,14 @@ inline std::string JParameterManager::Stringify(const std::array<T,N> &values) {
     return ss.str();
 }
 
+// @brief Equals() is called internally by SetDefaultParameter. This allows the user to define equivalence relations on custom data types so that
+// they can silence any spurious "loses equality with itself after stringification" warnings. Generally you should try specializing Stringify and Parse
+// first to normalize your data representation.
 template <typename T>
 inline bool JParameterManager::Equals(const T& lhs, const T& rhs) {
     return lhs == rhs;
 }
 
-template <>
-inline bool JParameterManager::Equals(const float& lhs, const float& rhs) {
-    return (std::abs(lhs-rhs) < std::abs(lhs)*std::numeric_limits<float>::epsilon());
-}
-
-template <>
-inline bool JParameterManager::Equals(const double& lhs, const double& rhs) {
-    return (std::abs(lhs-rhs) < std::abs(lhs)*std::numeric_limits<double>::epsilon());
-}
 
 #endif // _JParameterManager_h_
 

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -358,13 +358,14 @@ inline void JParameterManager::Parse(const std::string& value, std::vector<T> &v
 template <typename T>
 inline std::string JParameterManager::Stringify(const T& value) {
     std::stringstream ss;
-    ss << value;
-    if (ss.str() != (std::to_string((uintptr_t)value))) {
-        return ss.str();
-    }
-    else {
-        return ss.str()+".0";
-    }    
+    /* ss << value;
+    T tempVal;
+    Parse(ss.str(), tempVal);
+    if (!(value == tempVal)){
+        ss << std::setprecision(30) << tempVal;
+    } */
+    ss << std::setprecision(30) << value ; 
+    return ss.str();    
 }
 
 // @brief Specialization for strings. The stream operator is not only redundant here, but it also splits the string (see Issue #191)

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -113,9 +113,19 @@ public:
     template<typename T, size_t arrSize>
     static inline void Parse(const std::string& value, std::array<T,arrSize>& out); 
 
+    /*
+    Template specialization done for double and float numbers in order to match the 
+    precision of the number with the string
+    */
     template<typename T>
     static std::string Stringify(const T& value);
+    
+    template<typename T>
+    static std::string Stringify(const float value);
 
+    template<typename T>
+    static std::string Stringify(const double value);
+    
     template<typename T>
     static std::string Stringify(const std::vector<T>& values);
 
@@ -358,16 +368,35 @@ inline void JParameterManager::Parse(const std::string& value, std::vector<T> &v
 template <typename T>
 inline std::string JParameterManager::Stringify(const T& value) {
     std::stringstream ss;
-    /* ss << value;
-    T tempVal;
-    Parse(ss.str(), tempVal);
-    if (!(value == tempVal)){
-        ss << std::setprecision(30) << tempVal;
-    } */
     ss << std::setprecision(30) << value ; 
     return ss.str();    
 }
 
+// Template specialization for Stringifying a float  
+template <typename T>
+inline std::string JParameterManager::Stringify(const float value) {
+    std::stringstream ss;
+    ss << value;
+    float tempVal;
+    Parse(ss.str(), tempVal);
+    if (!(value == tempVal)){
+        ss << std::setprecision(30) << tempVal;
+    }  
+    return ss.str();    
+}
+
+// Template specialization for Stringifying a double 
+template <typename T>
+inline std::string JParameterManager::Stringify(const double value) {
+    std::stringstream ss;
+    ss << value;
+    double tempVal;
+    Parse(ss.str(), tempVal);
+    if (!(value == tempVal)){
+        ss << std::setprecision(30) << tempVal;
+    } 
+    return ss.str();    
+}
 // @brief Specialization for strings. The stream operator is not only redundant here, but it also splits the string (see Issue #191)
 template <>
 inline std::string JParameterManager::Stringify(const std::string& value) {

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -11,6 +11,7 @@
 #include <array>
 #include <map>
 #include <cmath>
+#include <iomanip>
 
 #include <JANA/JLogger.h>
 #include <JANA/JException.h>

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -317,7 +317,7 @@ TEST_CASE("JParameterManager_ArrayParams") {
     }
 }
 
-TEST_CASE("JParameter: Issue 233") {
+TEST_CASE("JParameterManagerFloatingPointRoundTrip") {
     JParameterManager jpm;
 
     SECTION("Integer") {
@@ -376,5 +376,20 @@ TEST_CASE("JParameter: Issue 233") {
     }
 
 }
+
+
+TEST_CASE("JParameterManagerIssue233") {
+    JParameterManager jpm;
+    double x = 0.0;
+    jpm.SetDefaultParameter("x", x, "Description");
+    // This should NOT print out a warning about losing equality with itself after stringification
+
+    // We reproduce the logic inside SetDefaultParameter here so that CI can catch regressions
+    std::string x_stringified = JParameterManager::Stringify(x);
+    double x_roundtrip;
+    JParameterManager::Parse(x_stringified, x_roundtrip);
+    REQUIRE(JParameterManager::Equals(x_roundtrip, x));
+}
+
 
 

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -317,4 +317,39 @@ TEST_CASE("JParameterManager_ArrayParams") {
     }
 }
 
+TEST_CASE("JParameterManager_Replicating_Issue_233") {
+    JParameterManager jpm;
+
+    SECTION("Double Test case: 1") {
+        const double testVal = 0.00000001;
+        std::string result = jpm.Stringify <double>(testVal);
+        REQUIRE(result == "0.00000001");
+    }
+    SECTION("Double Test case: 2") {
+        const double testVal = 0.01;
+        std::string result = jpm.Stringify <double>(testVal);
+        REQUIRE(result == "0.01");
+    }
+    SECTION("Double Test case: 3") {
+        const double testVal = 0.0;
+        std::string result = jpm.Stringify <double>(testVal);
+        REQUIRE(result == "0.0");
+    }
+
+    SECTION("Float Test case: 1") {
+        const float testVal = 0.0f;
+        std::string result = jpm.Stringify <float>(testVal);
+        REQUIRE(result == "0.0");
+    }
+
+    SECTION("Float Test case: 2") {
+        const float testVal = 0.0001f;
+        std::string result = jpm.Stringify <float>(testVal);
+        REQUIRE(result == "0.0001");
+    }
+
+
+
+}
+
 

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -317,38 +317,50 @@ TEST_CASE("JParameterManager_ArrayParams") {
     }
 }
 
-TEST_CASE("JParameterManager_Replicating_Issue_233") {
+TEST_CASE("JParamter: Issue 233:") {
     JParameterManager jpm;
 
-    SECTION("Double Test case: 1") {
-        const double testVal = 0.00000001;
-        std::string result = jpm.Stringify <double>(testVal);
-        REQUIRE(result == "0.00000001");
-    }
-    SECTION("Double Test case: 2") {
-        const double testVal = 0.01;
-        std::string result = jpm.Stringify <double>(testVal);
-        REQUIRE(result == "0.01");
-    }
-    SECTION("Double Test case: 3") {
-        const double testVal = 0.0;
-        std::string result = jpm.Stringify <double>(testVal);
-        REQUIRE(result == "0.0");
+    SECTION("int Test case: ") {
+        const int testVal = 123;
+        int temp;
+        jpm.Parse<int>(jpm.Stringify(testVal), temp);
+        REQUIRE(temp == testVal);    
     }
 
-    SECTION("Float Test case: 1") {
-        const float testVal = 0.0f;
-        std::string result = jpm.Stringify <float>(testVal);
-        REQUIRE(result == "0.0");
+    SECTION("double Test case: 1") {
+        const double testVal = 123;
+        double temp;
+        jpm.Parse<double>(jpm.Stringify(testVal), temp);
+        REQUIRE(temp == testVal);    
     }
 
-    SECTION("Float Test case: 2") {
-        const float testVal = 0.0001f;
-        std::string result = jpm.Stringify <float>(testVal);
-        REQUIRE(result == "0.0001");
+    SECTION("double Test case: 2") {
+        const double testVal = 123.0;
+        double temp;
+        jpm.Parse<double>(jpm.Stringify(testVal), temp);
+        REQUIRE(temp == testVal);    
     }
 
+    SECTION("double Test case: 3") {
+        const double testVal = 123.00001;
+        double temp;
+        jpm.Parse<double>(jpm.Stringify(testVal), temp);
+        REQUIRE(temp == testVal);    
+    }
 
+    SECTION("float Test case: 1") {
+        const float testVal = 123.0001f;
+        float temp;
+        jpm.Parse<float>(jpm.Stringify(testVal), temp);
+        REQUIRE(temp == testVal);    
+    }
+
+    SECTION("float Test case: 2") {
+        const float testVal = 123.0f;
+        float temp;
+        jpm.Parse<float>(jpm.Stringify(testVal), temp);
+        REQUIRE(temp == testVal);    
+    }
 
 }
 

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -317,49 +317,62 @@ TEST_CASE("JParameterManager_ArrayParams") {
     }
 }
 
-TEST_CASE("JParamter: Issue 233:") {
+TEST_CASE("JParameter: Issue 233") {
     JParameterManager jpm;
 
-    SECTION("int Test case: ") {
-        const int testVal = 123;
-        int temp;
-        jpm.Parse<int>(jpm.Stringify(testVal), temp);
-        REQUIRE(temp == testVal);    
+    SECTION("Integer") {
+        const std::string testValString = jpm.Stringify(123);
+        REQUIRE(testValString == "123");
+        int testValParsed;
+        jpm.Parse<int>(testValString, testValParsed);
+        REQUIRE(testValParsed == 123);
     }
 
-    SECTION("double Test case: 1") {
+    SECTION("Double requiring low precision") {
         const double testVal = 123;
-        double temp;
-        jpm.Parse<double>(jpm.Stringify(testVal), temp);
-        REQUIRE(temp == testVal);    
+        const std::string testValString = jpm.Stringify(testVal);
+        REQUIRE(testValString == "123");
+        double testValParsed;
+        jpm.Parse<double>(testValString, testValParsed);
+        REQUIRE(testValParsed == 123.0);
     }
 
-    SECTION("double Test case: 2") {
+    SECTION("Double requiring low precision, with extra zeros") {
         const double testVal = 123.0;
-        double temp;
-        jpm.Parse<double>(jpm.Stringify(testVal), temp);
-        REQUIRE(temp == testVal);    
+        const std::string testValString = jpm.Stringify(testVal);
+        REQUIRE(testValString == "123");
+        double testValParsed;
+        jpm.Parse<double>(testValString, testValParsed);
+        REQUIRE(testValParsed == 123.0);
     }
 
-    SECTION("double Test case: 3") {
-        const double testVal = 123.00001;
-        double temp;
-        jpm.Parse<double>(jpm.Stringify(testVal), temp);
-        REQUIRE(temp == testVal);    
+    SECTION("Double requiring high precision") {
+        const double testVal = 123.0001;
+        const std::string testValString = jpm.Stringify(testVal);
+        std::cout << "High-precision double stringified to " << testValString << std::endl;
+        // REQUIRE(testValString == "123.0001");
+        double testValParsed;
+        jpm.Parse<double>(testValString, testValParsed);
+        REQUIRE(testValParsed == 123.0001);
     }
 
-    SECTION("float Test case: 1") {
+    SECTION("Float requiring high precision") {
         const float testVal = 123.0001f;
-        float temp;
-        jpm.Parse<float>(jpm.Stringify(testVal), temp);
-        REQUIRE(temp == testVal);    
+        const std::string testValString = jpm.Stringify(testVal);
+        std::cout << "High-precision float stringified to " << testValString << std::endl;
+        // REQUIRE(testValString == "123.0001");
+        float testValParsed;
+        jpm.Parse<float>(testValString, testValParsed);
+        REQUIRE(testValParsed == 123.0001f);
     }
 
-    SECTION("float Test case: 2") {
+    SECTION("Float requiring low precision") {
         const float testVal = 123.0f;
-        float temp;
-        jpm.Parse<float>(jpm.Stringify(testVal), temp);
-        REQUIRE(temp == testVal);    
+        const std::string testValString = jpm.Stringify(testVal);
+        REQUIRE(testValString == "123");
+        float testValParsed;
+        jpm.Parse<float>(testValString, testValParsed);
+        REQUIRE(testValParsed == 123.0f);
     }
 
 }


### PR DESCRIPTION
Handling the precision for float and double when stringified. New specialization for float and double has been added. 
[X] New test cases added.
[X] Existing test cases passed