### PR TITLE
Fix for Lock Overwrite Issue in Multithreaded RootFillLock Handling

### DIFF
--- a/src/libraries/JANA/CLI/JBenchmarker.cc
+++ b/src/libraries/JANA/CLI/JBenchmarker.cc
@@ -159,7 +159,7 @@ void JBenchmarker::RunUntilFinished() {
             << "    cd " << m_output_dir << "\n"
             << "    $JANA_HOME/bin/jana-plot-scaletest.py\n" << LOG_END;
     }
-    m_app->Stop();
+    m_app->Stop(true);
 }
 
 

--- a/src/libraries/JANA/Calibrations/JCalibrationManager.h
+++ b/src/libraries/JANA/Calibrations/JCalibrationManager.h
@@ -29,6 +29,9 @@ class JCalibrationManager : public JService {
 public:
 
     JCalibrationManager() { 
+        pthread_mutex_init(&m_calibration_mutex, nullptr);
+        pthread_mutex_init(&m_resource_manager_mutex, nullptr);
+
         SetPrefix("jana"); 
     }
 


### PR DESCRIPTION
The issue occurs when multiple threads call `RootFillLock`. Each thread was independently creating its own lock and overriding the lock saved by the previous thread in `m_root_fill_rw_lock`. This resulted in only the last thread's lock being retained. When `RootFillUnlock` was invoked, all threads attempted to unlock the lock acquired by the last thread, leading to undefined behavior due to multiple unlock operations on the same lock.

### Resolution:
To address this, an additional check is added after acquiring the write lock. If the lock for the event processor (`proc`) has already been initialized by another thread, that lock will be used. This prevents each thread from initializing a new lock and ensures that only one lock is used across threads.