### PR TITLE
Bugfix: Missing JApplication pointer generating JEventSourcePODIO

### DIFF
--- a/src/examples/TimesliceExample/MyFileReader.h
+++ b/src/examples/TimesliceExample/MyFileReader.h
@@ -21,7 +21,7 @@ struct MyFileReader : public JEventSource {
 
     void Close() override { }
 
-    Result Emit(JEvent&) override {
+    Result Emit(JEvent& event) override {
 
         auto event_nr = event.GetEventNumber();
 

--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -124,11 +124,11 @@ void JApplication::Initialize() {
     // Attach all plugins
     plugin_loader->attach_plugins(component_manager.get());
 
-    // Resolve all event sources now that all plugins have been loaded
-    component_manager->resolve_event_sources();
-    
     // Give all components a JApplication pointer and a logger
     component_manager->configure_components();
+
+    // Resolve all event sources now that all plugins have been loaded
+    component_manager->resolve_event_sources();
 
     // Set desired nthreads. We parse the 'nthreads' parameter two different ways for backwards compatibility.
     m_desired_nthreads = 1;

--- a/src/plugins/JTestRoot/JTestRootEventSource.h
+++ b/src/plugins/JTestRoot/JTestRootEventSource.h
@@ -12,7 +12,7 @@
 class JTestRootEventSource : public JEventSource {
 
 public:
-    JTestRootEventSource(std::string resource_name, JApplication* app);
+    JTestRootEventSource();
     virtual ~JTestRootEventSource() = default;
 
     Result Emit(JEvent& event) override;

--- a/src/plugins/JTestRoot/JTestRootProcessor.cc
+++ b/src/plugins/JTestRoot/JTestRootProcessor.cc
@@ -19,7 +19,7 @@ JTestRootProcessor::JTestRootProcessor() {
     SetCallbackStyle(CallbackStyle::ExpertMode);
 }
 
-void JTestRootProcessor::Process(const JEvent&) {
+void JTestRootProcessor::Process(const JEvent& event) {
     // Get the cluster objects
     auto clusters = event.Get<Cluster>();
 


### PR DESCRIPTION
This fixes Issue #295 along with a couple other minor breakages on eic-shell. 