### PR TITLE
Bugfix: Use-after-free when same plugin is loaded twice

### DIFF
--- a/.github/workflows/eicshell.yml
+++ b/.github/workflows/eicshell.yml
@@ -24,6 +24,7 @@ jobs:
           cd $GITHUB_WORKSPACE/build
           cmake .. \
             -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE \
+            -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_STANDARD=20 \
             -DUSE_PYTHON=ON \
             -DUSE_ROOT=ON \
@@ -115,7 +116,7 @@ jobs:
           cd ..
           git clone https://github.com/eic/EICrecon
           cd EICrecon
-          cmake -S . -B build -DJANA_DIR=$JANA_HOME/lib/cmake/JANA
+          cmake -S . -B build -DJANA_DIR=$JANA_HOME/lib/JANA/cmake -DCMAKE_BUILD_TYPE=Debug
           cmake --build build --target install -- -j8
 
     - name: Generate EICrecon input data

--- a/.github/workflows/eicshell.yml
+++ b/.github/workflows/eicshell.yml
@@ -41,23 +41,26 @@ jobs:
           cd $GITHUB_WORKSPACE/build
           make -j4 install
     
-    - name: Examine dynamic linking
-      run: |
-        export JANA_HOME=$GITHUB_WORKSPACE
-        export JANA_PLUGIN_PATH=$JANA_HOME/plugins
-        export LD_LIBRARY_PATH=$JANA_HOME/lib:$JANA_HOME/lib/JANA/plugins:$LD_LIBRARY_PATH
-        echo "ldd bin/jana"
-        ldd bin/jana
-        echo "ldd bin/libJANA.so"
-        ldd lib/libJANA.so
-        echo "bin/jana rpath"
-        objdump -x bin/jana | grep PATH
-        echo "lib/libJANA.so rpath"
-        objdump -x lib/libJANA.so | grep PATH
-        echo "lib/JANA/plugins/TimesliceExample.so"
-        objdump -x lib/JANA/plugins/TimesliceExample.so | grep PATH
-        echo "bin/PodioExample"
-        objdump -x bin/PodioExample | grep PATH
+    - name: Examine JANA2 dynamic linking
+      uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "jug_xl:nightly"
+        run: |
+          export JANA_HOME=$GITHUB_WORKSPACE
+          export JANA_PLUGIN_PATH=$JANA_HOME/plugins
+          export LD_LIBRARY_PATH=$JANA_HOME/lib:$JANA_HOME/lib/JANA/plugins:$LD_LIBRARY_PATH
+          echo "ldd bin/jana"
+          ldd bin/jana
+          echo "ldd bin/libJANA.so"
+          ldd lib/libJANA.so
+          echo "bin/jana rpath"
+          objdump -x bin/jana | grep PATH
+          echo "lib/libJANA.so rpath"
+          objdump -x lib/libJANA.so | grep PATH
+          echo "lib/JANA/plugins/TimesliceExample.so"
+          objdump -x lib/JANA/plugins/TimesliceExample.so | grep PATH
+          echo "bin/PodioExample"
+          objdump -x bin/PodioExample | grep PATH
 
     - name: Run JTest plugin with 100 events
       uses: eic/run-cvmfs-osg-eic-shell@main
@@ -118,6 +121,22 @@ jobs:
           cd EICrecon
           cmake -S . -B build -DJANA_DIR=$JANA_HOME/lib/JANA/cmake -DCMAKE_BUILD_TYPE=Debug
           cmake --build build --target install -- -j8
+    
+    - name: Examine EICrecon dynamic linking
+      uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "jug_xl:nightly"
+        run: |
+          export JANA_HOME=$GITHUB_WORKSPACE
+          export JANA_PLUGIN_PATH=$JANA_HOME/plugins
+          export LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/../EICrecon/lib:${GITHUB_WORKSPACE}/../EICrecon/lib/EICrecon/plugins:${JANA_HOME}/lib:${JANA_HOME}/lib/JANA/plugins:$LD_LIBRARY_PATH
+          cd ../EICrecon
+          echo "ldd bin/eicrecon"
+          ldd bin/eicrecon
+          echo "ldd lib/libreco.so"
+          ldd lib/libreco.so
+          echo "ldd lib/EICrecon/plugins/tracking.so"
+          ldd lib/EICrecon/plugins/tracking.so
 
     - name: Generate EICrecon input data
       uses: eic/run-cvmfs-osg-eic-shell@main
