### PR TITLE
Bugfix: Components not being destroyed when they should

### DIFF
--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -39,7 +39,7 @@ JApplication::JApplication(JParameterManager* params) {
     }
     m_component_manager = std::make_shared<JComponentManager>();
     m_plugin_loader = std::make_shared<JPluginLoader>();
-    m_service_locator = new JServiceLocator;
+    m_service_locator = std::make_unique<JServiceLocator>();
 
     ProvideService(m_params);
     ProvideService(m_component_manager);

--- a/src/libraries/JANA/JApplicationFwd.h
+++ b/src/libraries/JANA/JApplicationFwd.h
@@ -135,7 +135,8 @@ public:
 private:
 
     JLogger m_logger;
-    JServiceLocator* m_service_locator;
+
+    std::unique_ptr<JServiceLocator> m_service_locator;
 
     std::shared_ptr<JParameterManager> m_params;
     std::shared_ptr<JPluginLoader> m_plugin_loader;


### PR DESCRIPTION
We are using shared_ptrs to manage the lifetimes of all JServices. JServiceLocator was holding onto some of these shared_ptrs and wasn't being deleted. The fix for now is to make sure JServiceLocator gets deleted when JApplication does. The longer-term fix is to stop holding on to JServices using shared_ptrs, since users may trivially create cycles. An even better option is to use Service<T> helpers with weak or raw pointers internally.

This addresses issue #284.