### PR TITLE
PodioExample: add schema_version

### DIFF
--- a/src/examples/PodioExample/layout.yaml
+++ b/src/examples/PodioExample/layout.yaml
@@ -1,6 +1,7 @@
 ---
 # A more complete example is provided by podio under tests/datalayout.yaml
 
+schema_version: 1
 options :
   # should getters / setters be prefixed with get / set?
   getSyntax: False


### PR DESCRIPTION
Prevents the CMake warning:
```
python/podio_gen/generator_base.py:105: FutureWarning: Please provide a schema_version entry. It will become mandatory. Setting it to 1 as default
```