### PR TITLE
JService is now a JComponent

### DIFF
--- a/src/libraries/JANA/CLI/JBenchmarker.cc
+++ b/src/libraries/JANA/CLI/JBenchmarker.cc
@@ -5,7 +5,7 @@
 #include "JBenchmarker.h"
 
 #include <JANA/Utils/JCpuInfo.h>
-#include <JANA/JLogger.h>
+#include <JANA/Services/JLoggingService.h>
 
 #include <fstream>
 #include <cmath>

--- a/src/libraries/JANA/CMakeLists.txt
+++ b/src/libraries/JANA/CMakeLists.txt
@@ -24,6 +24,7 @@ set(JANA2_SOURCES
     JLogger.h
     JMultifactory.cc
     JMultifactory.h
+    JService.cc
 
     Engine/JArrow.h
     Engine/JArrowMetrics.h

--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -24,8 +24,8 @@ JApplication::JApplication(JLogger::Level verbosity) {
     m_service_locator->provide(m_params);
     ProvideService(m_params);
     ProvideService(std::make_shared<JLoggingService>());
-    ProvideService(std::make_shared<JPluginLoader>(this));
-    ProvideService(std::make_shared<JComponentManager>(this));
+    ProvideService(std::make_shared<JPluginLoader>());
+    ProvideService(std::make_shared<JComponentManager>());
     ProvideService(std::make_shared<JGlobalRootLock>());
     ProvideService(std::make_shared<JTopologyBuilder>());
 
@@ -48,7 +48,7 @@ JApplication::JApplication(JParameterManager* params) {
     ProvideService(m_params);
     ProvideService(std::make_shared<JLoggingService>());
     ProvideService(std::make_shared<JPluginLoader>());
-    ProvideService(std::make_shared<JComponentManager>(this));
+    ProvideService(std::make_shared<JComponentManager>());
     ProvideService(std::make_shared<JGlobalRootLock>());
     ProvideService(std::make_shared<JTopologyBuilder>());
 
@@ -119,6 +119,10 @@ void JApplication::Initialize() {
     // Only run this once
     if (m_initialized) return;
 
+    // Obtain final values of parameters and loggers
+    m_plugin_loader->InitPhase2();
+    m_component_manager->InitPhase2();
+
     // Attach all plugins
     m_plugin_loader->attach_plugins(m_component_manager.get());
 
@@ -137,7 +141,7 @@ void JApplication::Initialize() {
     m_params->SetDefaultParameter("jana:ticker_interval", m_ticker_interval_ms, "Controls the ticker interval (in ms)");
     m_params->SetDefaultParameter("jana:extended_report", m_extended_report, "Controls whether the ticker shows simple vs detailed performance metrics");
 
-    m_component_manager->initialize();
+    m_component_manager->resolve_event_sources();
 
     /*
     int engine_choice = 0;

--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -22,11 +22,12 @@ JApplication::JApplication(JLogger::Level verbosity) {
     m_params = std::make_shared<JParameterManager>();
     m_params->SetParameter("log:global", verbosity);
     m_service_locator->provide(m_params);
-    m_service_locator->provide(std::make_shared<JLoggingService>());
-    m_service_locator->provide(std::make_shared<JPluginLoader>(this));
-    m_service_locator->provide(std::make_shared<JComponentManager>(this));
-    m_service_locator->provide(std::make_shared<JGlobalRootLock>());
-    m_service_locator->provide(std::make_shared<JTopologyBuilder>());
+    ProvideService(m_params);
+    ProvideService(std::make_shared<JLoggingService>());
+    ProvideService(std::make_shared<JPluginLoader>(this));
+    ProvideService(std::make_shared<JComponentManager>(this));
+    ProvideService(std::make_shared<JGlobalRootLock>());
+    ProvideService(std::make_shared<JTopologyBuilder>());
 
     m_plugin_loader = m_service_locator->get<JPluginLoader>();
     m_component_manager = m_service_locator->get<JComponentManager>();
@@ -44,12 +45,12 @@ JApplication::JApplication(JParameterManager* params) {
     }
 
     m_service_locator = new JServiceLocator;
-    m_service_locator->provide(m_params);
-    m_service_locator->provide(std::make_shared<JLoggingService>());
-    m_service_locator->provide(std::make_shared<JPluginLoader>(this));
-    m_service_locator->provide(std::make_shared<JComponentManager>(this));
-    m_service_locator->provide(std::make_shared<JGlobalRootLock>());
-    m_service_locator->provide(std::make_shared<JTopologyBuilder>());
+    ProvideService(m_params);
+    ProvideService(std::make_shared<JLoggingService>());
+    ProvideService(std::make_shared<JPluginLoader>());
+    ProvideService(std::make_shared<JComponentManager>(this));
+    ProvideService(std::make_shared<JGlobalRootLock>());
+    ProvideService(std::make_shared<JTopologyBuilder>());
 
     m_plugin_loader = m_service_locator->get<JPluginLoader>();
     m_component_manager = m_service_locator->get<JComponentManager>();

--- a/src/libraries/JANA/JApplication.h
+++ b/src/libraries/JANA/JApplication.h
@@ -45,6 +45,7 @@ std::shared_ptr<T> JApplication::GetService() {
 /// A convenience method which delegates to JServiceLocator
 template <typename T>
 void JApplication::ProvideService(std::shared_ptr<T> service) {
+    service->SetApplication(this);
     m_service_locator->provide(service);
 }
 

--- a/src/libraries/JANA/JApplication.h
+++ b/src/libraries/JANA/JApplication.h
@@ -2,164 +2,11 @@
 // Copyright 2020, Jefferson Science Associates, LLC.
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
-#ifndef _JApplication_h_
-#define _JApplication_h_
-
-#include <vector>
-#include <string>
-#include <iostream>
-#include <atomic>
-
-class JApplication;
-class JEventProcessor;
-class JEventSource;
-class JEventSourceGenerator;
-class JFactoryGenerator;
-class JFactorySet;
-class JComponentManager;
-class JPluginLoader;
-class JProcessingController;
-class JEventUnfolder;
-
-extern JApplication* japp;
+#pragma once
+#include <JANA/JApplicationFwd.h>
 
 #include <JANA/Services/JServiceLocator.h>
 #include <JANA/Services/JParameterManager.h>
-#include <JANA/Services/JLoggingService.h>
-#include <JANA/Status/JComponentSummary.h>
-#include <JANA/Status/JPerfSummary.h>
-
-
-//////////////////////////////////////////////////////////////////////////////////////////////////
-/// JANA application class
-///
-/// The JApplication class serves as a central access point for getting to most things
-/// in the JANA application. It owns the JThreadManager, JParameterManager, etc.
-/// It is also responsible for making sure all of the plugins are attached and other
-/// user specified configurations for the run are implemented before starting the processing
-/// of the data. User code (e.g. plugins) will generally register things like event sources
-/// and processors with the JApplication so they can be called up later at the appropriate time.
-//////////////////////////////////////////////////////////////////////////////////////////////////
-class JApplication {
-
-public:
-
-    /// These exit codes are what JANA uses internally. However they are fundamentally a suggestion --
-    /// the user code is likely to use arbitrary exit codes.
-    enum class ExitCode {Success=0, UnhandledException, Timeout, Segfault=139};
-
-    explicit JApplication(JParameterManager* params = nullptr);
-    explicit JApplication(JLogger::Level verbosity);
-    ~JApplication();
-
-
-    // Loading plugins
-
-    void AddPlugin(std::string plugin_name);
-    void AddPluginPath(std::string path);
-
-
-    // Building a JProcessingTopology
-
-    void Add(std::string event_source_name);
-    void Add(JEventSourceGenerator* source_generator);
-    void Add(JFactoryGenerator* factory_generator);
-    void Add(JEventSource* event_source);
-    void Add(JEventProcessor* processor);
-    void Add(JEventUnfolder* unfolder);
-
-
-    // Controlling processing
-
-    void Initialize(void);
-    void Run(bool wait_until_finished = true);
-    void Scale(int nthreads);
-    void Stop(bool wait_until_idle = false);
-    void Resume() {};  // TODO: Do we need this?
-    void Quit(bool skip_join = false);
-    void SetExitCode(int exitCode);
-    int GetExitCode();
-
-
-    // Performance/status monitoring
-
-    bool IsInitialized(void){return m_initialized;}
-    bool IsQuitting(void) { return m_quitting; }
-    bool IsDrainingQueues(void) { return m_draining_queues; }
-
-    void SetTicker(bool ticker_on = true);
-    bool IsTickerEnabled();
-    void SetTimeoutEnabled(bool enabled = true);
-    bool IsTimeoutEnabled();
-    void PrintStatus();
-    void PrintFinalReport();
-    uint64_t GetNThreads();
-    uint64_t GetNEventsProcessed();
-    float GetIntegratedRate();
-    float GetInstantaneousRate();
-
-    JComponentSummary GetComponentSummary();
-
-    // Parameter config
-
-    JParameterManager* GetJParameterManager() { return m_params.get(); }
-
-    template<typename T>
-    T GetParameterValue(std::string name);
-
-    template <typename T>
-    JParameter* GetParameter(std::string name, T& val);
-
-    template<typename T>
-    JParameter* SetParameterValue(std::string name, T val);
-
-    template <typename T>
-    JParameter* SetDefaultParameter(std::string name, T& val, std::string description="");
-
-    template <typename T>
-    T RegisterParameter(std::string name, const T default_val, std::string description="");
-
-    // Locating services
-
-    /// Use this in EventSources, Factories, or EventProcessors. Do not call this
-    /// from InitPlugin(), as not all JServices may have been loaded yet.
-    /// When initializing a Service, use acquire_services() instead.
-    template <typename T>
-    std::shared_ptr<T> GetService();
-
-    /// Call this from InitPlugin.
-    template <typename T>
-    void ProvideService(std::shared_ptr<T> service);
-
-
-private:
-
-    JLogger m_logger;
-    JServiceLocator m_service_locator;
-
-    std::shared_ptr<JParameterManager> m_params;
-    std::shared_ptr<JPluginLoader> m_plugin_loader;
-    std::shared_ptr<JComponentManager> m_component_manager;
-    std::shared_ptr<JProcessingController> m_processing_controller;
-
-    bool m_quitting = false;
-    bool m_draining_queues = false;
-    bool m_skip_join = false;
-    std::atomic_bool m_initialized {false};
-    bool m_ticker_on = true;
-    bool m_timeout_on = true;
-    bool m_extended_report = false;
-    int  m_exit_code = (int) ExitCode::Success;
-    int  m_desired_nthreads;
-
-    std::mutex m_status_mutex;
-    int m_ticker_interval_ms = 1000;
-    std::chrono::time_point<std::chrono::high_resolution_clock> m_last_measurement;
-    std::unique_ptr<const JPerfSummary> m_perf_summary;
-
-    void update_status();
-};
-
 
 
 /// A convenience method which delegates to JParameterManager
@@ -192,25 +39,14 @@ JParameter* JApplication::GetParameter(std::string name, T& result) {
 /// A convenience method which delegates to JServiceLocator
 template <typename T>
 std::shared_ptr<T> JApplication::GetService() {
-    return m_service_locator.get<T>();
+    return m_service_locator->get<T>();
 }
 
 /// A convenience method which delegates to JServiceLocator
 template <typename T>
 void JApplication::ProvideService(std::shared_ptr<T> service) {
-    m_service_locator.provide(service);
+    m_service_locator->provide(service);
 }
 
 
-
-// This routine is used to bootstrap plugins. It is done outside
-// of the JApplication class to ensure it sees the global variables
-// that the rest of the plugin's InitPlugin routine sees.
-inline void InitJANAPlugin(JApplication* app) {
-    // Make sure global pointers are pointing to the
-    // same ones being used by executable
-    japp = app;
-}
-
-#endif // _JApplication_h_
 

--- a/src/libraries/JANA/JApplicationFwd.h
+++ b/src/libraries/JANA/JApplicationFwd.h
@@ -1,0 +1,170 @@
+
+// Copyright 2020, Jefferson Science Associates, LLC.
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+#include <string>
+#include <atomic>
+
+class JEventProcessor;
+class JEventSource;
+class JEventSourceGenerator;
+class JFactoryGenerator;
+class JFactorySet;
+class JComponentManager;
+class JPluginLoader;
+class JProcessingController;
+class JEventUnfolder;
+class JServiceLocator;
+class JParameter;
+class JParameterManager;
+class JApplication;
+extern JApplication* japp;
+
+#include <JANA/Status/JComponentSummary.h>
+#include <JANA/Status/JPerfSummary.h>
+#include <JANA/JLogger.h>
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// JANA application class
+///
+/// The JApplication class serves as a central access point for getting to most things
+/// in the JANA application. It owns the JThreadManager, JParameterManager, etc.
+/// It is also responsible for making sure all of the plugins are attached and other
+/// user specified configurations for the run are implemented before starting the processing
+/// of the data. User code (e.g. plugins) will generally register things like event sources
+/// and processors with the JApplication so they can be called up later at the appropriate time.
+//////////////////////////////////////////////////////////////////////////////////////////////////
+class JApplication {
+
+public:
+
+    /// These exit codes are what JANA uses internally. However they are fundamentally a suggestion --
+    /// the user code is likely to use arbitrary exit codes.
+    enum class ExitCode {Success=0, UnhandledException, Timeout, Segfault=139};
+
+    explicit JApplication(JParameterManager* params = nullptr);
+    explicit JApplication(JLogger::Level verbosity);
+    ~JApplication();
+
+
+    // Loading plugins
+
+    void AddPlugin(std::string plugin_name);
+    void AddPluginPath(std::string path);
+
+
+    // Building a JProcessingTopology
+
+    void Add(std::string event_source_name);
+    void Add(JEventSourceGenerator* source_generator);
+    void Add(JFactoryGenerator* factory_generator);
+    void Add(JEventSource* event_source);
+    void Add(JEventProcessor* processor);
+    void Add(JEventUnfolder* unfolder);
+
+
+    // Controlling processing
+
+    void Initialize(void);
+    void Run(bool wait_until_finished = true);
+    void Scale(int nthreads);
+    void Stop(bool wait_until_idle = false);
+    void Resume() {};  // TODO: Do we need this?
+    void Quit(bool skip_join = false);
+    void SetExitCode(int exitCode);
+    int GetExitCode();
+
+
+    // Performance/status monitoring
+
+    bool IsInitialized(void){return m_initialized;}
+    bool IsQuitting(void) { return m_quitting; }
+    bool IsDrainingQueues(void) { return m_draining_queues; }
+
+    void SetTicker(bool ticker_on = true);
+    bool IsTickerEnabled();
+    void SetTimeoutEnabled(bool enabled = true);
+    bool IsTimeoutEnabled();
+    void PrintStatus();
+    void PrintFinalReport();
+    uint64_t GetNThreads();
+    uint64_t GetNEventsProcessed();
+    float GetIntegratedRate();
+    float GetInstantaneousRate();
+
+    JComponentSummary GetComponentSummary();
+
+    // Parameter config
+
+    JParameterManager* GetJParameterManager() { return m_params.get(); }
+
+    template<typename T>
+    T GetParameterValue(std::string name);
+
+    template <typename T>
+    JParameter* GetParameter(std::string name, T& val);
+
+    template<typename T>
+    JParameter* SetParameterValue(std::string name, T val);
+
+    template <typename T>
+    JParameter* SetDefaultParameter(std::string name, T& val, std::string description="");
+
+    template <typename T>
+    T RegisterParameter(std::string name, const T default_val, std::string description="");
+
+    // Locating services
+
+    /// Use this in EventSources, Factories, or EventProcessors. Do not call this
+    /// from InitPlugin(), as not all JServices may have been loaded yet.
+    /// When initializing a Service, use acquire_services() instead.
+    template <typename T>
+    std::shared_ptr<T> GetService();
+
+    /// Call this from InitPlugin.
+    template <typename T>
+    void ProvideService(std::shared_ptr<T> service);
+
+
+private:
+
+    JLogger m_logger;
+    JServiceLocator* m_service_locator;
+
+    std::shared_ptr<JParameterManager> m_params;
+    std::shared_ptr<JPluginLoader> m_plugin_loader;
+    std::shared_ptr<JComponentManager> m_component_manager;
+    std::shared_ptr<JProcessingController> m_processing_controller;
+
+    bool m_quitting = false;
+    bool m_draining_queues = false;
+    bool m_skip_join = false;
+    std::atomic_bool m_initialized {false};
+    bool m_ticker_on = true;
+    bool m_timeout_on = true;
+    bool m_extended_report = false;
+    int  m_exit_code = (int) ExitCode::Success;
+    int  m_desired_nthreads;
+
+    std::mutex m_status_mutex;
+    int m_ticker_interval_ms = 1000;
+    std::chrono::time_point<std::chrono::high_resolution_clock> m_last_measurement;
+    std::unique_ptr<const JPerfSummary> m_perf_summary;
+
+    void update_status();
+};
+
+
+// This routine is used to bootstrap plugins. It is done outside
+// of the JApplication class to ensure it sees the global variables
+// that the rest of the plugin's InitPlugin routine sees.
+inline void InitJANAPlugin(JApplication* app) {
+    // Make sure global pointers are pointing to the
+    // same ones being used by executable
+    japp = app;
+}
+
+

--- a/src/libraries/JANA/JApplicationFwd.h
+++ b/src/libraries/JANA/JApplicationFwd.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <atomic>
+#include <mutex>
 #include <memory>
 #include <chrono>
 

--- a/src/libraries/JANA/JApplicationFwd.h
+++ b/src/libraries/JANA/JApplicationFwd.h
@@ -6,6 +6,8 @@
 
 #include <string>
 #include <atomic>
+#include <memory>
+#include <chrono>
 
 class JEventProcessor;
 class JEventSource;

--- a/src/libraries/JANA/JService.cc
+++ b/src/libraries/JANA/JService.cc
@@ -1,0 +1,40 @@
+// Copyright 2024, Jefferson Science Associates, LLC.
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#include <JANA/JService.h>
+#include <JANA/JException.h>
+
+
+void JService::DoInit(JServiceLocator* sl) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    try {
+        for (auto* parameter : m_parameters) {
+            parameter->Configure(*(m_app->GetJParameterManager()), m_prefix);
+        }
+        for (auto* service : m_services) {
+            service->Init(GetApplication());  // TODO: This badly needs to be renamed. Maybe Fetch?
+        }
+        this->acquire_services(sl);
+        this->Init();
+        this->m_status = Status::Initialized;
+    }
+    catch (JException& ex) {
+        ex.plugin_name = m_plugin_name;
+        ex.component_name = m_type_name;
+        throw ex;
+    }
+    catch (std::exception& e){
+        auto ex = JException("Exception in JService::DoInit(): %s", e.what());
+        ex.nested_exception = std::current_exception();
+        ex.plugin_name = m_plugin_name;
+        ex.component_name = m_type_name;
+        throw ex;
+    }
+    catch (...) {
+        auto ex = JException("Unknown exception in JService::DoInit()");
+        ex.nested_exception = std::current_exception();
+        ex.plugin_name = m_plugin_name;
+        ex.component_name = m_type_name;
+        throw ex;
+    }
+}

--- a/src/libraries/JANA/JService.h
+++ b/src/libraries/JANA/JService.h
@@ -1,0 +1,5 @@
+
+#pragma once
+#include <JANA/JServiceFwd.h>
+#include <JANA/Omni/JComponent.h>
+

--- a/src/libraries/JANA/JServiceFwd.h
+++ b/src/libraries/JANA/JServiceFwd.h
@@ -1,0 +1,24 @@
+
+#pragma once
+#include <JANA/Omni/JComponentFwd.h>
+
+
+class JServiceLocator;
+struct JService : public jana::omni::JComponent {
+
+    /// acquire_services is a callback which allows the user to configure a JService
+    /// which relies on other JServices. The idea is that the user uses a constructor
+    /// or initialize() method to configure things which don't rely on other JServices, and
+    /// then use acquire_services() to configure the things which do. We need this because
+    /// due to JANA's plugin architecture, we can't guarantee the order in which JServices
+    /// get provided. So instead, we collect all of the JServices first and wire them
+    /// together afterwards in a separate phase.
+    ///
+    /// Note: Don't call JApplication::GetService() or JServiceLocator::get() from InitPlugin()!
+
+    virtual ~JService() = default;
+
+    // This will be deprecated eventually
+    virtual void acquire_services(JServiceLocator*) {};
+};
+

--- a/src/libraries/JANA/JServiceFwd.h
+++ b/src/libraries/JANA/JServiceFwd.h
@@ -18,6 +18,10 @@ struct JService : public jana::omni::JComponent {
 
     virtual ~JService() = default;
 
+    void DoInit(JServiceLocator*);
+
+    virtual void Init() {};
+
     // This will be deprecated eventually
     virtual void acquire_services(JServiceLocator*) {};
 };

--- a/src/libraries/JANA/Omni/JComponent.h
+++ b/src/libraries/JANA/Omni/JComponent.h
@@ -5,197 +5,90 @@
 
 #pragma once
 #include <JANA/JApplication.h>
+#include <JANA/Omni/JComponentFwd.h>
 
 namespace jana {
 namespace omni {
 
+template <typename T>
+class JComponent::ParameterRef : public JComponent::ParameterBase {
 
-struct JComponent {
-    enum class Status { Uninitialized, Initialized, Finalized };
-    enum class CallbackStyle { Compatibility, Classic, Declarative };
-
-protected:
-
-    struct ParameterBase;
-    struct ServiceBase;
-
-    std::vector<ParameterBase*> m_parameters;
-    std::vector<ServiceBase*> m_services;
-    
-    JEventLevel m_level = JEventLevel::Event;
-    CallbackStyle m_callback_style = CallbackStyle::Compatibility;
-    std::string m_prefix;
-    std::string m_plugin_name;
-    std::string m_type_name;
-    Status m_status = Status::Uninitialized;
-    mutable std::mutex m_mutex;
-    JApplication* m_app = nullptr;
-    JLogger m_logger;
+    T* m_data;
 
 public:
-    // ---------------------
-    // Meant to be called by users, or alternatively from a Generator
-    // ---------------------
-    void SetLevel(JEventLevel level) { m_level = level; }
-
-    void SetCallbackStyle(CallbackStyle style) { m_callback_style = style; }
-
-    void SetPrefix(std::string prefix) {
-        m_prefix = prefix;
-    }
-    /// For convenience, we provide a NAME_OF_THIS macro so that the user doesn't have to store the type name as a string, 
-    /// because that could get out of sync if automatic refactoring tools are used.
-    void SetTypeName(std::string type_name) { m_type_name = std::move(type_name); }
-
-    JApplication* GetApplication() const { 
-        if (m_app == nullptr) {
-            throw JException("JApplication pointer hasn't been provided yet! Hint: Component configuration should happen inside Init(), not in the constructor.");
-        }
-        return m_app; 
+    ParameterRef(JComponent* owner, std::string name, T& slot, std::string description="") {
+        owner->RegisterParameter(this);
+        this->m_name = name;
+        this->m_description = description;
+        m_data = &slot;
     }
 
-    JLogger& GetLogger() { return m_logger; }
-
-
-    // ---------------------
-    // Meant to be called by JANA
-    // ---------------------
-    std::string GetPrefix() { return m_prefix; }
-
-    JEventLevel GetLevel() { return m_level; }
-
-    std::string GetLoggerName() const { return m_prefix.empty() ? m_type_name : m_prefix; }
-
-    std::string GetPluginName() const { return m_plugin_name; }
-
-    void SetPluginName(std::string plugin_name) { m_plugin_name = std::move(plugin_name); };
-
-    std::string GetTypeName() const { return m_type_name; }
-
-    Status GetStatus() const { 
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return m_status; 
-    }
-
-    void SetApplication(JApplication* app) { m_app = app; }
-
-    void SetLogger(JLogger logger) { m_logger = logger; }
-
+    const T& operator()() { return *m_data; }
 
 protected:
-    struct ParameterBase {
-        std::string m_name;
-        std::string m_description;
-        virtual void Configure(JParameterManager& parman, const std::string& prefix) = 0;
-        virtual void Configure(std::map<std::string, std::string> fields) = 0;
-    };
 
-    struct ServiceBase {
-        virtual void Init(JApplication* app) = 0;
-    };
+    void Configure(JParameterManager& parman, const std::string& prefix) override {
+        parman.SetDefaultParameter(prefix + ":" + this->m_name, *m_data, this->m_description);
+    }
+    void Configure(std::map<std::string, std::string> fields) override {
+        auto it = fields.find(this->m_name);
+        if (it != fields.end()) {
+            const auto& value_str = it->second;
+            JParameterManager::Parse(value_str, *m_data);
+        }
+    }
+};
 
-    void RegisterParameter(ParameterBase* parameter) {
-        m_parameters.push_back(parameter);
+template <typename T>
+class JComponent::Parameter : public JComponent::ParameterBase {
+
+    T m_data;
+
+public:
+    Parameter(JComponent* owner, std::string name, T default_value, std::string description) {
+        owner->RegisterParameter(this);
+        this->m_name = name;
+        this->m_description = description;
+        m_data = default_value;
     }
 
-    void RegisterService(ServiceBase* service) {
-        m_services.push_back(service);
+    const T& operator()() { return m_data; }
+
+protected:
+
+    void Configure(JParameterManager& parman, const std::string& prefix) override {
+        parman.SetDefaultParameter(prefix + ":" + this->m_name, m_data, this->m_description);
     }
+    void Configure(std::map<std::string, std::string> fields) override {
+        auto it = fields.find(this->m_name);
+        if (it != fields.end()) {
+            const auto& value_str = it->second;
+            JParameterManager::Parse(value_str, m_data);
+        }
+    }
+};
+
+
+template <typename ServiceT>
+class JComponent::Service : public JComponent::ServiceBase {
+
+    std::shared_ptr<ServiceT> m_data;
 
 public:
 
-    void ConfigureAllParameters(std::map<std::string, std::string> fields) {
-        for (auto* parameter : this->m_parameters) {
-            parameter->Configure(fields);
-        }
+    Service(JComponent* owner) {
+        owner->RegisterService(this);
+    }
+
+    ServiceT& operator()() {
+        return *m_data;
     }
 
 protected:
-    template <typename T>
-    class ParameterRef : public ParameterBase {
 
-        T* m_data;
-
-    public:
-        ParameterRef(JComponent* owner, std::string name, T& slot, std::string description="") {
-            owner->RegisterParameter(this);
-            this->m_name = name;
-            this->m_description = description;
-            m_data = &slot;
-        }
-
-        const T& operator()() { return *m_data; }
-
-    protected:
-
-        void Configure(JParameterManager& parman, const std::string& prefix) override {
-            parman.SetDefaultParameter(prefix + ":" + this->m_name, *m_data, this->m_description);
-        }
-        void Configure(std::map<std::string, std::string> fields) override {
-            auto it = fields.find(this->m_name);
-            if (it != fields.end()) {
-                const auto& value_str = it->second;
-                JParameterManager::Parse(value_str, *m_data);
-            }
-        }
-    };
-
-    template <typename T>
-    class Parameter : public ParameterBase {
-
-        T m_data;
-
-    public:
-        Parameter(JComponent* owner, std::string name, T default_value, std::string description) {
-            owner->RegisterParameter(this);
-            this->m_name = name;
-            this->m_description = description;
-            m_data = default_value;
-        }
-
-        const T& operator()() { return m_data; }
-
-    protected:
-
-        void Configure(JParameterManager& parman, const std::string& prefix) override {
-            parman.SetDefaultParameter(prefix + ":" + this->m_name, m_data, this->m_description);
-        }
-        void Configure(std::map<std::string, std::string> fields) override {
-            auto it = fields.find(this->m_name);
-            if (it != fields.end()) {
-                const auto& value_str = it->second;
-                JParameterManager::Parse(value_str, m_data);
-            }
-        }
-    };
-
-
-    template <typename ServiceT>
-    class Service : public ServiceBase {
-
-        std::shared_ptr<ServiceT> m_data;
-
-    public:
-
-        Service(JComponent* owner) {
-            owner->RegisterService(this);
-        }
-
-        ServiceT& operator()() {
-            return *m_data;
-        }
-
-    protected:
-
-        void Init(JApplication* app) {
-            m_data = app->GetService<ServiceT>();
-        }
-
-    };
-
-
-
-
+    void Init(JApplication* app) {
+        m_data = app->GetService<ServiceT>();
+    }
 };
 
 

--- a/src/libraries/JANA/Omni/JComponent.h
+++ b/src/libraries/JANA/Omni/JComponent.h
@@ -28,7 +28,12 @@ public:
 protected:
 
     void Configure(JParameterManager& parman, const std::string& prefix) override {
-        parman.SetDefaultParameter(prefix + ":" + this->m_name, *m_data, this->m_description);
+        if (prefix.empty()) {
+            parman.SetDefaultParameter(this->m_name, *m_data, this->m_description);
+        }
+        else {
+            parman.SetDefaultParameter(prefix + ":" + this->m_name, *m_data, this->m_description);
+        }
     }
     void Configure(std::map<std::string, std::string> fields) override {
         auto it = fields.find(this->m_name);
@@ -57,7 +62,12 @@ public:
 protected:
 
     void Configure(JParameterManager& parman, const std::string& prefix) override {
-        parman.SetDefaultParameter(prefix + ":" + this->m_name, m_data, this->m_description);
+        if (prefix.empty()) {
+            parman.SetDefaultParameter(this->m_name, m_data, this->m_description);
+        }
+        else {
+            parman.SetDefaultParameter(prefix + ":" + this->m_name, m_data, this->m_description);
+        }
     }
     void Configure(std::map<std::string, std::string> fields) override {
         auto it = fields.find(this->m_name);

--- a/src/libraries/JANA/Omni/JComponentFwd.h
+++ b/src/libraries/JANA/Omni/JComponentFwd.h
@@ -9,6 +9,7 @@ class JApplication;
 class JParameterManager;
 #include <JANA/Utils/JEventLevel.h>
 #include <JANA/JLogger.h>
+#include <JANA/JException.h>
 
 namespace jana {
 namespace omni {

--- a/src/libraries/JANA/Omni/JComponentFwd.h
+++ b/src/libraries/JANA/Omni/JComponentFwd.h
@@ -7,10 +7,13 @@
 
 class JApplication;
 class JParameterManager;
+
 #include <JANA/Utils/JEventLevel.h>
 #include <JANA/JLogger.h>
 #include <JANA/JException.h>
+
 #include <vector>
+#include <mutex>
 
 namespace jana {
 namespace omni {

--- a/src/libraries/JANA/Omni/JComponentFwd.h
+++ b/src/libraries/JANA/Omni/JComponentFwd.h
@@ -10,6 +10,7 @@ class JParameterManager;
 #include <JANA/Utils/JEventLevel.h>
 #include <JANA/JLogger.h>
 #include <JANA/JException.h>
+#include <vector>
 
 namespace jana {
 namespace omni {

--- a/src/libraries/JANA/Omni/JComponentFwd.h
+++ b/src/libraries/JANA/Omni/JComponentFwd.h
@@ -1,0 +1,135 @@
+
+// Copyright 2024, Jefferson Science Associates, LLC.
+// Subject to the terms in the LICENSE file found in the top-level directory.
+// Created by Nathan Brei
+
+#pragma once
+
+class JApplication;
+class JParameterManager;
+#include <JANA/Utils/JEventLevel.h>
+#include <JANA/JLogger.h>
+
+namespace jana {
+namespace omni {
+
+
+struct JComponent {
+    enum class Status { Uninitialized, Initialized, Finalized };
+    enum class CallbackStyle { Compatibility, Classic, Declarative };
+
+    struct ParameterBase;
+    struct ServiceBase;
+
+protected:
+    std::vector<ParameterBase*> m_parameters;
+    std::vector<ServiceBase*> m_services;
+    
+    JEventLevel m_level = JEventLevel::Event;
+    CallbackStyle m_callback_style = CallbackStyle::Compatibility;
+    std::string m_prefix;
+    std::string m_plugin_name;
+    std::string m_type_name;
+    Status m_status = Status::Uninitialized;
+    mutable std::mutex m_mutex;
+    JApplication* m_app = nullptr;
+    JLogger m_logger;
+
+public:
+    // ---------------------
+    // Meant to be called by users, or alternatively from a Generator
+    // ---------------------
+    void SetLevel(JEventLevel level) { m_level = level; }
+
+    void SetCallbackStyle(CallbackStyle style) { m_callback_style = style; }
+
+    void SetPrefix(std::string prefix) {
+        m_prefix = prefix;
+    }
+    /// For convenience, we provide a NAME_OF_THIS macro so that the user doesn't have to store the type name as a string, 
+    /// because that could get out of sync if automatic refactoring tools are used.
+    void SetTypeName(std::string type_name) { m_type_name = std::move(type_name); }
+
+    JApplication* GetApplication() const { 
+        if (m_app == nullptr) {
+            throw JException("JApplication pointer hasn't been provided yet! Hint: Component configuration should happen inside Init(), not in the constructor.");
+        }
+        return m_app; 
+    }
+
+    JLogger& GetLogger() { return m_logger; }
+
+
+    // ---------------------
+    // Meant to be called by JANA
+    // ---------------------
+    std::string GetPrefix() { return m_prefix; }
+
+    JEventLevel GetLevel() { return m_level; }
+
+    std::string GetLoggerName() const { return m_prefix.empty() ? m_type_name : m_prefix; }
+
+    std::string GetPluginName() const { return m_plugin_name; }
+
+    void SetPluginName(std::string plugin_name) { m_plugin_name = std::move(plugin_name); };
+
+    std::string GetTypeName() const { return m_type_name; }
+
+    Status GetStatus() const { 
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_status; 
+    }
+
+    void SetApplication(JApplication* app) { m_app = app; }
+
+    void SetLogger(JLogger logger) { m_logger = logger; }
+
+
+    // ---------------------
+    // "Registered member" helpers
+    // ---------------------
+
+    struct ParameterBase {
+        std::string m_name;
+        std::string m_description;
+        virtual void Configure(JParameterManager& parman, const std::string& prefix) = 0;
+        virtual void Configure(std::map<std::string, std::string> fields) = 0;
+    };
+
+    template <typename T> 
+    class ParameterRef;
+
+    template <typename T> 
+    class Parameter;
+
+    struct ServiceBase {
+        virtual void Init(JApplication* app) = 0;
+    };
+
+    template <typename T> 
+    class Service;
+
+    void RegisterParameter(ParameterBase* parameter) {
+        m_parameters.push_back(parameter);
+    }
+
+    void RegisterService(ServiceBase* service) {
+        m_services.push_back(service);
+    }
+
+    void ConfigureAllParameters(std::map<std::string, std::string> fields) {
+        for (auto* parameter : this->m_parameters) {
+            parameter->Configure(fields);
+        }
+    }
+
+
+    // 
+};
+
+
+
+} // namespace omni
+} // namespace jana
+
+

--- a/src/libraries/JANA/Services/JComponentManager.cc
+++ b/src/libraries/JANA/Services/JComponentManager.cc
@@ -7,6 +7,7 @@
 #include <JANA/JEventProcessor.h>
 #include <JANA/JFactoryGenerator.h>
 #include <JANA/JEventUnfolder.h>
+#include <JANA/Utils/JAutoActivator.h>
 
 JComponentManager::JComponentManager() {}
 
@@ -38,6 +39,12 @@ void JComponentManager::InitPhase2() {
     m_params().SetDefaultParameter("jana:nevents", m_nevents, "Max number of events that sources can emit");
     m_params().SetDefaultParameter("jana:nskip", m_nskip, "Number of events that sources should skip before starting emitting");
     m_params().FilterParameters(m_default_tags, "DEFTAG:");
+
+    // Look for factories to auto-activate
+    // Right now AutoActivator parameter won't show up in parameters list. Reconsider this.
+    if (JAutoActivator::IsRequested(m_params())) {
+        add(new JAutoActivator);
+    }
 }
 
 void JComponentManager::next_plugin(std::string plugin_name) {

--- a/src/libraries/JANA/Services/JComponentManager.h
+++ b/src/libraries/JANA/Services/JComponentManager.h
@@ -18,8 +18,9 @@ class JEventUnfolder;
 class JComponentManager : public JService {
 public:
 
-    explicit JComponentManager(JApplication*);
+    explicit JComponentManager();
     ~JComponentManager() override;
+    void InitPhase2();
 
     void next_plugin(std::string plugin_name);
 
@@ -30,7 +31,6 @@ public:
     void add(JEventProcessor* processor);
     void add(JEventUnfolder* unfolder);
 
-    void initialize();
     void resolve_event_sources();
     JEventSourceGenerator* resolve_user_event_source_generator() const;
     JEventSourceGenerator* resolve_event_source(std::string source_name) const;
@@ -51,7 +51,8 @@ private:
     // Processors need: { typename, pluginname, mutexgroup, status, evtcnt }
     // Factories need:  { typename, pluginname }
 
-    JApplication* m_app;
+    Service<JParameterManager> m_params {this};
+    Service<JLoggingService> m_logging {this};
 
     std::string m_current_plugin_name;
     std::vector<std::string> m_src_names;

--- a/src/libraries/JANA/Services/JPluginLoader.h
+++ b/src/libraries/JANA/Services/JPluginLoader.h
@@ -6,8 +6,8 @@
 #ifndef JANA2_JPLUGINLOADER_H
 #define JANA2_JPLUGINLOADER_H
 
-#include <JANA/Services/JLoggingService.h>
 #include <JANA/Services/JParameterManager.h>
+#include <JANA/JService.h>
 
 #include <string>
 #include <vector>
@@ -20,9 +20,9 @@ class JPluginLoader : public JService {
 
 public:
 
-    JPluginLoader(JApplication* app);
+    JPluginLoader();
     ~JPluginLoader() override;
-    void acquire_services(JServiceLocator*) override;
+    void InitPhase2();
 
     void add_plugin(std::string plugin_name);
     void add_plugin_path(std::string path);
@@ -30,6 +30,7 @@ public:
     void attach_plugin(std::string plugin_name);
 
 private:
+    Service<JParameterManager> m_params {this};
 
     std::vector<std::string> m_plugins_to_include;
     std::vector<std::string> m_plugins_to_exclude;
@@ -38,9 +39,6 @@ private:
     std::map<std::string, void*> m_sohandles; // key=plugin name  val=dlopen handle
 
     bool m_verbose = false;
-    JLogger m_logger;
-
-    JApplication* m_app = nullptr;
 
 };
 

--- a/src/libraries/JANA/Services/JServiceLocator.h
+++ b/src/libraries/JANA/Services/JServiceLocator.h
@@ -6,7 +6,6 @@
 #ifndef _JSERVICELOCATOR_H_
 #define _JSERVICELOCATOR_H_
 
-#include <JANA/JException.h>
 
 #include <map>
 #include <typeinfo>
@@ -15,29 +14,16 @@
 #include <assert.h>
 #include <memory>
 #include <mutex>
+
+#include <JANA/JException.h>
 #include "JANA/Utils/JTypeInfo.h"
+#include <JANA/JServiceFwd.h>
 
 
-class JServiceLocator;
 
 /// JService is a trait indicating that an object can be shared among JANA components
 /// via a simple ServiceLocator. It provides a callback interface for configuring itself
 /// when it depends on other JServices.
-struct JService {
-
-    /// acquire_services is a callback which allows the user to configure a JService
-    /// which relies on other JServices. The idea is that the user uses a constructor
-    /// or initialize() method to configure things which don't rely on other JServices, and
-    /// then use acquire_services() to configure the things which do. We need this because
-    /// due to JANA's plugin architecture, we can't guarantee the order in which JServices
-    /// get provided. So instead, we collect all of the JServices first and wire them
-    /// together afterwards in a separate phase.
-    ///
-    /// Note: Don't call JApplication::GetService() or JServiceLocator::get() from InitPlugin()!
-
-    virtual ~JService() = default;
-    virtual void acquire_services(JServiceLocator*) {};
-};
 
 /// JServiceLocator is a nexus for collecting, initializing, and retrieving JServices.
 /// This may be exposed via the JApplication facade, or used on its own. JServiceLocator

--- a/src/libraries/JANA/Services/JServiceLocator.h
+++ b/src/libraries/JANA/Services/JServiceLocator.h
@@ -10,7 +10,6 @@
 #include <map>
 #include <typeinfo>
 #include <typeindex>
-#include <iostream>
 #include <assert.h>
 #include <memory>
 #include <mutex>
@@ -72,7 +71,7 @@ public:
         auto& pair = iter->second;
         auto& wired = pair.second;
         auto ptr = pair.first;
-        std::call_once(*wired, [&](){ptr->acquire_services(this);});
+        std::call_once(*wired, [&](){ptr->DoInit(this);});
         auto svc = std::static_pointer_cast<T>(ptr);
         return svc;
     }
@@ -85,7 +84,7 @@ public:
         for (auto& item : underlying) {
             auto sharedptr = item.second.first;
             auto& wired = item.second.second;
-            std::call_once(*wired, [&](){sharedptr->acquire_services(this);});
+            std::call_once(*wired, [&](){sharedptr->DoInit(this);});
         }
     }
 };

--- a/src/libraries/JANA/Utils/JAutoActivator.cc
+++ b/src/libraries/JANA/Utils/JAutoActivator.cc
@@ -9,8 +9,8 @@ JAutoActivator::JAutoActivator() {
     SetTypeName("JAutoActivator");
 }
 
-bool JAutoActivator::IsRequested(std::shared_ptr <JParameterManager> params) {
-    return params->Exists("autoactivate") && (!params->GetParameterValue<string>("autoactivate").empty());
+bool JAutoActivator::IsRequested(JParameterManager& params) {
+    return params.Exists("autoactivate") && (!params.GetParameterValue<string>("autoactivate").empty());
 }
 
 void JAutoActivator::AddAutoActivatedFactory(string factory_name, string factory_tag) {

--- a/src/libraries/JANA/Utils/JAutoActivator.h
+++ b/src/libraries/JANA/Utils/JAutoActivator.h
@@ -16,7 +16,7 @@ class JAutoActivator : public JEventProcessor {
 
 public:
     JAutoActivator();
-    static bool IsRequested(std::shared_ptr<JParameterManager> params);
+    static bool IsRequested(JParameterManager& params);
     static std::pair<std::string, std::string> Split(std::string factory_name);
     void AddAutoActivatedFactory(string factory_name, string factory_tag);
     void Init() override;

--- a/src/libraries/JANA/Utils/JEventLevel.h
+++ b/src/libraries/JANA/Utils/JEventLevel.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <ostream>
+#include <sstream>
 
 enum class JEventLevel { Run, Subrun, Timeslice, Block, Event, Subevent, Task, None };
 


### PR DESCRIPTION
This means that JServices can access parameters and services via Omni-style registered members, and are furnished with a logger, a JApplication pointer, and an Init() callback with proper exception handling.

There's a bigger change under the hood that made this possible: JANA2 has always had a problem with circular dependencies due to all of the member function templates. Among other things, this is why we need to #include<JANA/JEvent.h> whenever we declare a subclass of JFactoryT. In this pull request we finally resolve this problem by splitting JApplication.h into JApplicationFwd.h (which contains the class definition and forward declarations of the member templates) and JApplication.h (which contains the member template definitions and also pulls in JApplicationFwd.h). This way, anything that doesn't explicitly need the problematic member template definitions won't get them, and everything looks the same to users downstream.
