### PR TITLE
JParameterManager gives clean error messages for unsupported types (Addresses issue #132)

### DIFF
--- a/src/libraries/JANA/Utils/JTypeInfo.h
+++ b/src/libraries/JANA/Utils/JTypeInfo.h
@@ -12,6 +12,20 @@
 
 namespace JTypeInfo {
 
+
+template <typename, typename=void>
+struct is_parseable : std::false_type {};
+
+template <typename T>
+struct is_parseable<T, std::void_t<decltype(std::declval<std::istream>() >> std::declval<T&>())>> : std::true_type {};
+
+template <typename, typename=void>
+struct is_serializable : std::false_type {};
+
+template <typename T>
+struct is_serializable<T, std::void_t<decltype(std::declval<std::ostream>() << std::declval<T>())>> : std::true_type {};
+
+
 template<typename T>
 std::string demangle(void) {
 

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -402,4 +402,35 @@ TEST_CASE("JParameterManager_Issue217StringsWithWhitespace") {
     }
 }
 
+#if __cplusplus >= 201703L
+template <typename T>
+void fakeParse(std::string s, T& out) {
+    constexpr bool parseable = JTypeInfo::is_parseable<T>::value;
+    static_assert(parseable, "Type is not automatically supported by the ParameterManager. To use, implement a template specialization for Parse(std::string in, T& out).");
+    if constexpr (parseable) {
+        std::stringstream ss;
+        ss >> out;
+    }
+}
+#else
+template <typename T>
+void fakeParse(std::string s, T& out) {
+    std::stringstream ss;
+    ss >> out;
+}
+#endif
+}
+
+
+enum class Mood {Good, Bad, Mediocre};
+TEST_CASE("Error message on bad parse") {
+    int x;
+    fakeParse("22", x);
+    Mood m;
+    fakeParse("Mediocre", m);
+}
+
+
+
+
 

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -402,32 +402,16 @@ TEST_CASE("JParameterManager_Issue217StringsWithWhitespace") {
     }
 }
 
-#if __cplusplus >= 201703L
-template <typename T>
-void fakeParse(std::string s, T& out) {
-    constexpr bool parseable = JTypeInfo::is_parseable<T>::value;
-    static_assert(parseable, "Type is not automatically supported by the ParameterManager. To use, implement a template specialization for Parse(std::string in, T& out).");
-    if constexpr (parseable) {
-        std::stringstream ss;
-        ss >> out;
-    }
-}
-#else
-template <typename T>
-void fakeParse(std::string s, T& out) {
-    std::stringstream ss;
-    ss >> out;
-}
-#endif
-}
-
 
 enum class Mood {Good, Bad, Mediocre};
-TEST_CASE("Error message on bad parse") {
+TEST_CASE("JParameterManager_CompileTimeErrorForParseAndStringify") {
+
     int x;
-    fakeParse("22", x);
+    JParameterManager::Parse("22", x);
     Mood m;
-    fakeParse("Mediocre", m);
+    // Uncomment these to test compile-time error message
+    //JParameterManager::Parse("Mediocre", m);
+    //JParameterManager::Stringify(m);
 }
 
 


### PR DESCRIPTION
Previously, the compiler would emit hundreds of lines of failed template matches for `operator<<`. 

Now, it emits the following:
```
Type is not automatically serializable by JParameterManager. To use, provide a template specialization for JParameterManager::Stringify(const T& val) -> std::string.
```