### PR TITLE
fix: link_libraries against podio, podioRootIO in tld CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ if (${USE_PODIO})
     find_package(podio REQUIRED)
     add_compile_definitions(HAVE_PODIO)
     include_directories(SYSTEM ${podio_INCLUDE_DIR})
-    link_libraries(podio::podio podio::podioRootIO)
+    target_link_libraries(jana2_shared_lib podio::podio podio::podioRootIO)
 endif()
 
 #---------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ if (${USE_PODIO})
     find_package(podio REQUIRED)
     add_compile_definitions(HAVE_PODIO)
     include_directories(SYSTEM ${podio_INCLUDE_DIR})
+    link_libraries(podio::podio podio::podioRootIO)
 endif()
 
 #---------


### PR DESCRIPTION
Without linking, the shared library only 'happens to work' in older gcc versions because no NEEDED entries are included in the shared library:
```
$ readelf -d /opt/software/linux-ubuntu23.10-skylake/gcc-13.2.0/jana2-2.1.1-2vzfopkybqjsifmxc2bodpydpv3bthiv/lib/libJANA.so 

Dynamic section at offset 0x167618 contains 31 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libCore.so.6.28]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x000000000000000e (SONAME)             Library soname: [libJANA.so]
```
This causes linking errors in EICrecon (undefined references to ROOTFrameWriter functions).

After including podio in the linking, the necessary entries are there:
```
$ readelf -d /opt/software/linux-ubuntu23.10-skylake/gcc-13.2.0/jana2-master-7j2vwskbvoq45ibyuvnlh2qr6gfuvpce/lib/libJANA.so 

Dynamic section at offset 0x1685f8 contains 33 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libCore.so.6.28]
 0x0000000000000001 (NEEDED)             Shared library: [libpodioRootIO.so]
 0x0000000000000001 (NEEDED)             Shared library: [libpodio.so]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x000000000000000e (SONAME)             Library soname: [libJANA.so]
```

Note: It may make sense to revamp the CMakeLists.txt here to avoid this blanket link_libraries approach, and switch to a more granular target_link_libraries approach. See the note at https://cmake.org/cmake/help/latest/command/link_libraries.html.