@@ -137,9 +156,8 @@ jobs:
         platform-release: "jug_xl:nightly"
         setup: "/opt/detector/epic-main/bin/thisepic.sh"
         run: |
-          echo "--- Running EICrecon ---"
           export JANA_HOME=$GITHUB_WORKSPACE
           export JANA_PLUGIN_PATH=$GITHUB_WORKSPACE/../EICrecon/lib/EICrecon/plugins
-          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/../EICrecon/lib:$JANA_HOME/lib:$JANA_HOME/lib/JANA/plugins:$LD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/../EICrecon/lib:${GITHUB_WORKSPACE}/../EICrecon/lib/EICrecon/plugins:${JANA_HOME}/lib:${JANA_HOME}/lib/JANA/plugins:$LD_LIBRARY_PATH
           ../EICrecon/bin/eicrecon sim_e_1GeV_20GeV_craterlake.edm4hep.root
 

--- a/src/libraries/JANA/JEventProcessor.h
+++ b/src/libraries/JANA/JEventProcessor.h
@@ -112,9 +112,9 @@ public:
     }
 
 
-    void Summarize(JComponentSummary& summary) {
+    void Summarize(JComponentSummary& summary) const override {
         auto* result = new JComponentSummary::Component(
-                JComponentSummary::ComponentType::Processor, GetPrefix(), GetTypeName(), GetLevel(), GetPluginName());
+            "Processor", GetPrefix(), GetTypeName(), GetLevel(), GetPluginName());
 
         for (const auto* input : m_inputs) {
             size_t subinput_count = input->names.size();

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -373,10 +373,10 @@ public:
         }
     }
 
-    void Summarize(JComponentSummary& summary) {
+    void Summarize(JComponentSummary& summary) const override {
 
         auto* result = new JComponentSummary::Component(
-                JComponentSummary::ComponentType::Source, GetPrefix(), GetTypeName(), GetLevel(), GetPluginName());
+            "Source", GetPrefix(), GetTypeName(), GetLevel(), GetPluginName());
 
         for (const auto* output : m_outputs) {
             size_t suboutput_count = output->collection_names.size();

--- a/src/libraries/JANA/JEventUnfolder.h
+++ b/src/libraries/JANA/JEventUnfolder.h
@@ -169,9 +169,9 @@ public:
         }
     }
 
