### PR TITLE
Bugfix: JEventSource::GetObjects

### DIFF
--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -363,10 +363,10 @@ public:
 
     /// Calls the optional-and-discouraged user-provided FinishEvent virtual method, enforcing
     /// 1. Thread safety
-    /// 2. The m_enable_free_event flag
+    /// 2. The m_enable_finish_event flag
 
     void DoFinish(JEvent& event) {
-        if (m_enable_free_event) {
+        if (m_enable_finish_event) {
             std::lock_guard<std::mutex> lock(m_mutex);
             CallWithJExceptionWrapper("JEventSource::FinishEvent", [&](){
                 FinishEvent(event);
@@ -403,6 +403,9 @@ public:
     // TODO: Deprecate me
     std::string GetName() const { return m_resource_name; }
 
+    bool IsGetObjectsEnabled() const { return m_enable_get_objects; }
+    bool IsFinishEventEnabled() const { return m_enable_finish_event; }
+
     // TODO: Deprecate me
     virtual std::string GetVDescription() const {
         return "<description unavailable>";
@@ -418,7 +421,8 @@ public:
     /// have finished with a given event. This should only be enabled when absolutely necessary
     /// (e.g. for backwards compatibility) because it introduces contention for the JEventSource mutex,
     /// which will hurt performance. Conceptually, FinishEvent isn't great, and so should be avoided when possible.
-    void EnableFinishEvent() { m_enable_free_event = true; }
+    void EnableFinishEvent(bool enable=true) { m_enable_finish_event = enable; }
+    void EnableGetObjects(bool enable=true) { m_enable_get_objects = enable; }
 
     // Meant to be called by JANA
     void SetNEvents(uint64_t nevents) { m_nevents = nevents; };
@@ -432,7 +436,8 @@ private:
     std::atomic_ullong m_event_count {0};
     uint64_t m_nskip = 0;
     uint64_t m_nevents = 0;
-    bool m_enable_free_event = false;
+    bool m_enable_finish_event = false;
+    bool m_enable_get_objects = false;
 
 };
 

--- a/src/programs/unit_tests/Components/GetObjectsTests.cc
+++ b/src/programs/unit_tests/Components/GetObjectsTests.cc
@@ -2,48 +2,106 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
 #include <JANA/JEventSource.h>
+#include <JANA/JEventProcessor.h>
+#include <JANA/JApplication.h>
+#include "JANA/JFactoryGenerator.h"
 #include "catch.hpp"
 
-struct Obj1 : public JObject { int data; };
-struct Obj2 : public JObject { int data; };
-struct Obj3 : public JObject { int data; };
-struct Obj4 : public JObject { int data; };
+namespace jana::components::getobjects_tests {
 
-class Src : public JEventSource {
+struct Obj : public JObject { int data; };
+
+struct Src : public JEventSource {
     Src() {
+        EnableGetObjects();
         SetCallbackStyle(CallbackStyle::ExpertMode);
     }
-    Result Emit(JEvent& event) override {
-        auto obj = new Obj1;
-        obj->data = 21;
-        event.Insert(obj);
+    Result Emit(JEvent&) override {
         return Result::Success;
     }
     bool GetObjects(const std::shared_ptr<const JEvent>&, JFactory* fac) override {
-        if (fac->GetObjectName() == "Obj2") {
-            auto obj = new Obj2;
+
+        LOG_INFO(GetLogger()) << "GetObjects: Fac has object name '" << fac->GetObjectName() << "' and type name '" << fac->GetTypeName() << "'" << LOG_END;
+
+        //if (fac->GetObjectName() == "jana::components::getobjects_tests::Obj") {
+        auto typed_fac = dynamic_cast<JFactoryT<Obj>*>(fac);
+        if (typed_fac != nullptr) {
+            auto obj = new Obj;
             obj->data = 22;
-            fac->Insert(obj);
+            typed_fac->Insert(obj);
             return true;
         }
         return false;
     }
 };
 
-class Fac : public JFactoryT<Obj3> {
+struct Fac : public JFactoryT<Obj> {
     void Process(const std::shared_ptr<const JEvent>&) override {
-        auto obj = new Obj3;
+        auto obj = new Obj;
         obj->data = 23;
         Insert(obj);
     }
 };
 
-TEST_CASE("GetObjectsTests") {
-    JEvent event;
-    JFactorySet* fs = new JFactorySet;
-    fs->Add(new Fac);
-    event.SetFactorySet(fs);
-    event.GetJCallGraphRecorder()->SetEnabled(true);
+struct RFac : public JFactoryT<Obj> {
+    RFac() {
+        SetFactoryFlag(REGENERATE);
+    }
+    void Process(const std::shared_ptr<const JEvent>&) override {
+        auto obj = new Obj;
+        obj->data = 23;
+        Insert(obj);
+    }
+};
 
+struct Proc : public JEventProcessor {
+    bool from_getobjects=true;
+    void Process(const std::shared_ptr<const JEvent>& event) override {
+        auto objs = event->Get<Obj>();
+        REQUIRE(objs.size() == 1);
+        if (from_getobjects) {
+            REQUIRE(objs[0]->data == 22);
+        }
+        else {
+            REQUIRE(objs[0]->data == 23);
+        }
+    }
+};
+
+TEST_CASE("GetObjectsTests_NoFac") {
+    JApplication app;
+    app.SetParameterValue("jana:loglevel", "warn");
+    app.SetParameterValue("jana:nevents", 1);
+    app.Add(new Src);
+    auto proc = new Proc;
+    proc->from_getobjects = true;
+    app.Add(proc);
+    app.Add(new JFactoryGeneratorT<JFactoryT<Obj>>);
+    app.Run();
 }
 
+TEST_CASE("GetObjectsTests_OverrideFac") {
+    JApplication app;
+    app.SetParameterValue("jana:loglevel", "warn");
+    app.SetParameterValue("jana:nevents", 1);
+    app.Add(new Src);
+    app.Add(new JFactoryGeneratorT<Fac>);
+    auto proc = new Proc;
+    proc->from_getobjects = true;
+    app.Add(proc);
+    app.Run();
+}
+
+TEST_CASE("GetObjectsTests_Regenerate") {
+    JApplication app;
+    app.SetParameterValue("jana:loglevel", "warn");
+    app.SetParameterValue("jana:nevents", 1);
+    app.Add(new Src);
+    app.Add(new JFactoryGeneratorT<RFac>);
+    auto proc = new Proc;
+    proc->from_getobjects = false;
+    app.Add(proc);
+    app.Run();
+}
+
+} // namespace ...


### PR DESCRIPTION
`JFactory::Create` now calls `JEventSource::GetObjects()` _before_ calling `JFactory::Process`.

To minimize any performance implications, this behavior is opt-in, using the `JEventSource::EnableGetObjects()` flag.

Ideally we'd migrate away from using `GetObjects` anywhere, but we need it in order to finish the port of halld_recon.

This change makes `GetObjectsFactory` redundant.

