### PR TITLE
Deprecate PodioTypeMap

### DIFF
--- a/src/examples/PodioExample/DatamodelGlue.h
+++ b/src/examples/PodioExample/DatamodelGlue.h
@@ -6,6 +6,8 @@
 #ifndef JANA2_DATAMODELGLUE_H
 #define JANA2_DATAMODELGLUE_H
 
+#include <podio/podioVersion.h>
+
 #include <datamodel/ExampleHit.h>
 #include <datamodel/ExampleHitCollection.h>
 #include <datamodel/ExampleCluster.h>
@@ -13,6 +15,8 @@
 #include <datamodel/EventInfo.h>
 #include <datamodel/EventInfoCollection.h>
 
+#if podio_VERSION < PODIO_VERSION(0, 17, 0)
+/// Legacy PODIO support
 template <typename T>
 struct PodioTypeMap {
 };
@@ -34,6 +38,7 @@ struct PodioTypeMap<EventInfo> {
     using mutable_t = MutableEventInfo;
     using collection_t = EventInfoCollection;
 };
+#endif
 
 
 template<typename ... Ts>
@@ -61,7 +66,7 @@ void visitPodioType(const std::string& podio_typename, F& helper, ArgsT... args)
 /*
            visitPodioType(coll->getValueTypeName(),
                [&]<typename T>(const podio::CollectionBase* coll, std::string name) {
-                   using CollT = const typename PodioTypeMap<T>::collection_t;
+                   using CollT = const typename T::collection_type;
                    CollT* typed_col = static_cast<CollT*>(coll);
 
                    std::cout << name << std::endl;

--- a/src/examples/PodioExample/PodioExampleProcessor.cc
+++ b/src/examples/PodioExample/PodioExampleProcessor.cc
@@ -11,7 +11,7 @@ struct PrintingVisitor {
     template <typename T>
     void operator() (const podio::CollectionBase* collection, std::string collection_name) {
 
-        auto* typed_collection = static_cast<const typename PodioTypeMap<T>::collection_t*>(collection);
+        auto* typed_collection = static_cast<const typename T::collection_type*>(collection);
 
         std::cout << collection_name << " :: " << collection->getValueTypeName() << " = [";
         for (const T& object : *typed_collection) {

--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -102,9 +102,9 @@ class JEvent : public JResettable, public std::enable_shared_from_this<JEvent>
 #ifdef HAVE_PODIO
         std::vector<std::string> GetAllCollectionNames() const;
         const podio::CollectionBase* GetCollectionBase(std::string name) const;
-        template <typename T> const typename PodioTypeMap<T>::collection_t* GetCollection(std::string name) const;
-        template <typename T> JFactoryPodioT<T>* InsertCollection(typename PodioTypeMap<T>::collection_t&& collection, std::string name);
-        template <typename T> JFactoryPodioT<T>* InsertCollectionAlreadyInFrame(const typename PodioTypeMap<T>::collection_t* collection, std::string name);
+        template <typename T> const typename JFactoryPodioT<T>::CollectionT* GetCollection(std::string name) const;
+        template <typename T> JFactoryPodioT<T>* InsertCollection(typename JFactoryPodioT<T>::CollectionT&& collection, std::string name);
+        template <typename T> JFactoryPodioT<T>* InsertCollectionAlreadyInFrame(const typename JFactoryPodioT<T>::CollectionT* collection, std::string name);
 #endif
 
         //SETTERS
@@ -457,7 +457,7 @@ inline const podio::CollectionBase* JEvent::GetCollectionBase(std::string name) 
 }
 
 template <typename T>
-const typename PodioTypeMap<T>::collection_t* JEvent::GetCollection(std::string name) const {
+const typename JFactoryPodioT<T>::CollectionT* JEvent::GetCollection(std::string name) const {
     JFactoryT<T>* factory = GetFactory<T>(name, true);
     JFactoryPodioT<T>* typed_factory = dynamic_cast<JFactoryPodioT<T>*>(factory);
     if (typed_factory == nullptr) {
@@ -465,12 +465,12 @@ const typename PodioTypeMap<T>::collection_t* JEvent::GetCollection(std::string 
     }
     JCallGraphEntryMaker cg_entry(mCallGraph, typed_factory); // times execution until this goes out of scope
     typed_factory->Create(this->shared_from_this());
-    return static_cast<const typename PodioTypeMap<T>::collection_t*>(typed_factory->GetCollection());
+    return static_cast<const typename JFactoryPodioT<T>::CollectionT*>(typed_factory->GetCollection());
 }
 
 
 template <typename T>
-JFactoryPodioT<T>* JEvent::InsertCollection(typename PodioTypeMap<T>::collection_t&& collection, std::string name) {
+JFactoryPodioT<T>* JEvent::InsertCollection(typename JFactoryPodioT<T>::CollectionT&& collection, std::string name) {
     /// InsertCollection inserts the provided PODIO collection into both the podio::Frame and then a JFactoryPodioT<T>
 
     auto frame = GetOrCreateFrame(shared_from_this());
@@ -480,7 +480,7 @@ JFactoryPodioT<T>* JEvent::InsertCollection(typename PodioTypeMap<T>::collection
 
 
 template <typename T>
-JFactoryPodioT<T>* JEvent::InsertCollectionAlreadyInFrame(const typename PodioTypeMap<T>::collection_t* collection, std::string name) {
+JFactoryPodioT<T>* JEvent::InsertCollectionAlreadyInFrame(const typename JFactoryPodioT<T>::CollectionT* collection, std::string name) {
     /// InsertCollection inserts the provided PODIO collection into a JFactoryPodioT<T>. It assumes that the collection pointer
     /// is _already_ owned by the podio::Frame corresponding to this JEvent. This is meant to be used if you are starting out
     /// with a PODIO frame (e.g. a JEventSource that uses podio::ROOTFrameReader).

--- a/src/libraries/JANA/JMultifactory.h
+++ b/src/libraries/JANA/JMultifactory.h
@@ -106,10 +106,10 @@ public:
     void DeclarePodioOutput(std::string tag, bool owns_data=true);
 
     template <typename T>
-    void SetCollection(std::string tag, typename PodioTypeMap<T>::collection_t&& collection);
+    void SetCollection(std::string tag, typename JFactoryPodioT<T>::CollectionT&& collection);
 
     template <typename T>
-    void SetCollection(std::string tag, std::unique_ptr<typename PodioTypeMap<T>::collection_t> collection);
+    void SetCollection(std::string tag, std::unique_ptr<typename JFactoryPodioT<T>::CollectionT> collection);
 
 #endif
 
@@ -183,7 +183,7 @@ void JMultifactory::DeclarePodioOutput(std::string tag, bool owns_data) {
 }
 
 template <typename T>
-void JMultifactory::SetCollection(std::string tag, typename PodioTypeMap<T>::collection_t&& collection) {
+void JMultifactory::SetCollection(std::string tag, typename JFactoryPodioT<T>::CollectionT&& collection) {
     JFactoryT<T>* helper = mHelpers.GetFactory<T>(tag);
     if (helper == nullptr) {
         throw JException("JMultifactory: Attempting to SetData() without corresponding DeclareOutput()");
@@ -198,7 +198,7 @@ void JMultifactory::SetCollection(std::string tag, typename PodioTypeMap<T>::col
 }
 
 template <typename T>
-void JMultifactory::SetCollection(std::string tag, std::unique_ptr<typename PodioTypeMap<T>::collection_t> collection) {
+void JMultifactory::SetCollection(std::string tag, std::unique_ptr<typename JFactoryPodioT<T>::CollectionT> collection) {
     JFactoryT<T>* helper = mHelpers.GetFactory<T>(tag);
     if (helper == nullptr) {
         throw JException("JMultifactory: Attempting to SetData() without corresponding DeclareOutput()");

--- a/src/libraries/JANA/Podio/JPodioTypeHelpers.h
+++ b/src/libraries/JANA/Podio/JPodioTypeHelpers.h
@@ -8,14 +8,9 @@
 
 #include <type_traits>
 
+#include <podio/podioVersion.h>
+
 /// These allow us to have both a PODIO-enabled and a PODIO-free definition of certain key structures and functions.
-/// Ideally, we would use concepts for this. However, we are limiting ourselves to C++17 for now.
-/// The user is expected to provide some datamodel glue which specializes PodioTypeMap like this:
-///    template <> struct PodioTypeMap<ExampleHit> {
-///        using collection_t = ExampleHitCollection;
-///        using mutable_t = MutableExampleHit;
-///    }
-/// Eventually we hope to hang these type relations off of the Podio types themselves.
 
 #ifdef HAVE_PODIO
 // Sadly, this will only work with C++17 or higher, and for now JANA still supports C++14 (when not using PODIO)
@@ -27,7 +22,16 @@ template <typename, typename=void>
 struct is_podio : std::false_type {};
 
 template <typename T>
+#if podio_VERSION >= PODIO_VERSION(0, 17, 0)
+struct is_podio<T, std::void_t<typename T::collection_type>> : std::true_type {};
+#else
+/// The user was expected to provide some datamodel glue which specializes PodioTypeMap like this:
+///    template <> struct PodioTypeMap<ExampleHit> {
+///        using collection_t = ExampleHitCollection;
+///        using mutable_t = MutableExampleHit;
+///    }
 struct is_podio<T, std::void_t<typename PodioTypeMap<T>::collection_t>> : std::true_type {};
+#endif
 
 template <typename T>
 static constexpr bool is_podio_v = is_podio<T>::value;

--- a/src/programs/unit_tests/PodioTests.cc
+++ b/src/programs/unit_tests/PodioTests.cc
@@ -203,7 +203,7 @@ struct MyWrapper {
 };
 
 template <typename T>
-struct MyWrapper<T, std::void_t<typename PodioTypeMap<T>::collection_t>> {
+struct MyWrapper<T, std::void_t<typename T::collection_type>> {
     int x = 2;
     bool have_podio() {
         return true;
@@ -224,7 +224,7 @@ template <typename, typename=void>
 struct is_podio : std::false_type {};
 
 template <typename T>
-struct is_podio<T, std::void_t<typename PodioTypeMap<T>::collection_t>> : std::true_type {};
+struct is_podio<T, std::void_t<typename T::collection_type>> : std::true_type {};
 
 template <typename T>
 static constexpr bool is_podio_v = is_podio<T>::value;


### PR DESCRIPTION
Similarly to https://github.com/eic/EICrecon/pull/1108, this relies on https://github.com/AIDASoft/podio/pull/465 to get rid of a need to declare PodioTypeMap as long as PODIO is of a recent version.