### PR TITLE
Bugfix: Build system fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,13 +46,12 @@ Darwin_*
 .Darwin_*
 Makefile
 
-build/
-cmake-build-debug/
-install/
-bin/
-include/
-lib/
-programs/
+/build*/
+/install*/
+
+/bin/
+/include/
+/lib/
 
 # Doxygen generated files
 docs/html/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ endfunction()
 #----------------------
 
 option(USE_ROOT "Include ROOT dependency." OFF)
-option(USE_ZEROMQ "Include ZeroMQ dependency. (Needed for examples/StreamingExample, programs/StreamDet, plugins/janacontrol), " OFF)
+option(USE_ZEROMQ "Include ZeroMQ dependency. (Needed for examples/StreamingExample, plugins/streamDet, plugins/janacontrol), " OFF)
 option(USE_XERCES "Include XercesC 3 dependency. (Needed for JGeometryXML)" OFF)
 option(USE_PYTHON "Include Python dependency. This requires python-devel and python-distutils." OFF)
 option(USE_ASAN "Compile with address sanitizer" OFF)

--- a/scripts/ci/submit_SubeventCUDAExample.slurm
+++ b/scripts/ci/submit_SubeventCUDAExample.slurm
@@ -40,5 +40,5 @@ srun cmake --build build -j 32 --target install
 
 # run
 echo "\n Launching SubeventCUDAExample for 1s..."
-srun ./install/programs/SubeventCUDAExample & \
+srun ./install/bin/SubeventCUDAExample & \
   sleep 1  # exit effect

--- a/scripts/jana-config.in
+++ b/scripts/jana-config.in
@@ -75,7 +75,12 @@ while test $# -gt 0; do
 	esac
 	case $1 in
 		--libs)
-			mess="$mess -L${JANA_INSTALL_DIR}/lib -lJANA ${LDFLAGS} ${JANA_ONLY_LIBS} ${LIBS}"
+			mess="$mess -Wl,-rpath,${JANA_INSTALL_DIR}/lib -L${JANA_INSTALL_DIR}/lib -lJANA ${LDFLAGS} ${JANA_ONLY_LIBS} ${LIBS}"
+			;;
+	esac
+	case $1 in
+		--static-libs)
+			mess="$mess ${JANA_INSTALL_DIR}/lib/libJANA.a ${LDFLAGS} ${JANA_ONLY_LIBS} ${LIBS}"
 			;;
 	esac
 	case $1 in

--- a/src/examples/SubeventCUDAExample/CMakeLists.txt
+++ b/src/examples/SubeventCUDAExample/CMakeLists.txt
@@ -12,7 +12,7 @@ if (USE_CUDA)
 	target_link_libraries(SubeventCUDAExample jana2)
 	set_target_properties(SubeventCUDAExample PROPERTIES PREFIX "" OUTPUT_NAME "SubeventCUDAExample"
 			CUDA_ARCHITECTURES "75;80")
-	install(TARGETS SubeventCUDAExample DESTINATION programs)
+	install(TARGETS SubeventCUDAExample DESTINATION bin)
 else()
 	message(STATUS "Skipping examples/SubeventCUDAExample because USE_CUDA=Off")
 

--- a/src/examples/SubeventCUDAExample/README.md
+++ b/src/examples/SubeventCUDAExample/README.md
@@ -22,6 +22,6 @@ This is an example that can run on a single GPU.
    ```
    Launch the application.
    ```bash
-   bash-4.2$ ./install/programs/SubeventCUDAExample
+   bash-4.2$ ./install/bin/SubeventCUDAExample
    ```
 

--- a/src/examples/UnitTestingExample/CMakeLists.txt
+++ b/src/examples/UnitTestingExample/CMakeLists.txt
@@ -10,4 +10,4 @@ target_include_directories(UnitTestingExample PRIVATE ${CMAKE_SOURCE_DIR}/src/ex
 
 target_link_libraries(UnitTestingExample Tutorial_plugin jana2)
 set_target_properties(UnitTestingExample PROPERTIES PREFIX "" OUTPUT_NAME "UnitTestingExample")
-install(TARGETS UnitTestingExample DESTINATION programs)
+install(TARGETS UnitTestingExample DESTINATION bin)


### PR DESCRIPTION
- `jana-config` now adds `$JANA_INSTALL_DIR/lib` to rpath
- `jana-config` now understands static vs dynamic library linking
- `.gitignore` no longer accidentally ignores `src/programs`
- `examples/SubeventCUDAExample` and `examples/UnitTestingExample` now install to `bin` instead of `programs`
- `.gitignore` now uses wildcards for build and install directories