-    void Summarize(JComponentSummary& summary) override {
+    void Summarize(JComponentSummary& summary) const override {
         auto* us = new JComponentSummary::Component( 
-                JComponentSummary::ComponentType::Unfolder, GetPrefix(), GetTypeName(), GetLevel(), GetPluginName());
+            "Unfolder", GetPrefix(), GetTypeName(), GetLevel(), GetPluginName());
 
         for (const auto* input : m_inputs) {
             size_t subinput_count = input->names.size();

--- a/src/libraries/JANA/JFactory.cc
+++ b/src/libraries/JANA/JFactory.cc
@@ -47,10 +47,10 @@ void JFactory::DoInit() {
     }
 }
 
-void JFactory::Summarize(JComponentSummary& summary) {
+void JFactory::Summarize(JComponentSummary& summary) const {
 
     auto fs = new JComponentSummary::Component(
-            JComponentSummary::ComponentType::Factory,
+            "Factory",
             GetPrefix(),
             GetTypeName(),
             GetLevel(),

--- a/src/libraries/JANA/JFactory.h
+++ b/src/libraries/JANA/JFactory.h
@@ -174,7 +174,7 @@ public:
     /// type of object contained. In order to access these objects when all you have is a JFactory*, use JFactory::GetAs().
     virtual void Create(const std::shared_ptr<const JEvent>& event);
     void DoInit();
-    void Summarize(JComponentSummary& summary);
+    void Summarize(JComponentSummary& summary) const override;
 
 
     virtual void Set(const std::vector<JObject *> &data) = 0;

--- a/src/libraries/JANA/JFactoryGenerator.h
+++ b/src/libraries/JANA/JFactoryGenerator.h
@@ -57,7 +57,7 @@ public:
             // Otherwise, use whatever tag the factory may have set for itself.
             factory->SetTag(m_tag);
         }
-        factory->SetFactoryName(JTypeInfo::demangle<T>());
+        factory->SetTypeName(JTypeInfo::demangle<T>());
         factory->SetPluginName(GetPluginName());
         factory->SetApplication(GetApplication());
         factory->SetLogger(GetApplication()->template GetService<JLoggingService>()->get_logger(factory->GetPrefix()));

--- a/src/libraries/JANA/JFactorySet.h
+++ b/src/libraries/JANA/JFactorySet.h
@@ -21,14 +21,12 @@ class JMultifactory;
 class JFactorySet : public JResettable
 {
     public:
-        JFactorySet(void);
+        JFactorySet();
         JFactorySet(const std::vector<JFactoryGenerator*>& aFactoryGenerators);
-        JFactorySet(JFactoryGenerator* source_gen, const std::vector<JFactoryGenerator*>& default_gens);
         virtual ~JFactorySet();
 
         bool Add(JFactory* aFactory);
         bool Add(JMultifactory* multifactory);
-        void Merge(JFactorySet &aFactorySet);
         void Print(void) const;
         void Release(void);
 

--- a/src/libraries/JANA/JMultifactory.cc
+++ b/src/libraries/JANA/JMultifactory.cc
@@ -74,15 +74,15 @@ void JMultifactory::DoInit() {
     }
 }
 
-void JMultifactory::Summarize(JComponentSummary& summary) {
+void JMultifactory::Summarize(JComponentSummary& summary) const {
     auto mfs = new JComponentSummary::Component(
-            JComponentSummary::ComponentType::Factory,
+            "Multifactory",
             GetPrefix(),
             GetTypeName(),
             GetLevel(),
             GetPluginName());
 
-    for (auto* helper : GetHelpers()->GetAllFactories()) {
+    for (auto* helper : mHelpers.GetAllFactories()) {
         auto coll = new JComponentSummary::Collection(
                 helper->GetTag(), 
                 helper->GetFactoryName(), 

--- a/src/libraries/JANA/JMultifactory.h
+++ b/src/libraries/JANA/JMultifactory.h
@@ -34,6 +34,9 @@ public:
     // Alternatively, we could move all the JMultiFactoryHelper functionality into JFactoryT directly
 
     JMultifactory* GetMultifactory() { return mMultiFactory; }
+
+    // Helpers do not produce any summary information
+    void Summarize(JComponentSummary&) const override { }
 };
 
 
@@ -46,6 +49,7 @@ class JMultifactoryHelperPodio : public JFactoryPodioT<T>{
 
 public:
     JMultifactoryHelperPodio(JMultifactory* parent) : mMultiFactory(parent) {}
+
     virtual ~JMultifactoryHelperPodio() = default;
     // This does NOT own mMultiFactory; the enclosing JFactorySet does
 
@@ -55,6 +59,9 @@ public:
     // Alternatively, we could move all of the JMultiFactoryHelper functionality into JFactoryT directly
 
     JMultifactory* GetMultifactory() { return mMultiFactory; }
+
+    // Helpers do not produce any summary information
+    void Summarize(JComponentSummary&) const override { }
 };
 #endif // JANA2_HAVE_PODIO
 
@@ -131,7 +138,7 @@ public:
         SetTypeName(factoryName);
     }
     
-    void Summarize(JComponentSummary& summary) override;
+    void Summarize(JComponentSummary& summary) const override;
 };
 
 

--- a/src/libraries/JANA/JMultifactory.h
+++ b/src/libraries/JANA/JMultifactory.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "JANA/Utils/JTypeInfo.h"
 #include <JANA/JFactoryT.h>
 #include <JANA/JFactorySet.h>
 #include <JANA/Omni/JComponent.h>
@@ -67,10 +68,6 @@ class JMultifactory : public jana::omni::JComponent,
     // However, don't worry about a Status variable. Every time Execute() gets called, so does Process().
     // The JMultifactoryHelpers will control calls to Execute().
 
-    std::string mTag;         // JMultifactories each get their own name
-                              // This can be used for parameter and collection name prefixing, though at a higher level
-    std::string mFactoryName; // So we can propagate this to the JMultifactoryHelpers, so we can have useful error messages
-
 #if JANA2_HAVE_PODIO
     bool mNeedPodio = false;      // Whether we need to retrieve the podio::Frame
     podio::Frame* mPodioFrame = nullptr;  // To provide the podio::Frame to SetPodioData, SetCollection
@@ -128,8 +125,11 @@ public:
     // in place. This method is only supposed to be called by JFactorySet::Add(JMultifactory).
 
     // These are set by JFactoryGeneratorT (just like JFactories) and get propagated to each of the JMultifactoryHelpers
-    void SetTag(std::string tag) { mTag = std::move(tag); }
-    void SetFactoryName(std::string factoryName) { mFactoryName = std::move(factoryName); }
+    void SetTag(std::string tag) { SetPrefix(tag); }
+
+    void SetFactoryName(std::string factoryName) { 
+        SetTypeName(factoryName);
+    }
     
     void Summarize(JComponentSummary& summary) override;
 };
@@ -141,7 +141,7 @@ void JMultifactory::DeclareOutput(std::string tag, bool owns_data) {
     JFactory* helper = new JMultifactoryHelper<T>(this);
     if (!owns_data) helper->SetFactoryFlag(JFactory::JFactory_Flags_t::NOT_OBJECT_OWNER);
     helper->SetPluginName(m_plugin_name);
-    helper->SetFactoryName(mFactoryName);
+    helper->SetFactoryName(GetTypeName()+"::Helper<" + JTypeInfo::demangle<T>() + ">");
     helper->SetTag(std::move(tag));
     helper->SetLevel(GetLevel());
     mHelpers.SetLevel(GetLevel());
@@ -180,7 +180,7 @@ void JMultifactory::DeclarePodioOutput(std::string tag, bool owns_data) {
 
     helper->SetTag(std::move(tag));
     helper->SetPluginName(m_plugin_name);
-    helper->SetFactoryName(mFactoryName);
+    helper->SetFactoryName(GetTypeName() + "::Helper<" + JTypeInfo::demangle<T>() + ">");
     helper->SetLevel(GetLevel());
     mHelpers.SetLevel(GetLevel());
     mHelpers.Add(helper);

--- a/src/libraries/JANA/Omni/JComponentFwd.h
+++ b/src/libraries/JANA/Omni/JComponentFwd.h
@@ -69,9 +69,9 @@ public:
     // ---------------------
     // Meant to be called by JANA
     // ---------------------
-    std::string GetPrefix() { return m_prefix.empty() ? m_type_name : m_prefix; }
+    std::string GetPrefix() const { return m_prefix.empty() ? m_type_name : m_prefix; }
 
-    JEventLevel GetLevel() { return m_level; }
+    JEventLevel GetLevel() const { return m_level; }
 
     std::string GetLoggerName() const { return m_prefix.empty() ? m_type_name : m_prefix; }
 
@@ -81,7 +81,7 @@ public:
 
     std::string GetTypeName() const { return m_type_name; }
 
-    virtual void Summarize(JComponentSummary&) {};
+    virtual void Summarize(JComponentSummary&) const {};
 
     Status GetStatus() const { 
         std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/libraries/JANA/Omni/JOmniFactory.h
+++ b/src/libraries/JANA/Omni/JOmniFactory.h
@@ -202,7 +202,6 @@ public:
                         std::vector<JEventLevel> input_collection_levels,
                         std::vector<std::string> output_collection_names ) {
 
-        // TODO: NWB: JMultiFactory::GetTag,SetTag are not currently usable
         m_prefix = (this->GetPluginName().empty()) ? tag : this->GetPluginName() + ":" + tag;
         m_level = level;
 

--- a/src/libraries/JANA/Omni/JOmniFactory.h
+++ b/src/libraries/JANA/Omni/JOmniFactory.h
@@ -325,10 +325,10 @@ public:
 
 
     /// Generate summary for UI, inspector
-    void Summarize(JComponentSummary& summary) override {
+    void Summarize(JComponentSummary& summary) const override {
 
         auto* mfs = new JComponentSummary::Component(
-                JComponentSummary::ComponentType::Factory, GetPrefix(), GetTypeName(), GetLevel(), GetPluginName());
+            "OmniFactory", GetPrefix(), GetTypeName(), GetLevel(), GetPluginName());
 
         for (const auto* input : m_inputs) {
             size_t subinput_count = input->names.size();

--- a/src/libraries/JANA/Omni/JOmniFactoryGeneratorT.h
+++ b/src/libraries/JANA/Omni/JOmniFactoryGeneratorT.h
@@ -99,14 +99,10 @@ public:
 
         for (const auto& wiring : m_typed_wirings) {
 
-
             FactoryT *factory = new FactoryT;
             factory->SetApplication(GetApplication());
             factory->SetPluginName(this->GetPluginName());
-            factory->SetFactoryName(JTypeInfo::demangle<FactoryT>());
-            // factory->SetTag(wiring.m_tag);
-            // We do NOT want to do this because JMF will use the tag to suffix the collection names
-            // TODO: NWB: Change this in JANA
+            factory->SetTypeName(JTypeInfo::demangle<FactoryT>());
             factory->config() = wiring.configs;
 
             // Set up all of the wiring prereqs so that Init() can do its thing

--- a/src/libraries/JANA/Services/JParameterManager.cc
+++ b/src/libraries/JANA/Services/JParameterManager.cc
@@ -189,12 +189,12 @@ void JParameterManager::PrintParameters(int verbosity, int strictness) {
 
     // Print table
     JTablePrinter table;
-    table.AddColumn("Name");
+    table.AddColumn("Name", JTablePrinter::Justify::Left, 20);
     if (warnings_present) {
         table.AddColumn("Warnings");  // IsDeprecated column
     }
-    table.AddColumn("Value", JTablePrinter::Justify::Left, 20);
-    table.AddColumn("Default", JTablePrinter::Justify::Left, 20);
+    table.AddColumn("Value", JTablePrinter::Justify::Left, 25);
+    table.AddColumn("Default", JTablePrinter::Justify::Left, 25);
     table.AddColumn("Description", JTablePrinter::Justify::Left, 50);
 
     for (JParameter* p: params_to_print) {

--- a/src/libraries/JANA/Services/JPluginLoader.cc
+++ b/src/libraries/JANA/Services/JPluginLoader.cc
@@ -115,18 +115,13 @@ void JPluginLoader::attach_plugins(JComponentManager* jcm) {
 
     while (!m_all_plugins_requested.empty()) {
 
-        const std::string& user_plugin = m_all_plugins_requested.front();
+        const std::string name = m_all_plugins_requested.front();
         m_all_plugins_requested.pop();
 
         std::ostringstream paths_checked;
 
-        std::string name;
-        bool user_provided_path = is_path(user_plugin);
-        if (user_provided_path) {
-            name = extract_name_from_path(user_plugin);
-        }
-        else {
-            name = normalize_name(user_plugin);
+        if (!is_valid_plugin_name(name)) {
+            throw JException("Invalid plugin name: '%s'. Should not be a path or have an extension.", name.c_str());
         }
 
         if (exclusions.find(name) != exclusions.end()) {
@@ -135,37 +130,19 @@ void JPluginLoader::attach_plugins(JComponentManager* jcm) {
         }
         if (m_plugin_index.find(name) != m_plugin_index.end()) {
             // Make sure each plugin is only loaded once (whether provided as a path or not)
-            // Things get very weird if you request a plugin by specifying a path, and a elsewhere
-            // request the same plugin by name, but it resolves to a different path. Maybe this
-            // is a sign that this whole approach is flawed and we should _only_ load plugins by name.
-
             LOG_DEBUG(m_logger) << "Ignoring already-loaded plugin `" << name << "`" << LOG_END;
             continue;
         }
 
-        std::string path;
-        if (user_provided_path) {
-            if(validate_path(user_plugin)) {
-                paths_checked << "    " << user_plugin << " => Found" << std::endl;
-                path = user_plugin;
-            }
-            else {
-                // User entered an invalid path; `path` variable stays enpty
-                paths_checked << "    " << user_plugin << " => Not found" << std::endl;
-            }
-        }
-        else {
-            path = find_first_valid_path(name, paths_checked);
-            // User didn't provide a path, so we have to search
-            // If no valid paths found, `path` variable stays empty
-        }
+        std::string path = find_first_valid_path(name, paths_checked);
+        // User didn't provide a path, so we have to search
+        // If no valid paths found, `path` variable stays empty
 
         if (path.empty()) {
-
-            LOG_ERROR(m_logger) << "Couldn't find plugin '" << name << "'\n" <<
-                                "  Make sure that JANA_HOME and/or JANA_PLUGIN_PATH environment variables are set correctly.\n"
-                                <<
-                                "  Paths checked:\n" << paths_checked.str() << LOG_END;
+            LOG_ERROR(m_logger) 
+                << "Couldn't find plugin '" << name << "'\n" 
+                << "  Make sure that the plugin search path is correctly set using the 'jana:plugin_path' parameter or the JANA_PLUGIN_PATH environment variable.\n"
+                << "  Paths checked:\n" << paths_checked.str() << LOG_END;
             throw JException("Couldn't find plugin '%s'", name.c_str());
         }
 
@@ -270,29 +247,12 @@ JPlugin::~JPlugin() {
     LOG_DEBUG(m_logger) << "Unloaded plugin \"" << m_name << "\"" << LOG_END;
 }
 
-
-bool JPluginLoader::is_path(const std::string user_plugin) {
-    return user_plugin.find('/') != -1;
-}
-
-std::string JPluginLoader::normalize_name(const std::string user_plugin) {
-    if (user_plugin.substr(user_plugin.size() - 3) == ".so") {
-        return user_plugin.substr(0, user_plugin.size() - 3);
-    }
-    return user_plugin;
-}
-
-std::string JPluginLoader::extract_name_from_path(const std::string user_plugin) {
-    // Ideally we would just do this, but we want to be C++17 compatible
-    // return std::filesystem::path(filesystem_path).filename().stem().string();
+bool JPluginLoader::is_valid_plugin_name(const std::string& plugin_name) const {
     
-    size_t pos_begin = user_plugin.find_last_of('/');
-    if (pos_begin == std::string::npos) pos_begin = 0;
-    
-    size_t pos_end = user_plugin.find_last_of('.');
-    //if (pos_end == std::string::npos) pos_end = filesystem_path.size();
-
-    return user_plugin.substr(pos_begin+1, pos_end-pos_begin-1);
+    if (plugin_name.size() > 2 && plugin_name.substr(plugin_name.size() - 3) == ".so") return false;
+    if (plugin_name.size() > 5 && plugin_name.substr(plugin_name.size() - 6) == ".dylib") return false;
+    if (plugin_name.find('/') != std::string::npos) return false;
+    return true;
 }
 
 bool ends_with(const std::string& s, char c) {
@@ -301,7 +261,7 @@ bool ends_with(const std::string& s, char c) {
     return s.back() == c;
 }
 
-std::string JPluginLoader::make_path_from_name(std::string name, const std::string& path_prefix) {
+std::string JPluginLoader::make_path_from_name(const std::string& name, const std::string& path_prefix) const {
     std::ostringstream oss;
     oss << path_prefix;
     if (!ends_with(path_prefix, '/')) {
@@ -312,12 +272,12 @@ std::string JPluginLoader::make_path_from_name(std::string name, const std::stri
     return oss.str();
 }
 
-std::string JPluginLoader::find_first_valid_path(const std::string& name, std::ostringstream& debug_log) {
+std::string JPluginLoader::find_first_valid_path(const std::string& name, std::ostringstream& debug_log) const {
 
     for (const std::string& path_prefix : m_plugin_paths) {
         auto path = make_path_from_name(name, path_prefix);
 
-        if (validate_path(path)) {
+        if (is_valid_path(path)) {
             debug_log << "    " << path << " => Found" << std::endl;
             return path;
         }
@@ -329,7 +289,7 @@ std::string JPluginLoader::find_first_valid_path(const std::string& name, std::o
 }
 
 
-bool JPluginLoader::validate_path(const std::string& path) {
+bool JPluginLoader::is_valid_path(const std::string& path) const {
     return (access(path.c_str(), F_OK) != -1);
 }
 

--- a/src/libraries/JANA/Services/JPluginLoader.h
+++ b/src/libraries/JANA/Services/JPluginLoader.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 #include <list>
+#include <queue>
 
 
 class JComponentManager;
@@ -55,7 +56,8 @@ public:
 private:
     Service<JParameterManager> m_params {this};
 
-    std::vector<std::string> m_plugins_to_include;
+    std::queue<std::string> m_all_plugins_requested;
+    std::vector<std::string> m_plugins_from_parameter;
     std::vector<std::string> m_plugins_to_exclude;
     std::vector<std::string> m_plugin_paths;
     std::string m_plugin_paths_str;

--- a/src/libraries/JANA/Services/JPluginLoader.h
+++ b/src/libraries/JANA/Services/JPluginLoader.h
@@ -46,12 +46,10 @@ public:
     void attach_plugin(std::string name, std::string path);
     void resolve_plugin_paths();
 
-    bool is_path(const std::string user_plugin);
-    std::string normalize_name(const std::string user_plugin);
-    std::string extract_name_from_path(const std::string user_plugin);
-    std::string find_first_valid_path(const std::string& name, std::ostringstream& debug_log);
-    std::string make_path_from_name(std::string name, const std::string& path_prefix);
-    bool validate_path(const std::string& path);
+    bool is_valid_plugin_name(const std::string& plugin_name) const;
+    bool is_valid_path(const std::string& path) const;
+    std::string find_first_valid_path(const std::string& name, std::ostringstream& debug_log) const;
+    std::string make_path_from_name(const std::string& name, const std::string& path_prefix) const;
 
 private:
     Service<JParameterManager> m_params {this};

--- a/src/libraries/JANA/Status/JComponentSummary.cc
+++ b/src/libraries/JANA/Status/JComponentSummary.cc
@@ -113,11 +113,11 @@ void PrintComponentTable(std::ostream& os, const JComponentSummary& cs) {
 
 
     JTablePrinter comp_table;
-    comp_table.AddColumn("Base");
-    comp_table.AddColumn("Type");
-    comp_table.AddColumn("Prefix");
-    comp_table.AddColumn("Level");
-    comp_table.AddColumn("Plugin");
+    comp_table.AddColumn("Base", JTablePrinter::Justify::Left, 12);
+    comp_table.AddColumn("Type", JTablePrinter::Justify::Left, 40);
+    comp_table.AddColumn("Prefix", JTablePrinter::Justify::Left, 40);
+    comp_table.AddColumn("Level", JTablePrinter::Justify::Left, 12);
+    comp_table.AddColumn("Plugin", JTablePrinter::Justify::Left, 16);
 
     os << "  Component Summary" << std::endl;
 

--- a/src/libraries/JANA/Status/JComponentSummary.cc
+++ b/src/libraries/JANA/Status/JComponentSummary.cc
@@ -3,7 +3,6 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
 #include <iostream>
-#include <iomanip>
 #include <JANA/Utils/JTablePrinter.h>
 #include "JComponentSummary.h"
 
@@ -123,14 +122,7 @@ void PrintComponentTable(std::ostream& os, const JComponentSummary& cs) {
     os << "  Component Summary" << std::endl;
 
     for (const auto* comp : cs.GetAllComponents()) {
-        switch(comp->GetComponentType()) {
-            case JComponentSummary::ComponentType::Source: comp_table | "Source"; break;
-            case JComponentSummary::ComponentType::Processor: comp_table | "Processor"; break;
-            case JComponentSummary::ComponentType::Factory: comp_table | "Factory"; break;
-            case JComponentSummary::ComponentType::Unfolder: comp_table | "Unfolder"; break;
-            case JComponentSummary::ComponentType::Folder: comp_table | "Folder"; break;
-        }
-        comp_table | comp->GetTypeName() | comp->GetPrefix() | comp->GetLevel() | comp->GetPluginName();
+        comp_table | comp->GetBaseName() | comp->GetTypeName() | comp->GetPrefix() | comp->GetLevel() | comp->GetPluginName();
     }
     os << comp_table;
 }

--- a/src/libraries/JANA/Status/JComponentSummary.h
+++ b/src/libraries/JANA/Status/JComponentSummary.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <memory>
 
 
 // Keeping this around for backwards compatibility only
@@ -23,14 +22,13 @@ struct JFactorySummary {
 
 class JComponentSummary {
 public:
-    enum class ComponentType { Source, Processor, Factory, Unfolder, Folder };
 
     class Collection;
 
     class Component {
         friend class JComponentSummary;
 
-        ComponentType m_component_type;
+        std::string m_base_name;
         std::string m_prefix;
         std::string m_type_name;
         JEventLevel m_level;
@@ -39,11 +37,11 @@ public:
         std::vector<Collection*> m_outputs;
 
     public:
-        Component(ComponentType component_type, std::string prefix, std::string type_name, JEventLevel level, std::string plugin_name)
-            : m_component_type(component_type), m_prefix(prefix), m_type_name(type_name), m_level(level), m_plugin_name(plugin_name) {}
+        Component(std::string base_name, std::string prefix, std::string type_name, JEventLevel level, std::string plugin_name)
+            : m_base_name(base_name), m_prefix(prefix), m_type_name(type_name), m_level(level), m_plugin_name(plugin_name) {}
         void AddInput(Collection* input) { m_inputs.push_back(input); }
         void AddOutput(Collection* output) { m_outputs.push_back(output); }
-        ComponentType GetComponentType() const { return m_component_type; }
+        std::string GetBaseName() const { return m_base_name; }
         std::string GetPrefix() const { return m_prefix; }
         std::string GetTypeName() const { return m_type_name; }
         JEventLevel GetLevel() const { return m_level; }

--- a/src/programs/unit_tests/Topology/MultiLevelTopologyTests.cc
+++ b/src/programs/unit_tests/Topology/MultiLevelTopologyTests.cc
@@ -1,8 +1,11 @@
-#include <catch.hpp>
+#include "MultiLevelTopologyTests.h"
+#include "JANA/JException.h"
+
 #include <iostream>
 #include <map>
-#include "MultiLevelTopologyTests.h"
 
+namespace jana {
+namespace timeslice_tests {
 
 enum class Level { None, Timeslice, Event, Subevent };
 enum class ComponentType { None, Source, Filter, Map, Split, Merge, Reduce };
@@ -442,7 +445,13 @@ TEST_CASE("TimeslicesTests") {
     app.Add(new JFactoryGeneratorT<MyProtoClusterFactory>);
     app.Add(new JFactoryGeneratorT<MyClusterFactory>);
     app.SetTicker(true);
-    app.Run();
+    try {
+        app.Run();
+    }
+    catch (JException& e) {
+        std::cout << e << std::endl;
+        throw e;
+    }
 }
 
 

--- a/src/programs/unit_tests/Topology/MultiLevelTopologyTests.h
+++ b/src/programs/unit_tests/Topology/MultiLevelTopologyTests.h
@@ -4,6 +4,7 @@
 #include <JANA/JEventSource.h>
 #include <JANA/JEventUnfolder.h>
 #include <JANA/JEventProcessor.h>
+#include <catch.hpp>
 
 namespace jana {
 namespace timeslice_tests {
@@ -94,9 +95,9 @@ struct MyEventProcessor : public JEventProcessor {
 
     void Process(const JEvent& event) override {
         process_called_count++;
-        // TODO: Trigger cluster factory
-        // TODO: Validate that the clusters make sense
         jout << "MyEventProcessor: Processing " << event.GetEventNumber() << jendl;
+        auto clusters = event.Get<MyCluster>("evt");
+        // TODO: Validate that the clusters make sense
         REQUIRE(init_called_count == 1);
         REQUIRE(finish_called_count == 0);
     }
@@ -116,6 +117,7 @@ struct MyProtoClusterFactory : public JFactoryT<MyCluster> {
 
     MyProtoClusterFactory() {
         SetLevel(JEventLevel::Timeslice);
+        SetTag("ts");
     }
 
     void Init() override {
@@ -142,6 +144,7 @@ struct MyClusterFactory : public JFactoryT<MyCluster> {
 
     MyClusterFactory() {
         SetLevel(JEventLevel::PhysicsEvent);
+        SetTag("evt");
     }
 
     void Init() override {
@@ -159,4 +162,5 @@ struct MyClusterFactory : public JFactoryT<MyCluster> {
     }
 };
 
-
+} // namespace timeslice_tests
+} // namespace jana


### PR DESCRIPTION
This bugfix addresses issue #333. 
It introduces some behavior changes: (!)
- If the user adds duplicate JFactories to the same factory set, JANA will throw an exception rather than silently destroying the second copy. This is necessary because otherwise JANA can't enforce the integrity of JMultifactories.
- If the user includes the same plugin twice in the `plugins`  parameter, it only gets loaded once. 
- The user-provided `plugins` parameter no longer clobbers the projects' default plugins specified via `JApplication::AddPlugin`. Rather, the project's default plugins are loaded first, and any additional user plugins specified by the `plugins` parameter are loaded afterwards.
- JPluginLoader now throws an exception if the user provides a plugin name that is really a path. This is because the logic for ensuring that plugins get loaded exactly once becomes extremely hairy when we account for plugin name conflicts that are off the search path. Consider the example `jana -Pplugins=MyPlugin,other/plugin/dir/MyPlugin.so -Pjana:plugin_path=normal/plugin/dir` where `MyPlugin.so` can be found in both places. We aren't doing the users any favors by letting them get into this mess, and we are better off with a plugin loader that is easier to reason about.