### PR TITLE
Add JFactory "REGENERATE" flag

### DIFF
--- a/src/libraries/JANA/Calibrations/JCalibrationCCDB.h
+++ b/src/libraries/JANA/Calibrations/JCalibrationCCDB.h
@@ -128,7 +128,7 @@ public:
             pthread_mutex_unlock(&mutex);
             return !result; //JANA has false - if success and true if error
         }
-        catch (std::exception ex) {
+        catch (std::exception& ex) {
             //>oO CCDB debug output
 #ifdef CCDB_DEBUG_OUTPUT
             cout <<"CCDB::janaccdb Exception caught at GetCalib(string namepath, map<string, string> &svals, int event_number=0)"<<endl;
@@ -206,7 +206,7 @@ public:
             pthread_mutex_unlock(&mutex);
             return !result; //JANA has false - if success and true if error
         }
-        catch (std::exception ex) {
+        catch (std::exception& ex) {
             //>oO CCDB debug output
 #ifdef CCDB_DEBUG_OUTPUT
             cout <<"CCDB::janaccdb Exception caught at GetCalib(string namepath, map<string, string> &svals, int event_number=0)"<<endl;
@@ -261,7 +261,7 @@ public:
             pthread_mutex_unlock(&mutex);
             return !result; //JANA has false - if success and true if error, CCDB otherwise
         }
-        catch (std::exception ex) {
+        catch (std::exception& ex) {
             //>oO CCDB debug output
 #ifdef CCDB_DEBUG_OUTPUT
             cout <<"CCDB::janaccdb Exception caught at GetCalib(string namepath, map<string, string> &svals, int event_number=0)"<<endl;
@@ -315,7 +315,7 @@ public:
             pthread_mutex_unlock(&mutex);
             return !result; //JANA has false - if success and true if error, CCDB otherwise
         }
-        catch (std::exception ex) {
+        catch (std::exception& ex) {
             //>oO CCDB debug output
 #ifdef CCDB_DEBUG_OUTPUT
             cout <<"CCDB::janaccdb Exception caught at GetCalib(string namepath, map<string, string> &svals, int event_number=0)"<<endl;
@@ -345,7 +345,7 @@ public:
 
             mCalibration->GetListOfNamepaths(namepaths);
         }
-        catch (std::exception ex) {
+        catch (std::exception& ex) {
 
             //some ccdb debug output
 #ifdef CCDB_DEBUG_OUTPUT

--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -295,7 +295,7 @@ inline JMetadata<T> JEvent::GetMetadata(const std::string& tag) const {
 
     auto factory = GetFactory<T>(tag, true);
     // Make sure that JFactoryT::Process has already been called before returning the metadata
-    factory->GetOrCreate(this->shared_from_this());
+    factory->CreateAndGetData(this->shared_from_this());
     return factory->GetMetadata();
 }
 
@@ -314,7 +314,7 @@ JFactoryT<T>* JEvent::Get(const T** destination, const std::string& tag) const
 {
     auto factory = GetFactory<T>(tag, true);
     JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iterators = factory->GetOrCreate(this->shared_from_this());
+    auto iterators = factory->CreateAndGetData(this->shared_from_this());
     if (std::distance(iterators.first, iterators.second) == 0) {
         *destination = nullptr;
     }
@@ -330,7 +330,7 @@ JFactoryT<T>* JEvent::Get(std::vector<const T*>& destination, const std::string&
 {
     auto factory = GetFactory<T>(tag, true);
     JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iterators = factory->GetOrCreate(this->shared_from_this());
+    auto iterators = factory->CreateAndGetData(this->shared_from_this());
     for (auto it=iterators.first; it!=iterators.second; it++) {
         destination.push_back(*it);
     }
@@ -350,7 +350,7 @@ JFactoryT<T>* JEvent::Get(std::vector<const T*>& destination, const std::string&
 template<class T> const T* JEvent::GetSingle(const std::string& tag) const {
     auto factory = GetFactory<T>(tag, true);
     JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iterators = factory->GetOrCreate(this->shared_from_this());
+    auto iterators = factory->CreateAndGetData(this->shared_from_this());
     if (std::distance(iterators.first, iterators.second) == 0) {
         return nullptr;
     }
@@ -366,7 +366,7 @@ template<class T> const T* JEvent::GetSingle(const std::string& tag) const {
 template<class T> const T* JEvent::GetSingleStrict(const std::string& tag) const {
     auto factory = GetFactory<T>(tag, true);
     JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iterators = factory->GetOrCreate(this->shared_from_this());
+    auto iterators = factory->CreateAndGetData(this->shared_from_this());
     if (std::distance(iterators.first, iterators.second) == 0) {
         JException ex("GetSingle failed due to missing %d", NAME_OF(T));
         ex.show_stacktrace = false;
@@ -386,7 +386,7 @@ std::vector<const T*> JEvent::Get(const std::string& tag) const {
 
     auto factory = GetFactory<T>(tag, true);
     JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iters = factory->GetOrCreate(this->shared_from_this());
+    auto iters = factory->CreateAndGetData(this->shared_from_this());
     std::vector<const T*> vec;
     for (auto it=iters.first; it!=iters.second; ++it) {
         vec.push_back(*it);
@@ -415,7 +415,7 @@ template<class T>
 void JEvent::GetAll(std::vector<const T*>& destination) const {
     auto factories = GetFactoryAll<T>(true);
     for (auto factory : factories) {
-        auto iterators = factory->GetOrCreate(this->shared_from_this());
+        auto iterators = factory->CreateAndGetData(this->shared_from_this());
         for (auto it = iterators.first; it != iterators.second; it++) {
             destination.push_back(*it);
         }
@@ -429,7 +429,7 @@ std::vector<const T*> JEvent::GetAll() const {
     auto factories = GetFactoryAll<T>(true);
 
     for (auto factory : factories) {
-        auto iters = factory->GetOrCreate(this->shared_from_this());
+        auto iters = factory->CreateAndGetData(this->shared_from_this());
         std::vector<const T*> vec;
         for (auto it = iters.first; it != iters.second; ++it) {
             vec.push_back(*it);
@@ -462,7 +462,7 @@ template<class T>
 typename JFactoryT<T>::PairType JEvent::GetIterators(const std::string& tag) const {
     auto factory = GetFactory<T>(tag, true);
     JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iters = factory->GetOrCreate(this->shared_from_this());
+    auto iters = factory->CreateAndGetData(this->shared_from_this());
     return iters;
 }
 

--- a/src/libraries/JANA/JFactory.cc
+++ b/src/libraries/JANA/JFactory.cc
@@ -34,6 +34,12 @@ void JFactory::Create(const std::shared_ptr<const JEvent>& event) {
             throw ex;
         }
     }
+
+    if (TestFactoryFlag(REGENERATE) && (mStatus == Status::Inserted)) {
+        ClearData();
+        // ClearData will reset mStatus to Status::Unprocessed
+    }
+
     if (mStatus == Status::Unprocessed) {
         try {
             if (mPreviousRunNumber == -1) {

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -79,12 +79,7 @@ public:
     /// exactly once, exceptions are tagged with the originating plugin and eventsource, ChangeRun() is
     /// called if and only if the run number changes, etc.
     PairType GetOrCreate(const std::shared_ptr<const JEvent>& event) {
-        if (mStatus == Status::Uninitialized || mStatus == Status::Unprocessed) {
-            Create(event);
-        }
-        if (mStatus != Status::Processed && mStatus != Status::Inserted) {
-            throw JException("JFactoryT::Status is corrupted");
-        }
+        Create(event);
         return std::make_pair(mData.cbegin(), mData.cend());
     }
 

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -74,11 +74,11 @@ public:
         return mData.size();
     }
 
-    /// GetOrCreate handles all the preconditions and postconditions involved in calling the user-defined Open(),
+    /// CreateAndGetData handles all the preconditions and postconditions involved in calling the user-defined Open(),
     /// ChangeRun(), and Process() methods. These include making sure the JFactory JApplication is set, Init() is called
     /// exactly once, exceptions are tagged with the originating plugin and eventsource, ChangeRun() is
     /// called if and only if the run number changes, etc.
-    PairType GetOrCreate(const std::shared_ptr<const JEvent>& event) {
+    PairType CreateAndGetData(const std::shared_ptr<const JEvent>& event) {
         Create(event);
         return std::make_pair(mData.cbegin(), mData.cend());
     }

--- a/src/programs/unit_tests/JFactoryTests.cc
+++ b/src/programs/unit_tests/JFactoryTests.cc
@@ -170,5 +170,32 @@ TEST_CASE("JFactoryTests") {
             data++;
         }
     }
+
+    struct RegenerateFactory : public JFactoryT<JFactoryTestDummyObject> {
+        RegenerateFactory() {
+            SetRegenerateFlag(true);
+        }
+        void Process(const std::shared_ptr<const JEvent>&) override {
+            mData.emplace_back(new JFactoryTestDummyObject(49));
+            Set(mData);
+        }
+    };
+
+    SECTION("Factory regeneration") {
+        RegenerateFactory sut;
+        auto event = std::make_shared<JEvent>();
+
+        std::vector<JFactoryTestDummyObject*> inserted_data;
+        inserted_data.push_back(new JFactoryTestDummyObject(22));
+        inserted_data.push_back(new JFactoryTestDummyObject(618));
+        sut.Set(inserted_data);
+
+        REQUIRE(sut.GetStatus() == JFactory::Status::Inserted);
+
+        auto results = sut.GetOrCreate(event);
+        auto it = results.first;
+        REQUIRE((*it)->data == 49);
+        REQUIRE(sut.GetNumObjects() == 1);
+    }
 }
 

--- a/src/programs/unit_tests/JFactoryTests.cc
+++ b/src/programs/unit_tests/JFactoryTests.cc
@@ -12,27 +12,27 @@
 TEST_CASE("JFactoryTests") {
 
 
-    SECTION("GetOrCreate calls Init, ChangeRun, and Process as needed") {
+    SECTION("CreateAndGetData calls Init, ChangeRun, and Process as needed") {
 
         JFactoryTestDummyFactory sut;
         auto event = std::make_shared<JEvent>();
 
         // The first time it is run, Init, ChangeRun, and Process each get run once
-        sut.GetOrCreate(event);
+        sut.CreateAndGetData(event);
         REQUIRE(sut.init_call_count == 1);
         REQUIRE(sut.change_run_call_count == 1);
         REQUIRE(sut.process_call_count == 1);
 
         // We can getOrCreate as many times as we want and nothing will happen
         // until somebody clears the factory (assuming persistence flag is unset)
-        sut.GetOrCreate(event);
+        sut.CreateAndGetData(event);
         REQUIRE(sut.init_call_count == 1);
         REQUIRE(sut.change_run_call_count == 1);
         REQUIRE(sut.process_call_count == 1);
 
         // Once we clear the factory, Process gets called again but Init and ChangeRun do not.
         sut.ClearData();
-        sut.GetOrCreate(event);
+        sut.CreateAndGetData(event);
         REQUIRE(sut.init_call_count == 1);
         REQUIRE(sut.change_run_call_count == 1);
         REQUIRE(sut.process_call_count == 2);
@@ -62,31 +62,31 @@ TEST_CASE("JFactoryTests") {
         // For the first event, ChangeRun() always gets called
         event->SetEventNumber(1);
         event->SetRunNumber(22);
-        sut.GetOrCreate(event);
+        sut.CreateAndGetData(event);
         REQUIRE(sut.change_run_call_count == 1);
 
         // Subsequent events with the same run number do not trigger ChangeRun()
         event->SetEventNumber(2);
         sut.ClearData();
-        sut.GetOrCreate(event);
+        sut.CreateAndGetData(event);
 
         event->SetEventNumber(3);
         sut.ClearData();
-        sut.GetOrCreate(event);
+        sut.CreateAndGetData(event);
         REQUIRE(sut.change_run_call_count == 1);
 
         // As soon as the run number changes, ChangeRun() gets called again
         event->SetEventNumber(4);
         event->SetRunNumber(49);
         sut.ClearData();
-        sut.GetOrCreate(event);
+        sut.CreateAndGetData(event);
         REQUIRE(sut.change_run_call_count == 2);
 
         // This keeps happening
         event->SetEventNumber(5);
         event->SetRunNumber(6180);
         sut.ClearData();
-        sut.GetOrCreate(event);
+        sut.CreateAndGetData(event);
         REQUIRE(sut.change_run_call_count == 3);
     }
 
@@ -98,7 +98,7 @@ TEST_CASE("JFactoryTests") {
         sut.ClearFactoryFlag(JFactory::NOT_OBJECT_OWNER);
         sut.Insert(new JFactoryTestDummyObject(42, &deleted_flag));
         sut.ClearData();
-        auto results = sut.GetOrCreate(event);
+        auto results = sut.CreateAndGetData(event);
         REQUIRE(std::distance(results.first, results.second) == 0);
         REQUIRE(deleted_flag == true);
     }
@@ -111,7 +111,7 @@ TEST_CASE("JFactoryTests") {
         sut.SetFactoryFlag(JFactory::NOT_OBJECT_OWNER);
         sut.Insert(new JFactoryTestDummyObject(42, &deleted_flag));
         sut.ClearData();
-        auto results = sut.GetOrCreate(event);
+        auto results = sut.CreateAndGetData(event);
         REQUIRE(std::distance(results.first, results.second) == 0);
         REQUIRE(deleted_flag == false);
     }
@@ -124,7 +124,7 @@ TEST_CASE("JFactoryTests") {
         sut.ClearFactoryFlag(JFactory::NOT_OBJECT_OWNER);
         sut.Insert(new JFactoryTestDummyObject(42, &deleted_flag));
         sut.ClearData();
-        auto results = sut.GetOrCreate(event);
+        auto results = sut.CreateAndGetData(event);
         REQUIRE(std::distance(results.first, results.second) == 1);
         REQUIRE(deleted_flag == false);
     }
@@ -137,7 +137,7 @@ TEST_CASE("JFactoryTests") {
         sut.SetFactoryFlag(JFactory::NOT_OBJECT_OWNER);
         sut.Insert(new JFactoryTestDummyObject(42, &deleted_flag));
         sut.ClearData();
-        auto results = sut.GetOrCreate(event);
+        auto results = sut.CreateAndGetData(event);
         REQUIRE(std::distance(results.first, results.second) == 1);
         REQUIRE(deleted_flag == false);
     }
@@ -160,7 +160,7 @@ TEST_CASE("JFactoryTests") {
 
         Issue135Factory sut;
         auto event = std::make_shared<JEvent>();
-        auto results = sut.GetOrCreate(event);
+        auto results = sut.CreateAndGetData(event);
         REQUIRE(sut.GetNumObjects() == 3);
         REQUIRE(std::distance(results.first, results.second) == 3);
 
@@ -192,7 +192,7 @@ TEST_CASE("JFactoryTests") {
 
         REQUIRE(sut.GetStatus() == JFactory::Status::Inserted);
 
-        auto results = sut.GetOrCreate(event);
+        auto results = sut.CreateAndGetData(event);
         auto it = results.first;
         REQUIRE((*it)->data == 49);
         REQUIRE(sut.GetNumObjects() == 1);


### PR DESCRIPTION
This tells JFactory::Create() to clear any Insert()ed data and recompute it using JFactory::Process(). This is necessary for certain factories in halld_recon.

This PR also includes several small cleanup operations:
- Fixes warnings about std::exception being caught by value. These are in a header file that only gets used in halld_recon.
- Renames JFactoryT::GetOrCreate() to JFactoryT::CreateAndGetData()