### PR TITLE
Removing duplicate copying into input vector in SetDefaultParameter

### DIFF
--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -237,6 +237,7 @@ JParameter* JParameterManager::SetDefaultParameter(std::string name, T& val, std
     std::lock_guard<std::mutex> lock(m_mutex);
     JParameter* param = nullptr;
     T t;
+    T t1;
     auto result = m_parameters.find(ToLower(name));
     if (result != m_parameters.end()) {
         // We already have a value stored for this parameter
@@ -284,8 +285,8 @@ JParameter* JParameterManager::SetDefaultParameter(std::string name, T& val, std
 
     // Always put val through the stringification/parsing cycle to be consistent with
     // values passed in from config file, accesses from other threads
-    Parse(param->GetValue(),t);
-    val = t;
+    Parse(param->GetValue(),t1);
+    val = t1;
     param->SetIsUsed(true);
     return param;
 }

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -237,7 +237,6 @@ JParameter* JParameterManager::SetDefaultParameter(std::string name, T& val, std
     std::lock_guard<std::mutex> lock(m_mutex);
     JParameter* param = nullptr;
     T t;
-    T t1;
     auto result = m_parameters.find(ToLower(name));
     if (result != m_parameters.end()) {
         // We already have a value stored for this parameter
@@ -367,7 +366,7 @@ template<typename T>
 inline void JParameterManager::Parse(const std::string& value, std::vector<T> &val) {
     std::stringstream ss(value);
     std::string s;
-    val.clear(); // clearing the input vector to make remove dulication which can be caused due to val.push_back(t);
+    val.clear(); // clearing the input vector to ensure no dulication which can be caused due to val.push_back(t);
     while (getline(ss, s, ',')) {
         T t;
         Parse(s, t);

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -285,8 +285,8 @@ JParameter* JParameterManager::SetDefaultParameter(std::string name, T& val, std
 
     // Always put val through the stringification/parsing cycle to be consistent with
     // values passed in from config file, accesses from other threads
-    Parse(param->GetValue(),t1);
-    val = t1;
+    Parse(param->GetValue(),t);
+    val = t;
     param->SetIsUsed(true);
     return param;
 }
@@ -367,6 +367,7 @@ template<typename T>
 inline void JParameterManager::Parse(const std::string& value, std::vector<T> &val) {
     std::stringstream ss(value);
     std::string s;
+    val.clear(); // clearing the input vector to make remove dulication which can be caused due to val.push_back(t);
     while (getline(ss, s, ',')) {
         T t;
         Parse(s, t);

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -192,7 +192,6 @@ TEST_CASE("JParameterManager_VectorParams") {
         inputs.emplace_back(" third one ");
 
         jpm.SetDefaultParameter("test", inputs);
-        std::cout << " Size of the vector after calling the SetDefaultParameter" << inputs.size() << std::endl;
         std::vector<std::string> outputs;
         auto param = jpm.GetParameter("test", outputs);
         REQUIRE(param->GetValue() == "first,second one, third one ");

--- a/src/programs/tests/JParameterManagerTests.cc
+++ b/src/programs/tests/JParameterManagerTests.cc
@@ -192,9 +192,11 @@ TEST_CASE("JParameterManager_VectorParams") {
         inputs.emplace_back(" third one ");
 
         jpm.SetDefaultParameter("test", inputs);
+        std::cout << " Size of the vector after calling the SetDefaultParameter" << inputs.size() << std::endl;
         std::vector<std::string> outputs;
         auto param = jpm.GetParameter("test", outputs);
         REQUIRE(param->GetValue() == "first,second one, third one ");
+        REQUIRE(inputs.size()==3); // an additional test to see that the size of the input vector remains the same: Issue #256
     }
     SECTION("Reading a vector of ints") {
         jpm.SetParameter("test", "1,2, 3 ");


### PR DESCRIPTION
Change is made to make sure that the input vector reference is not duplicated.

[x] Code changes made 
[x] Test case added