### PR TITLE
Simplify JEventProcessor API

### DIFF
--- a/src/examples/DstExample/DstExampleProcessor.cc
+++ b/src/examples/DstExample/DstExampleProcessor.cc
@@ -9,6 +9,7 @@
 
 DstExampleProcessor::DstExampleProcessor() {
     SetTypeName(NAME_OF_THIS); // Provide JANA with this class's name
+    SetCallbackStyle(CallbackStyle::ExpertMode);
 }
 
 void DstExampleProcessor::Init() {
@@ -16,20 +17,20 @@ void DstExampleProcessor::Init() {
     // Open TFiles, set up TTree branches, etc
 }
 
-void DstExampleProcessor::Process(const std::shared_ptr<const JEvent> &event) {
-    LOG << "DstExampleProcessor::Process, Event #" << event->GetEventNumber() << LOG_END;
+void DstExampleProcessor::Process(const JEvent& event) {
+    LOG << "DstExampleProcessor::Process, Event #" << event.GetEventNumber() << LOG_END;
 
     /// Note that GetAllChildren won't trigger any new computations, it will only
     /// project down results which already exist in the JEvent. In order to obtain
     /// results from our DstExampleFactory, we need to trigger it explicitly using
     /// either JEvent::Get or JEvent::GetAll.
 
-    event->Get<MyRenderableJObject>("from_factory");
+    event.Get<MyRenderableJObject>("from_factory");
 
     /// Now we can project our event down to a map of Renderables and a separate
     /// map of JObjects. Note we do this in parallel.
-    auto renderable_map = event->GetAllChildren<Renderable>();
-    auto jobject_map = event->GetAllChildren<JObject>();
+    auto renderable_map = event.GetAllChildren<Renderable>();
+    auto jobject_map = event.GetAllChildren<JObject>();
 
     /// Senquentially, we iterate over all of our Renderables and JObjects and use
     /// whatever functionality each interface provides.

--- a/src/examples/DstExample/DstExampleProcessor.h
+++ b/src/examples/DstExample/DstExampleProcessor.h
@@ -19,7 +19,7 @@ public:
     virtual ~DstExampleProcessor() = default;
 
     void Init() override;
-    void Process(const std::shared_ptr<const JEvent>& event) override;
+    void Process(const JEvent&) override;
     void Finish() override;
 
 };

--- a/src/examples/EventGroupExample/GroupedEventProcessor.h
+++ b/src/examples/EventGroupExample/GroupedEventProcessor.h
@@ -17,23 +17,27 @@
 /// GroupedEventProcessor demonstrates basic usage of JEventGroups
 
 class GroupedEventProcessor : public JEventProcessor {
-    std::mutex m_mutex;
 
 public:
-    void Process(const std::shared_ptr<const JEvent>& event) override {
+    GroupedEventProcessor() {
+        SetTypeName(NAME_OF_THIS);
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+
+    void Process(const JEvent& event) override {
 
         // In parallel, perform a random amount of (slow) computation
         consume_cpu_ms(100, 1.0);
 
-        auto tridas_event = event->GetSingle<TridasEvent>();
+        auto tridas_event = event.GetSingle<TridasEvent>();
         tridas_event->should_keep = true;
 
-        auto group = event->GetSingle<JEventGroup>();
+        auto group = event.GetSingle<JEventGroup>();
 
         // Sequentially, process each event and report when a group finishes
         std::lock_guard<std::mutex> lock(m_mutex);
 
-        LOG << "Processed group #" << group->GetGroupId() << ", event #" << event->GetEventNumber() << LOG_END;
+        LOG << "Processed group #" << group->GetGroupId() << ", event #" << event.GetEventNumber() << LOG_END;
 
         bool finishes_group = group->FinishEvent();
         if (finishes_group) {

--- a/src/examples/MetadataExample/MetadataAggregator.cc
+++ b/src/examples/MetadataExample/MetadataAggregator.cc
@@ -9,6 +9,7 @@
 
 MetadataAggregator::MetadataAggregator() {
     SetTypeName(NAME_OF_THIS); // Provide JANA with this class's name
+    SetCallbackStyle(CallbackStyle::ExpertMode);
 }
 
 void MetadataAggregator::Init() {
@@ -20,17 +21,17 @@ void MetadataAggregator::Init() {
     LOG << "MetadataAggregator::Init" << LOG_END;
 }
 
-void MetadataAggregator::Process(const std::shared_ptr<const JEvent> &event) {
-    LOG << "MetadataAggregator::Process, Run #" << event->GetRunNumber() << ", Event #" << event->GetEventNumber() << LOG_END;
+void MetadataAggregator::Process(const JEvent& event) {
+    LOG << "MetadataAggregator::Process, Run #" << event.GetRunNumber() << ", Event #" << event.GetEventNumber() << LOG_END;
 
     // Acquire tracks in parallel
-    auto tracks = event->Get<Track>(m_track_factory);
+    auto tracks = event.Get<Track>(m_track_factory);
 
     // Lock mutex, so we can update shared state sequentially
     std::lock_guard<std::mutex>lock(m_mutex);
 
     // Since the run number probably doesn't change too frequently we cache the last entry
-    int run_nr = event->GetRunNumber();
+    int run_nr = event.GetRunNumber();
     if (run_nr != m_last_run_nr) {
         m_last_run_nr = run_nr;
         m_last_statistics = &m_statistics[m_last_run_nr]; // Get-or-create
@@ -39,7 +40,7 @@ void MetadataAggregator::Process(const std::shared_ptr<const JEvent> &event) {
     // Update the statistics accumulator using the metadata from this event
     m_last_statistics->event_count += 1;
     m_last_statistics->total_track_count += tracks.size();
-    m_last_statistics->total_latency_ns += event->GetMetadata<Track>(m_track_factory).elapsed_time_ns;
+    m_last_statistics->total_latency_ns += event.GetMetadata<Track>(m_track_factory).elapsed_time_ns;
 }
 
 void MetadataAggregator::Finish() {

--- a/src/examples/MetadataExample/MetadataAggregator.h
+++ b/src/examples/MetadataExample/MetadataAggregator.h
@@ -19,8 +19,6 @@ class MetadataAggregator : public JEventProcessor {
         std::chrono::nanoseconds total_latency_ns {0};
     };
 
-    std::mutex m_mutex;
-
     std::string m_track_factory = "smeared"; // So we can choose what we are measuring at runtime
 
     std::map<int, Statistics> m_statistics; // Keyed off of run nr
@@ -43,7 +41,7 @@ public:
     virtual ~MetadataAggregator() = default;
 
     void Init() override;
-    void Process(const std::shared_ptr<const JEvent>& event) override;
+    void Process(const JEvent&) override;
     void Finish() override;
 
 };

--- a/src/examples/PodioExample/PodioExampleProcessor.cc
+++ b/src/examples/PodioExample/PodioExampleProcessor.cc
@@ -40,17 +40,22 @@ struct PrintingVisitor {
 // TODO: C++20 visitor using a lambda overload set
 // TODO: Less generic visitor, e.g. VisitCollection
 
-void PodioExampleProcessor::Process(const std::shared_ptr<const JEvent> &event) {
+PodioExampleProcessor::PodioExampleProcessor() {
+    SetTypeName(NAME_OF_THIS);
+    SetCallbackStyle(CallbackStyle::ExpertMode);
+}
+
+void PodioExampleProcessor::Process(const JEvent& event) {
 
     // Obtain a typed collection just like you would in a JFactory
-    auto hits = event->GetCollection<ExampleHit>("hits");
-    auto hits_filtered = event->GetCollection<ExampleHit>("hits_filtered");
-    auto clusters = event->GetCollection<ExampleCluster>("clusters");
-    auto clusters_filtered = event->GetCollection<ExampleCluster>("clusters_filtered");
-    auto clusters_from_hits_filtered = event->GetCollection<ExampleCluster>("clusters_from_hits_filtered");
+    auto hits = event.GetCollection<ExampleHit>("hits");
+    auto hits_filtered = event.GetCollection<ExampleHit>("hits_filtered");
+    auto clusters = event.GetCollection<ExampleCluster>("clusters");
+    auto clusters_filtered = event.GetCollection<ExampleCluster>("clusters_filtered");
+    auto clusters_from_hits_filtered = event.GetCollection<ExampleCluster>("clusters_from_hits_filtered");
 
     std::cout << "========================" << std::endl;
-    std::cout << "Event nr: " << event->GetEventNumber() << ", Cluster count: " << clusters->size() << std::endl;
+    std::cout << "Event nr: " << event.GetEventNumber() << ", Cluster count: " << clusters->size() << std::endl;
 
     std::cout << "hits:" << std::endl;
     for (const ExampleHit& hit : *hits) {

--- a/src/examples/PodioExample/PodioExampleProcessor.h
+++ b/src/examples/PodioExample/PodioExampleProcessor.h
@@ -11,9 +11,8 @@
 
 class PodioExampleProcessor : public JEventProcessor {
 public:
-    void Process(const std::shared_ptr<const JEvent> &ptr) override;
-
-
+    PodioExampleProcessor();
+    void Process(const JEvent&) override;
 };
 
 

--- a/src/examples/StreamingExample/AHitAnomalyDetector.h
+++ b/src/examples/StreamingExample/AHitAnomalyDetector.h
@@ -16,16 +16,18 @@ class AHitAnomalyDetector : public JEventProcessor {
 public:
     AHitAnomalyDetector(JApplication* app = nullptr, size_t delay_ms=1000)
         : JEventProcessor(app)
-        , m_delay_ms(delay_ms) {};
+        , m_delay_ms(delay_ms) {
+            SetCallbackStyle(CallbackStyle::ExpertMode);
+        };
 
     void Init() override {
 
     }
-    void Process(const std::shared_ptr<const JEvent>& event) override {
+    void Process(const JEvent& event) override {
 
-        auto a_hits = event->Get<AHit>();
+        auto a_hits = event.Get<AHit>();
         std::stringstream ss;
-        ss << "Anomaly detection: Event #" << event->GetEventNumber() << " : {";
+        ss << "Anomaly detection: Event #" << event.GetEventNumber() << " : {";
         for (auto & hit : a_hits) {
             ss << "(" << hit->E << "," << hit->x << "), ";
         }

--- a/src/examples/StreamingExample/AHitBHitFuser.h
+++ b/src/examples/StreamingExample/AHitBHitFuser.h
@@ -17,17 +17,19 @@ class AHitBHitFuser : public JEventProcessor {
 public:
     AHitAnomalyDetector(JApplication* app = nullptr, size_t delay_ms=1000)
         : JEventProcessor(app)
-        , m_delay_ms(delay_ms) {};
+        , m_delay_ms(delay_ms) {
+            SetCallbackStyle(CallbackStyle::ExpertMode);
+        };
 
     void Init() override {
 
     }
-    void Process(const std::shared_ptr<const JEvent>& event) override {
+    void Process(const JEvent& event) override {
 
-        auto a_hits = event->Get<AHit>();
-        auto b_hits = event->Get<BHit>();
+        auto a_hits = event.Get<AHit>();
+        auto b_hits = event.Get<BHit>();
         std::stringstream ss;
-        ss << "AHit/BHit fusion: Event #" << event->GetEventNumber() << " : {";
+        ss << "AHit/BHit fusion: Event #" << event.GetEventNumber() << " : {";
         for (auto & hit : a_hits) {
             ss << "(" << hit->E << "," << hit->t << "), ";
         }
@@ -40,10 +42,10 @@ public:
         consume_cpu_ms(m_delay_ms);
 
 
-        auto raw_hits = event->Get<AHit>("raw_hits");
+        auto raw_hits = event.Get<AHit>("raw_hits");
 
 
-        std::cout << "Processing event #" << event->GetEventNumber() << std::endl;
+        std::cout << "Processing event #" << event.GetEventNumber() << std::endl;
         Serializer<AHit> serializer;
         for (auto & hit : raw_hits) {
             AHit* calibrated_hit = new DetectorAHit(*hit);

--- a/src/examples/SubeventCUDAExample/SubeventCUDAExample.cu
+++ b/src/examples/SubeventCUDAExample/SubeventCUDAExample.cu
@@ -96,23 +96,26 @@ struct SimpleSource : public JEventSource {
 };
 
 struct SimpleProcessor : public JEventProcessor {
-    std::mutex m_mutex;
 
-    void Process(const std::shared_ptr<const JEvent> &event) {
+    SimpleProcessor() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+
+    void Process(const JEvent& event) {
 
         std::lock_guard <std::mutex> guard(m_mutex);
 
-        auto outputs = event->Get<MyOutput>();
+        auto outputs = event.Get<MyOutput>();
         // assert(outputs.size() == 4);
         // assert(outputs[0]->z == 25.6f);
         // assert(outputs[1]->z == 26.5f);
         // assert(outputs[2]->z == 27.4f);
         // assert(outputs[3]->z == 28.3f);
-        LOG << " Contents of event " << event->GetEventNumber() << LOG_END;
+        LOG << " Contents of event " << event.GetEventNumber() << LOG_END;
         for (auto output: outputs) {
             LOG << " " << output->evt << ":" << output->sub << " " << output->z << LOG_END;
         }
-        LOG << " DONE with contents of event " << event->GetEventNumber() << LOG_END;
+        LOG << " DONE with contents of event " << event.GetEventNumber() << LOG_END;
     }
 };
 

--- a/src/examples/SubeventExample/SubeventExample.cc
+++ b/src/examples/SubeventExample/SubeventExample.cc
@@ -57,22 +57,24 @@ struct SimpleSource : public JEventSource {
 };
 
 struct SimpleProcessor : public JEventProcessor {
-    std::mutex m_mutex;
-    void Process(const std::shared_ptr<const JEvent>& event) {
+    SimpleProcessor() {
+        SetCallbackStyle(CallbackStyle::ExpertMode); 
+    }
+    void Process(const JEvent& event) {
 
         std::lock_guard<std::mutex> guard(m_mutex);
 
-        auto outputs = event->Get<MyOutput>();
+        auto outputs = event.Get<MyOutput>();
         // assert(outputs.size() == 4);
         // assert(outputs[0]->z == 25.6f);
         // assert(outputs[1]->z == 26.5f);
         // assert(outputs[2]->z == 27.4f);
         // assert(outputs[3]->z == 28.3f);
-        LOG << " Contents of event " << event->GetEventNumber() << LOG_END;
+        LOG << " Contents of event " << event.GetEventNumber() << LOG_END;
         for (auto output : outputs) {
             LOG << " " << output->evt << ":" << output->sub << " " << output->z << LOG_END;
         }
-        LOG << " DONE with contents of event " << event->GetEventNumber() << LOG_END;
+        LOG << " DONE with contents of event " << event.GetEventNumber() << LOG_END;
     }
 };
 

--- a/src/examples/TimesliceExample/MyFileWriter.h
+++ b/src/examples/TimesliceExample/MyFileWriter.h
@@ -31,26 +31,27 @@ struct MyFileWriter : public JEventProcessor {
     
     MyFileWriter() {
         SetTypeName(NAME_OF_THIS);
+        SetCallbackStyle(CallbackStyle::ExpertMode);
     }
 
     void Init() {
         m_writer = std::make_unique<podio::ROOTFrameWriter>("output.root");
     }
 
-    void Process(const std::shared_ptr<const JEvent>& event) {
+    void Process(const JEvent& event) {
 
         std::lock_guard<std::mutex> guard(m_mutex);
-        if (event->HasParent(JEventLevel::Timeslice)) {
+        if (event.HasParent(JEventLevel::Timeslice)) {
 
-            auto& ts = event->GetParent(JEventLevel::Timeslice);
+            auto& ts = event.GetParent(JEventLevel::Timeslice);
             auto ts_nr = ts.GetEventNumber();
 
-            if (event->GetEventIndex() == 0) {
+            if (event.GetEventIndex() == 0) {
                 m_writer->writeFrame(*(m_ts_frame_in().at(0)), "timeslices");
             }
 
             LOG_DEBUG(GetLogger()) 
-                << "Event " << event->GetEventNumber() << " from Timeslice " << ts_nr
+                << "Event " << event.GetEventNumber() << " from Timeslice " << ts_nr
                 << "\nClusters\n"
                 << TabulateClusters(m_evt_clusters_in())
                 << LOG_END;
@@ -58,7 +59,7 @@ struct MyFileWriter : public JEventProcessor {
         else {
 
             LOG_DEBUG(GetLogger()) 
-                << "Event " << event->GetEventNumber()
+                << "Event " << event.GetEventNumber()
                 << "\nClusters\n"
                 << TabulateClusters(m_evt_clusters_in())
                 << LOG_END;

--- a/src/examples/Tutorial/TutorialProcessor.cc
+++ b/src/examples/Tutorial/TutorialProcessor.cc
@@ -8,6 +8,7 @@
 
 TutorialProcessor::TutorialProcessor() {
     SetTypeName(NAME_OF_THIS); // Provide JANA with this class's name
+    SetCallbackStyle(CallbackStyle::ExpertMode);
 }
 
 void TutorialProcessor::Init() {
@@ -20,12 +21,12 @@ void TutorialProcessor::Init() {
     }
 }
 
-void TutorialProcessor::Process(const std::shared_ptr<const JEvent> &event) {
-    LOG << "TutorialProcessor::Process, Event #" << event->GetEventNumber() << LOG_END;
+void TutorialProcessor::Process(const JEvent& event) {
+    LOG << "TutorialProcessor::Process, Event #" << event.GetEventNumber() << LOG_END;
     
     /// Do everything we can in parallel
     /// Warning: We are only allowed to use local variables and `event` here
-    auto hits = event->Get<Hit>();
+    auto hits = event.Get<Hit>();
 
     /// Lock mutex
     std::lock_guard<std::mutex>lock(m_mutex);

--- a/src/examples/Tutorial/TutorialProcessor.h
+++ b/src/examples/Tutorial/TutorialProcessor.h
@@ -9,9 +9,8 @@
 
 class TutorialProcessor : public JEventProcessor {
 
-    /// Shared state (e.g. histograms, TTrees, TFiles) live
+    /// Shared state (e.g. histograms, TTrees, TFiles) live here
     double m_heatmap[100][100];
-    std::mutex m_mutex;
     
 public:
 
@@ -19,7 +18,7 @@ public:
     virtual ~TutorialProcessor() = default;
 
     void Init() override;
-    void Process(const std::shared_ptr<const JEvent>& event) override;
+    void Process(const JEvent& event) override;
     void Finish() override;
 
 };

--- a/src/libraries/JANA/JCsvWriter.h
+++ b/src/libraries/JANA/JCsvWriter.h
@@ -25,6 +25,7 @@ public:
 
     JCsvWriter(std::string tag = "") : m_tag(std::move(tag)) {
         SetTypeName(NAME_OF_THIS);
+        SetCallbackStyle(CallbackStyle::ExpertMode);
     };
 
     void Init() override {
@@ -41,10 +42,10 @@ public:
         m_dest_file.open(filename, std::fstream::out);
     }
 
-    void Process(const std::shared_ptr<const JEvent>& event) override {
+    void Process(const JEvent& event) override {
 
-        auto event_nr = event->GetEventNumber();
-        auto jobjs = event->Get<T>(m_tag);
+        auto event_nr = event.GetEventNumber();
+        auto jobjs = event.Get<T>(m_tag);
 
         std::lock_guard<std::mutex> lock(m_mutex);
 

--- a/src/libraries/JANA/JEventProcessor.h
+++ b/src/libraries/JANA/JEventProcessor.h
@@ -104,6 +104,9 @@ public:
             if (m_callback_style == CallbackStyle::DeclarativeMode) {
                 Process(e->GetRunNumber(), e->GetEventNumber(), e->GetEventIndex());
             }
+            else if (m_callback_style == CallbackStyle::ExpertMode) {
+                Process(*e);
+            }
             else {
                 Process(e);
             }
@@ -161,6 +164,10 @@ public:
 
 
     virtual void Process(const std::shared_ptr<const JEvent>& /*event*/) {
+        throw JException("Not implemented yet!");
+    }
+    
+    virtual void Process(const JEvent& /*event*/) {
         throw JException("Not implemented yet!");
     }
 

--- a/src/libraries/JANA/Podio/JEventProcessorPodio.cc
+++ b/src/libraries/JANA/Podio/JEventProcessorPodio.cc
@@ -5,17 +5,20 @@
 
 #include "JEventProcessorPodio.h"
 
+JEventProcessorPodio::JEventProcessorPodio() {
+    SetCallbackStyle(CallbackStyle::ExpertMode);
+}
+
 void JEventProcessorPodio::Init() {
-    // TODO: Obtain m_output_filename, etc, from parameter manager
     // TODO: Does PODIO test that output file is writable and fail otherwise?
     //       We want to throw an exception immediately so that we don't waste compute time
 
-    m_writer = std::make_unique<podio::ROOTFrameWriter>(m_output_filename);
+    m_writer = std::make_unique<podio::ROOTFrameWriter>(m_output_filename());
 }
 
-void JEventProcessorPodio::Process(const std::shared_ptr<const JEvent> &event) {
+void JEventProcessorPodio::Process(const JEvent& event) {
 
-    auto* frame = event->GetSingle<podio::Frame>();
+    auto* frame = event.GetSingle<podio::Frame>();
     // This will throw if no PODIO frame is found. There will be no PODIO frame if the event source doesn't insert any
     // PODIO classes, or there are no JFactoryPodioT's provided.
     // Is this really the behavior we want? The alternatives are to silently not write anything, or to print a warning.

--- a/src/libraries/JANA/Podio/JEventProcessorPodio.h
+++ b/src/libraries/JANA/Podio/JEventProcessorPodio.h
@@ -11,14 +11,16 @@
 
 class JEventProcessorPodio : public JEventProcessor {
 
-    std::string m_output_filename = "podio_output.root";
+    Parameter<std::string> m_output_filename {this, "podio:output_filename", "podio_output.root", "Output filename for JEventProcessorPodio"};
+
     std::set<std::string> m_output_include_collections;
     std::set<std::string> m_output_exclude_collections;
     std::unique_ptr<podio::ROOTFrameWriter> m_writer;
 
 public:
+    JEventProcessorPodio();
     void Init() override;
-    void Process(const std::shared_ptr<const JEvent>&) override;
+    void Process(const JEvent&) override;
     void Finish() override;
 
 };

--- a/src/libraries/JANA/Utils/JAutoActivator.cc
+++ b/src/libraries/JANA/Utils/JAutoActivator.cc
@@ -69,13 +69,13 @@ void JAutoActivator::Init() {
     }
 }
 
-void JAutoActivator::Process(const std::shared_ptr<const JEvent> &event) {
+void JAutoActivator::Process(const JEvent& event) {
     for (const auto &pair: m_auto_activated_factories) {
         auto name = pair.first;
         auto tag = pair.second;
-        auto factory = event->GetFactory(name, tag);
+        auto factory = event.GetFactory(name, tag);
         if (factory != nullptr) {
-            factory->Create(event); // This will do nothing if factory is already created
+            factory->Create(event.shared_from_this()); // This will do nothing if factory is already created
         }
         else {
             LOG_ERROR(GetLogger()) << "Could not find factory with typename=" << name << ", tag=" << tag << LOG_END;

--- a/src/libraries/JANA/Utils/JAutoActivator.h
+++ b/src/libraries/JANA/Utils/JAutoActivator.h
@@ -19,7 +19,7 @@ public:
     static std::pair<std::string, std::string> Split(std::string factory_name);
     void AddAutoActivatedFactory(string factory_name, string factory_tag);
     void Init() override;
-    void Process(const std::shared_ptr<const JEvent>& event) override;
+    void Process(const JEvent&) override;
 
 private:
     vector<pair<string,string>> m_auto_activated_factories;

--- a/src/plugins/JTest/JTestPlotter.h
+++ b/src/plugins/JTest/JTestPlotter.h
@@ -21,7 +21,9 @@ class JTestPlotter : public JEventProcessor {
 public:
 
     JTestPlotter() {
+        SetPrefix("jtest:plotter");
         SetTypeName(NAME_OF_THIS);
+        SetCallbackStyle(CallbackStyle::ExpertMode);
     }
 
     void Init() override {
@@ -32,14 +34,14 @@ public:
         app->SetDefaultParameter("jtest:plotter_bytes_spread", m_write_spread, "Spread of bytes written during plotting");
     }
 
-    void Process(const std::shared_ptr<const JEvent>& aEvent) override {
+    void Process(const JEvent& event) override {
 
         // Read the track data
-        auto td = aEvent->GetSingle<JTestTrackData>();
+        auto td = event.GetSingle<JTestTrackData>();
         read_memory(td->buffer);
 
         // Read the extra data objects inserted by JTestTracker
-        aEvent->Get<JTestTracker::JTestTrackAuxilliaryData>();
+        event.Get<JTestTracker::JTestTrackAuxilliaryData>();
 
         // Everything that happens after here is in a critical section
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -50,7 +52,7 @@ public:
         // Write the histogram data
         auto hd = new JTestHistogramData;
         write_memory(hd->buffer, m_write_bytes, m_write_spread);
-        aEvent->Insert(hd);
+        event.Insert(hd);
     }
 
 };

--- a/src/plugins/JTestRoot/JTestRootProcessor.cc
+++ b/src/plugins/JTestRoot/JTestRootProcessor.cc
@@ -16,11 +16,12 @@
 
 JTestRootProcessor::JTestRootProcessor() {
     SetTypeName(NAME_OF_THIS); // Provide JANA with this class's name
+    SetCallbackStyle(CallbackStyle::ExpertMode);
 }
 
-void JTestRootProcessor::Process(const std::shared_ptr<const JEvent> &event) {
+void JTestRootProcessor::Process(const JEvent&) {
     // Get the cluster objects
-    auto clusters = event->Get<Cluster>();
+    auto clusters = event.Get<Cluster>();
 
     // Lock mutex so operations on ROOT objects are serialized
     std::lock_guard<std::mutex>lock(m_mutex);

--- a/src/plugins/JTestRoot/JTestRootProcessor.h
+++ b/src/plugins/JTestRoot/JTestRootProcessor.h
@@ -9,14 +9,13 @@
 class JTestRootProcessor : public JEventProcessor {
 
     // Shared state (e.g. histograms, TTrees, TFiles) live
-    std::mutex m_mutex;
     
 public:
 
     JTestRootProcessor();
     virtual ~JTestRootProcessor() = default;
 
-    void Process(const std::shared_ptr<const JEvent>& event) override;
+    void Process(const JEvent&) override;
 };
 
 

--- a/src/programs/unit_tests/BarrierEventTests.h
+++ b/src/programs/unit_tests/BarrierEventTests.h
@@ -46,14 +46,17 @@ public:
 struct BarrierProcessor : public JEventProcessor {
 
 public:
-    void Process(const std::shared_ptr<const JEvent>& event) override {
+    BarrierProcessor() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+    void Process(const JEvent& event) override {
 
-        if (event->GetSequential()) {
+        if (event.GetSequential()) {
             global_resource += 1;
-            LOG << "Barrier event = " << event->GetEventNumber() << ", writing global var = " << global_resource << LOG_END;
+            LOG << "Barrier event = " << event.GetEventNumber() << ", writing global var = " << global_resource << LOG_END;
         }
         else {
-            LOG << "Processing non-barrier event = " << event->GetEventNumber() << ", reading global var = " << global_resource << LOG_END;
+            LOG << "Processing non-barrier event = " << event.GetEventNumber() << ", reading global var = " << global_resource << LOG_END;
         }
     }
 };

--- a/src/programs/unit_tests/CMakeLists.txt
+++ b/src/programs/unit_tests/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TEST_SOURCES
     UnfoldTests.cc
     JComponentTests.cc
     Components/JEventSourceTests.cc
+    Components/JEventProcessorTests.cc
     )
 
 if (${USE_PODIO})

--- a/src/programs/unit_tests/Components/JEventProcessorTests.cc
+++ b/src/programs/unit_tests/Components/JEventProcessorTests.cc
@@ -1,0 +1,51 @@
+
+#include "catch.hpp"
+
+#include <JANA/JEventProcessor.h>
+#include <JANA/JEventSource.h>
+
+struct MyEventProcessor : public JEventProcessor {
+    int init_count = 0;
+    int process_count = 0;
+    int finish_count = 0;
+
+    MyEventProcessor() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+        SetTypeName(NAME_OF_THIS);
+    }
+    void Init() override {
+        LOG_INFO(GetLogger()) << "Init() called" << LOG_END;
+        init_count++;
+    }
+    void Process(const JEvent&) override {
+        process_count++;
+        LOG_INFO(GetLogger()) << "Process() called" << LOG_END;
+    }
+    void Finish() override {
+        LOG_INFO(GetLogger()) << "Finish() called" << LOG_END;
+        finish_count++;
+    }
+};
+
+TEST_CASE("JEventProcessor_ExpertMode_ProcessCount") {
+
+    LOG << "Running test: JEventProcessor_ExpertMode_ProcessCount" << LOG_END;
+
+    auto sut = new MyEventProcessor;
+
+    JApplication app;
+    app.SetParameterValue("log:global", "off");
+    app.SetParameterValue("log:info", "MyEventProcessor");
+    app.SetParameterValue("jana:nevents", 5);
+
+    app.Add(new JEventSource);
+    app.Add(sut);
+    app.Run();
+
+    REQUIRE(sut->init_count == 1);
+    REQUIRE(sut->process_count == 5);
+    REQUIRE(sut->GetEventCount() == 5);
+    REQUIRE(sut->finish_count == 1);
+
+}
+

--- a/src/programs/unit_tests/ExactlyOnceTests.h
+++ b/src/programs/unit_tests/ExactlyOnceTests.h
@@ -41,11 +41,15 @@ struct SimpleProcessor : public JEventProcessor {
     std::atomic_int init_count {0};
     std::atomic_int finish_count {0};
 
+    SimpleProcessor() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+
     void Init() override {
         init_count += 1;
     }
 
-    void Process(const std::shared_ptr<const JEvent>&) override {
+    void Process(const JEvent&) override {
     }
 
     void Finish() override {

--- a/src/programs/unit_tests/MultiLevelTopologyTests.h
+++ b/src/programs/unit_tests/MultiLevelTopologyTests.h
@@ -84,15 +84,19 @@ struct MyEventProcessor : public JEventProcessor {
     std::atomic_int process_called_count {0};
     std::atomic_int finish_called_count {0};
 
+    MyEventProcessor() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+
     void Init() override {
         init_called_count++;
     }
 
-    void Process(const std::shared_ptr<const JEvent>& event) override {
+    void Process(const JEvent& event) override {
         process_called_count++;
         // TODO: Trigger cluster factory
         // TODO: Validate that the clusters make sense
-        jout << "MyEventProcessor: Processing " << event->GetEventNumber() << jendl;
+        jout << "MyEventProcessor: Processing " << event.GetEventNumber() << jendl;
         REQUIRE(init_called_count == 1);
         REQUIRE(finish_called_count == 0);
     }

--- a/src/programs/unit_tests/ScaleTests.h
+++ b/src/programs/unit_tests/ScaleTests.h
@@ -25,7 +25,10 @@ struct DummySource : public JEventSource {
 
 struct DummyProcessor : public JEventProcessor {
 
-    void Process(const std::shared_ptr<const JEvent> &) override {
+    DummyProcessor() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+    void Process(const JEvent&) override {
         consume_cpu_ms(100);
         std::this_thread::sleep_for(std::chrono::nanoseconds(1));
     }

--- a/src/programs/unit_tests/SubeventTests.cc
+++ b/src/programs/unit_tests/SubeventTests.cc
@@ -160,8 +160,11 @@ TEST_CASE("Basic subevent arrow functionality") {
     };
 
     struct SimpleProcessor : public JEventProcessor {
-        void Process(const std::shared_ptr<const JEvent>& event) {
-            auto outputs = event->Get<MyOutput>();
+        SimpleProcessor() {
+            SetCallbackStyle(CallbackStyle::ExpertMode);
+        }
+        void Process(const JEvent& event) {
+            auto outputs = event.Get<MyOutput>();
             REQUIRE(outputs.size() == 4);
             REQUIRE(outputs[0]->z == 25.6f);
             REQUIRE(outputs[1]->z == 26.5f);

--- a/src/programs/unit_tests/TerminationTests.h
+++ b/src/programs/unit_tests/TerminationTests.h
@@ -63,10 +63,13 @@ struct CountingProcessor : public JEventProcessor {
     std::atomic_int processed_count {0};
     std::atomic_int finish_call_count {0};
 
+    CountingProcessor() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
 
     void Init() override {}
 
-    void Process(const std::shared_ptr<const JEvent>& /*event*/) override {
+    void Process(const JEvent&) override {
         processed_count += 1;
         // jout << "Processing " << event->GetEventNumber() << jendl;
         REQUIRE(finish_call_count == 0);

--- a/src/programs/unit_tests/TimeoutTests.h
+++ b/src/programs/unit_tests/TimeoutTests.h
@@ -61,11 +61,13 @@ struct ProcessorWithTimeout : public JEventProcessor {
                                   int first_event_delay_ms = 0)
         : timeout_on_event_nr(timeout_on_event_nr)
         , first_event_delay_ms(first_event_delay_ms)
-    { }
+    { 
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
 
     void Init() override {}
 
-    void Process(const std::shared_ptr<const JEvent>&) override {
+    void Process(const JEvent&) override {
         processed_count += 1;
         if (processed_count == 1) {
             std::this_thread::sleep_for(std::chrono::milliseconds(first_event_delay_ms));

--- a/src/programs/unit_tests/UserExceptionTests.h
+++ b/src/programs/unit_tests/UserExceptionTests.h
@@ -50,7 +50,9 @@ struct FlakyProcessor : public JEventProcessor {
         : init_excepts(init_excepts)
         , process_excepts(process_excepts)
         , finish_excepts(finish_excepts)
-        {};
+        {
+            SetCallbackStyle(CallbackStyle::ExpertMode);
+        };
 
     void Init() override {
         if (init_excepts) {
@@ -58,7 +60,7 @@ struct FlakyProcessor : public JEventProcessor {
         }
     };
 
-    void Process(const std::shared_ptr<const JEvent>&) override {
+    void Process(const JEvent&) override {
         if (process_excepts) {
             throw JException("Unable to process!");
         }


### PR DESCRIPTION
JEventProcessor now provides a callback `void Process(const JEvent&)` as an eventual replacement for `void Process(const std::shared_ptr<const JEvent>&)`. It is usable immediately, though you have to call `SetCallbackStyle(CallbackStyle::ExpertMode);` in the constructor in order to enable it.
