### PR TITLE
Improvements to JVersion

### DIFF
--- a/cmake/MakeJVersionH.cmake
+++ b/cmake/MakeJVersionH.cmake
@@ -15,31 +15,35 @@ set_property(
 )
 
 execute_process(
-        COMMAND git log -1 --format=%H 2>/dev/null
+        COMMAND git log -1 --format=%H
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         RESULT_VARIABLE JVERSION_GIT_RESULT
         OUTPUT_VARIABLE JVERSION_COMMIT_HASH
+        ERROR_QUIET
         OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 execute_process(
-        COMMAND git log -1 --format=%aD 2>/dev/null
+        COMMAND git log -1 --format=%aD
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         OUTPUT_VARIABLE JVERSION_COMMIT_DATE
+        ERROR_QUIET
         OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 execute_process(
-        COMMAND git show-ref -s v${jana2_VERSION_MAJOR}.${jana2_VERSION_MINOR}.${jana2_VERSION_PATCH} 2>/dev/null
+        COMMAND git show-ref -s v${jana2_VERSION_MAJOR}.${jana2_VERSION_MINOR}.${jana2_VERSION_PATCH}
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         OUTPUT_VARIABLE JVERSION_RELEASE_COMMIT_HASH
+        ERROR_QUIET
         OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 execute_process(
-        COMMAND git status --porcelain 2>/dev/null
+        COMMAND git status --porcelain
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         OUTPUT_VARIABLE JVERSION_MODIFIED_FILES
+        ERROR_QUIET
         OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 

--- a/src/libraries/JANA/CLI/JMain.cc
+++ b/src/libraries/JANA/CLI/JMain.cc
@@ -4,7 +4,6 @@
 
 #include "JMain.h"
 
-#include <JANA/JVersion.h>
 #include <JANA/CLI/JBenchmarker.h>
 #include <JANA/CLI/JSignalHandler.h>
 
@@ -76,8 +75,6 @@ JApplication* CreateJApplication(UserOptions& options) {
 
 int Execute(JApplication* app, UserOptions &options) {
 
-    JVersion::PrintSplash(std::cout);
-    JVersion::PrintVersionDescription(std::cout);
     JSignalHandler::register_handlers(app);
 
     if (options.flags[ShowConfigs]) {

--- a/src/libraries/JANA/CLI/JMain.cc
+++ b/src/libraries/JANA/CLI/JMain.cc
@@ -45,15 +45,6 @@ void PrintUsageOptions() {
     std::cout << "        --inspect-component <name>    Inspect a component" << std::endl;
 }
 
-void PrintVersion() {
-    /// Prints JANA version information to stdout, for use by the CLI.
-
-    std::cout << "JANA2 version:  " << JVersion::GetVersion() << std::endl;
-    if (!JVersion::is_unknown) {
-        std::cout << "Commit hash:    " << JVersion::GetCommitHash() << std::endl;
-        std::cout << "Commit date:    " << JVersion::GetCommitDate() << std::endl;
-    }
-}
 
 JApplication* CreateJApplication(UserOptions& options) {
 
@@ -85,13 +76,8 @@ JApplication* CreateJApplication(UserOptions& options) {
 
 int Execute(JApplication* app, UserOptions &options) {
 
-    std::cout << std::endl;
-    std::cout << "       |    \\      \\  |     \\    ___ \\   " << std::endl;
-    std::cout << "       |   _ \\      \\ |    _ \\      ) |" << std::endl;
-    std::cout << "   \\   |  ___ \\   |\\  |   ___ \\    __/" << std::endl;
-    std::cout << "  \\___/ _/    _\\ _| \\_| _/    _\\ _____|" << std::endl;
-    std::cout << std::endl;
-    PrintVersion();
+    JVersion::PrintSplash(std::cout);
+    JVersion::PrintVersionDescription(std::cout);
     JSignalHandler::register_handlers(app);
 
     if (options.flags[ShowConfigs]) {

--- a/src/libraries/JANA/CMakeLists.txt
+++ b/src/libraries/JANA/CMakeLists.txt
@@ -23,6 +23,7 @@ set(JANA2_SOURCES
     JMultifactory.cc
     JMultifactory.h
     JService.cc
+    JVersion.cc
 
     Engine/JArrowProcessingController.cc
     Engine/JArrowProcessingController.h

--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -17,6 +17,7 @@
 #include <JANA/Engine/JArrowProcessingController.h>
 #include <JANA/Utils/JApplicationInspector.h>
 
+#include <sstream>
 #include <unistd.h>
 
 JApplication *japp = nullptr;
@@ -107,6 +108,12 @@ void JApplication::Initialize() {
 
     // Only run this once
     if (m_initialized) return;
+
+    std::ostringstream oss;
+    oss << "Initializing..." << std::endl;
+    JVersion::PrintSplash(oss);
+    JVersion::PrintVersionDescription(oss);
+    LOG_INFO(m_logger) << oss.str() << LOG_END;
 
     // Now that all parameters, components, plugin names, etc have been set, 
     // we can expose our builtin services to the user via GetService()

--- a/src/libraries/JANA/JVersion.cc
+++ b/src/libraries/JANA/JVersion.cc
@@ -6,6 +6,10 @@
 #include <sstream>
 
 
+constexpr size_t JVersion::GetVersionNumber() {
+    return 1000000*major + 1000*minor + patch;
+}
+
 std::string JVersion::GetVersion() {
     std::stringstream ss;
     PrintVersionNumbers(ss);

--- a/src/libraries/JANA/JVersion.cc
+++ b/src/libraries/JANA/JVersion.cc
@@ -6,8 +6,8 @@
 #include <sstream>
 
 
-constexpr size_t JVersion::GetVersionNumber() {
-    return 1000000*major + 1000*minor + patch;
+constexpr uint64_t JVersion::GetVersionNumber() {
+    return 1000000*GetMajorNumber() + 1000*minor + patch;
 }
 
 std::string JVersion::GetVersion() {
@@ -31,7 +31,7 @@ void JVersion::PrintSplash(std::ostream& os) {
 
 void JVersion::PrintVersionDescription(std::ostream& os) {
 
-    os << "JANA2 version:  " << JVersion::GetVersion() << " ";
+    os << "JANA2 version:   " << JVersion::GetVersion() << " ";
     if (is_unknown) {
         os << " (unknown git status)";
     }
@@ -46,12 +46,12 @@ void JVersion::PrintVersionDescription(std::ostream& os) {
     }
     os << std::endl;
     if (!JVersion::is_unknown) {
-        os << "Commit hash:    " << JVersion::GetCommitHash() << std::endl;
-        os << "Commit date:    " << JVersion::GetCommitDate() << std::endl;
+        os << "Commit hash:     " << JVersion::GetCommitHash() << std::endl;
+        os << "Commit date:     " << JVersion::GetCommitDate() << std::endl;
     }
-    os << "Install prefix: " << JVersion::GetInstallDir() << std::endl;
+    os << "Install prefix:  " << JVersion::GetInstallDir() << std::endl;
     if (JVersion::HasPodio() || JVersion::HasROOT() || JVersion::HasXerces()) {
-        os << "Optional deps:  ";
+        os << "Optional deps:   ";
         if (JVersion::HasPodio()) os << "Podio ";
         if (JVersion::HasROOT()) os << "ROOT ";
         if (JVersion::HasXerces()) os << "Xerces ";

--- a/src/libraries/JANA/JVersion.cc
+++ b/src/libraries/JANA/JVersion.cc
@@ -1,0 +1,58 @@
+// Copyright 2024, Jefferson Science Associates, LLC.
+// Subject to the terms in the LICENSE file found in the top-level directory.
+// Author: Nathan Brei
+
+#include <JANA/JVersion.h>
+#include <sstream>
+
+
+std::string JVersion::GetVersion() {
+    std::stringstream ss;
+    PrintVersionNumbers(ss);
+    return ss.str();
+}
+
+void JVersion::PrintVersionNumbers(std::ostream& os) {
+    os << major << "." << minor << "." << patch;
+}
+
+void JVersion::PrintSplash(std::ostream& os) {
+    os << std::endl;
+    os << "       |    \\      \\  |     \\    ___ \\   " << std::endl;
+    os << "       |   _ \\      \\ |    _ \\      ) |" << std::endl;
+    os << "   \\   |  ___ \\   |\\  |   ___ \\    __/" << std::endl;
+    os << "  \\___/ _/    _\\ _| \\_| _/    _\\ _____|" << std::endl;
+    os << std::endl;
+}
+
+void JVersion::PrintVersionDescription(std::ostream& os) {
+
+    os << "JANA2 version:  " << JVersion::GetVersion() << " ";
+    if (is_unknown) {
+        os << " (unknown git status)";
+    }
+    else if (is_release) {
+        os << " (release)";
+    }
+    else if (is_modified) {
+        os << " (uncommitted changes)";
+    }
+    else {
+        os << " (committed changes)";
+    }
+    os << std::endl;
+    if (!JVersion::is_unknown) {
+        os << "Commit hash:    " << JVersion::GetCommitHash() << std::endl;
+        os << "Commit date:    " << JVersion::GetCommitDate() << std::endl;
+    }
+    os << "Install prefix: " << JVersion::GetInstallDir() << std::endl;
+    if (JVersion::HasPodio() || JVersion::HasROOT() || JVersion::HasXerces()) {
+        os << "Optional deps:  ";
+        if (JVersion::HasPodio()) os << "Podio ";
+        if (JVersion::HasROOT()) os << "ROOT ";
+        if (JVersion::HasXerces()) os << "Xerces ";
+        os << std::endl;
+    }
+}
+
+

--- a/src/libraries/JANA/JVersion.h.in
+++ b/src/libraries/JANA/JVersion.h.in
@@ -3,7 +3,7 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
 #pragma once
-#include <sstream>
+#include <ostream>
 
 #define JANA2_HAVE_PODIO @JANA2_HAVE_PODIO@
 #define JANA2_HAVE_ROOT @JANA2_HAVE_ROOT@
@@ -36,24 +36,11 @@ struct JVersion {
     static bool HasROOT() { return JANA2_HAVE_ROOT; }
     static bool HasXerces() { return JANA2_HAVE_XERCES; }
 
-    static std::string GetVersion() {
-        std::stringstream ss;
-        ss << major << "." << minor << "." << patch;
-        if (is_unknown) {
-            // ss << " (git status unknown)";
-            // If .git is not present, degrade gracefully. Don't lead the user to believe that there is an error
-        }
-        else if (is_modified) {
-            ss << " (uncommitted changes)";
-        }
-        else if (is_release) {
-            ss << " (release)";
-        }
-        else {
-            ss << " (development)";
-        }
-        return ss.str();
-    }
+    static std::string GetVersion();
+    static void PrintSplash(std::ostream& os);
+    static void PrintVersionNumbers(std::ostream& os);
+    static void PrintVersionDescription(std::ostream& os);
+
 };
 
 

--- a/src/libraries/JANA/JVersion.h.in
+++ b/src/libraries/JANA/JVersion.h.in
@@ -3,6 +3,7 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
 #pragma once
+#include <cstdint>
 #include <ostream>
 
 #define JANA2_HAVE_PODIO @JANA2_HAVE_PODIO@
@@ -12,9 +13,9 @@
 
 struct JVersion {
 
-    static const int major = @jana2_VERSION_MAJOR@;
-    static const int minor = @jana2_VERSION_MINOR@;
-    static const int patch = @jana2_VERSION_PATCH@;
+    static const uint64_t major = @jana2_VERSION_MAJOR@;
+    static const uint64_t minor = @jana2_VERSION_MINOR@;
+    static const uint64_t patch = @jana2_VERSION_PATCH@;
 
     inline static const std::string last_commit_hash = "@JVERSION_COMMIT_HASH@";
     inline static const std::string last_commit_date = "@JVERSION_COMMIT_DATE@";
@@ -24,20 +25,20 @@ struct JVersion {
     static const bool is_release = @JVERSION_RELEASE@;
     static const bool is_modified = @JVERSION_MODIFIED@;
 
-    static unsigned int GetMajorNumber() { return major; }
-    static unsigned int GetMinorNumber() { return minor; }
-    static unsigned int GetPatchNumber() { return patch; }
+    static constexpr uint64_t GetMajorNumber() { return major; }
+    static constexpr uint64_t GetMinorNumber() { return minor; }
+    static constexpr uint64_t GetPatchNumber() { return patch; }
 
     static std::string GetCommitHash() { return last_commit_hash; }
     static std::string GetCommitDate() { return last_commit_date; }
     static std::string GetInstallDir() { return installdir; }
 
-    static bool HasPodio() { return JANA2_HAVE_PODIO; }
-    static bool HasROOT() { return JANA2_HAVE_ROOT; }
-    static bool HasXerces() { return JANA2_HAVE_XERCES; }
+    static constexpr bool HasPodio() { return JANA2_HAVE_PODIO; }
+    static constexpr bool HasROOT() { return JANA2_HAVE_ROOT; }
+    static constexpr bool HasXerces() { return JANA2_HAVE_XERCES; }
 
     static std::string GetVersion();
-    static constexpr size_t GetVersionNumber();
+    static constexpr uint64_t GetVersionNumber();
 
     static void PrintSplash(std::ostream& os);
     static void PrintVersionNumbers(std::ostream& os);

--- a/src/libraries/JANA/JVersion.h.in
+++ b/src/libraries/JANA/JVersion.h.in
@@ -37,6 +37,8 @@ struct JVersion {
     static bool HasXerces() { return JANA2_HAVE_XERCES; }
 
     static std::string GetVersion();
+    static constexpr size_t GetVersionNumber();
+
     static void PrintSplash(std::ostream& os);
     static void PrintVersionNumbers(std::ostream& os);
     static void PrintVersionDescription(std::ostream& os);

--- a/src/libraries/JANA/Services/JPluginLoader.h
+++ b/src/libraries/JANA/Services/JPluginLoader.h
@@ -28,6 +28,7 @@ public:
     void add_plugin_path(std::string path);
     void attach_plugins(JComponentManager* jcm);
     void attach_plugin(std::string plugin_name);
+    void resolve_plugin_paths();
 
 private:
     Service<JParameterManager> m_params {this};

--- a/src/programs/jana/jana.cc
+++ b/src/programs/jana/jana.cc
@@ -3,6 +3,7 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
 #include <JANA/CLI/JMain.h>
+#include <JANA/JVersion.h>
 
 int main(int argc, char* argv[]) {
 
@@ -15,7 +16,7 @@ int main(int argc, char* argv[]) {
 	}
 	if (options.flags[jana::ShowVersion]) {
 		// Show version information and exit immediately
-		jana::PrintVersion();
+		JVersion::PrintVersionDescription(std::cout);
 		return -1;
 	}
 	auto app = jana::CreateJApplication(options);


### PR DESCRIPTION
- Feature: constexpr JVersion arithmetic
- Feature: JPluginLoader now searches for plugins in CMAKE_INSTALL_PREFIX
- Feature: Version description now includes install prefix and optional dependencies
- Bugfix: stderr suppression while generating JVersion.h
- Refactoring: Move version and splash printers out of JMain and into JVersion
- Refactoring: Call version and splash printers from JApplication::Initialize instead of JMain
