### PR TITLE
fix: no copy constructor in PodioExample.cc

### DIFF
--- a/src/examples/PodioExample/PodioExample.cc
+++ b/src/examples/PodioExample/PodioExample.cc
@@ -26,10 +26,10 @@ void create_hits_file() {
     eventinfos1.push_back(eventinfo1);
 
     ExampleHitCollection hits1;
-    hits1.push_back(ExampleHit({22, -1, -1, 0, 100}));
-    hits1.push_back(ExampleHit({49, 1, 1, 0, 15.5}));
-    hits1.push_back(ExampleHit({47, 1, 2, 0, 0.5}));
-    hits1.push_back(ExampleHit({42, 2, 1, 0, 4.0}));
+    hits1.push_back(ExampleHit(22, -1, -1, 0, 100));
+    hits1.push_back(ExampleHit(49, 1, 1, 0, 15.5));
+    hits1.push_back(ExampleHit(47, 1, 2, 0, 0.5));
+    hits1.push_back(ExampleHit(42, 2, 1, 0, 4.0));
 
     podio::Frame event1;
     event1.put(std::move(hits1), "hits");
@@ -43,10 +43,10 @@ void create_hits_file() {
     eventinfos2.push_back(eventinfo2);
 
     ExampleHitCollection hits2;
-    hits2.push_back(ExampleHit({42, 5, -5, 5, 7.6}));
-    hits2.push_back(ExampleHit({618, -3, -5, 1, 99.9}));
-    hits2.push_back(ExampleHit({27, -10, 10, 10, 22.2}));
-    hits2.push_back(ExampleHit({28, -9, 11, 10, 7.8}));
+    hits2.push_back(ExampleHit(42, 5, -5, 5, 7.6));
+    hits2.push_back(ExampleHit(618, -3, -5, 1, 99.9));
+    hits2.push_back(ExampleHit(27, -10, 10, 10, 22.2));
+    hits2.push_back(ExampleHit(28, -9, 11, 10, 7.8));
 
     podio::Frame event2;
     event2.put(std::move(hits2), "hits");


### PR DESCRIPTION
Due to https://github.com/AIDASoft/podio/pull/564 we get compilation errors:
```
  >> 322    /home/wdconinc/git/JANA2/src/examples/PodioExample/PodioExample.cc:46:51: error: call of overloaded 'ExampleHit(<brace-enclosed initializer list>)' is ambiguous
     323       46 |     hits2.push_back(ExampleHit({42, 5, -5, 5, 7.6}));
     324          |                                                   ^
     325    In file included from /home/wdconinc/git/JANA2/src/examples/PodioExample/datamodel/MutableExampleHit.h:8,
     326                     from /home/wdconinc/git/JANA2/src/examples/PodioExample/PodioExample.cc:7:
     327    /home/wdconinc/git/JANA2/src/examples/PodioExample/./datamodel/ExampleHit.h:59:3: note: candidate: 'ExampleHit::ExampleHit(const MutableExampleHit&)'
     328       59 |   ExampleHit(const MutableExampleHit& other);
     329          |   ^~~~~~~~~~
     330    /home/wdconinc/git/JANA2/src/examples/PodioExample/./datamodel/ExampleHit.h:47:3: note: candidate: 'ExampleHit::ExampleHit(const ExampleHit&)'
     331       47 |   ExampleHit(const ExampleHit& other) = default;
     332          |   ^~~~~~~~~~
```
This PR removes the ambiguity that is present by passing an initializer list to a constructor.

After this commit, JANA2 compiles both before and after podio PR 564 (and also with v00-17-03 which is before https://github.com/AIDASoft/podio/pull/514 which led to https://github.com/JeffersonLab/JANA2/pull/269). There is no minimum podio version specified in CMakeLists.txt to test with.