### PR TITLE
Bugfix: JFactory::Finish

### DIFF
--- a/docs/howto/other-howtos.md
+++ b/docs/howto/other-howtos.md
@@ -71,13 +71,15 @@ The following configuration options are used most commonly:
 | nthreads                  | int     | Size of thread team (Defaults to the number of cores on your machine) |
 | plugins                   | string  | Comma-separated list of plugin filenames. JANA will look for these on the `$JANA_PLUGIN_PATH` |
 | plugins_to_ignore         | string  | This removes plugins which had been specified in `plugins`. |
-| event_source_type         | string  | Manually override JANA's decision about which JEventSource to use |
+| event_source_type         | string  | Manually specify which JEventSource to use |
 | jana:nevents              | int     | Limit the number of events each source may emit |
 | jana:nskip                | int     | Skip processing the first n events from each event source |
-| jana:extended_report      | bool    | The amount of status information to show while running |
 | jana:status_fname         | string  | Named pipe for retrieving status information remotely |
 | jana:loglevel | string | Set the log level (trace,debug,info,warn,error,fatal,off) for loggers internal to JANA |
 | jana:global_loglevel | string | Set the default log level (trace,debug,info,warn,error,fatal,off) for all loggers |
+| jana:show_ticker          | bool    | Controls whether the status ticker is shown |
+| jana:ticker_interval          | int     | Controls how often the status ticker updates (in ms)  |
+| jana:extended_report       | bool    | Controls whether to show extra details in the status ticker and final report |
 
 JANA automatically provides each component with its own logger. You can control the logging verbosity of individual components
 just like any other parameter. For instance, if your component prefixes its parameters with `BCAL:tracking`,

--- a/src/libraries/JANA/CMakeLists.txt
+++ b/src/libraries/JANA/CMakeLists.txt
@@ -10,6 +10,7 @@ set(JANA2_SOURCES
     JMultifactory.cc
     JService.cc
     JVersion.cc
+    JEvent.cc
 
     Engine/JArrowProcessingController.cc
     Engine/JScheduler.cc

--- a/src/libraries/JANA/CMakeLists.txt
+++ b/src/libraries/JANA/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(JANA2_SOURCES
 
     JApplication.cc
+    JEvent.cc
     JEventSource.cc
     JFactory.cc
     JFactorySet.cc

--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -149,6 +149,7 @@ void JApplication::Initialize() {
         m_desired_nthreads = JCpuInfo::GetNumCpus();
     }
 
+    m_params->SetDefaultParameter("jana:show_ticker", m_ticker_on, "Controls whether the ticker is visible");
     m_params->SetDefaultParameter("jana:ticker_interval", m_ticker_interval_ms, "Controls the ticker interval (in ms)");
     m_params->SetDefaultParameter("jana:extended_report", m_extended_report, "Controls whether the ticker shows simple vs detailed performance metrics");
 

--- a/src/libraries/JANA/JEvent.cc
+++ b/src/libraries/JANA/JEvent.cc
@@ -11,3 +11,79 @@ JEvent::JEvent(JApplication* app) : mInspector(&(*this)) {
     }
 }
 
+void JEvent::SetFactorySet(JFactorySet* factorySet) {
+    delete mFactorySet;
+    mFactorySet = factorySet;
+#if JANA2_HAVE_PODIO
+    // Maintain the index of PODIO factories
+    for (JFactory* factory : mFactorySet->GetAllFactories()) {
+        if (dynamic_cast<JFactoryPodio*>(factory) != nullptr) {
+            auto tag = factory->GetTag();
+            auto it = mPodioFactories.find(tag);
+            if (it != mPodioFactories.end()) {
+                throw JException("SetFactorySet failed because PODIO factory tag '%s' is not unique", tag.c_str());
+            }
+            mPodioFactories[tag] = factory;
+        }
+    }
+#endif
+}
+
+bool JEvent::HasParent(JEventLevel level) const {
+    for (const auto& pair : mParents) {
+        if (pair.first == level) return true;
+    }
+    return false;
+}
+
+const JEvent& JEvent::GetParent(JEventLevel level) const {
+    for (const auto& pair : mParents) {
+        if (pair.first == level) return *(*(pair.second));
+    }
+    throw JException("Unable to find parent at level %s", 
+                        toString(level).c_str());
+}
+
+void JEvent::SetParent(std::shared_ptr<JEvent>* parent) {
+    JEventLevel level = parent->get()->GetLevel();
+    for (const auto& pair : mParents) {
+        if (pair.first == level) throw JException("Event already has a parent at level %s", 
+                                                    toString(parent->get()->GetLevel()).c_str());
+    }
+    mParents.push_back({level, parent});
+    parent->get()->mReferenceCount.fetch_add(1);
+}
+
+std::shared_ptr<JEvent>* JEvent::ReleaseParent(JEventLevel level) {
+    if (mParents.size() == 0) {
+        throw JException("ReleaseParent failed: child has no parents!");
+    }
+    auto pair = mParents.back();
+    if (pair.first != level) {
+        throw JException("JEvent::ReleaseParent called out of level order: Caller expected %s, but parent was actually %s", 
+                toString(level).c_str(), toString(pair.first).c_str());
+    }
+    mParents.pop_back();
+    auto remaining_refs = pair.second->get()->mReferenceCount.fetch_sub(1);
+    if (remaining_refs < 1) { // Remember, this was fetched _before_ the last subtraction
+        throw JException("Parent refcount has gone negative!");
+    }
+    if (remaining_refs == 1) {
+        return pair.second; 
+        // Parent is no longer shared. Transfer back to arrow
+    }
+    else {
+        return nullptr; // Parent is still shared by other children
+    }
+}
+
+void JEvent::Release() {
+    auto remaining_refs = mReferenceCount.fetch_sub(1);
+    if (remaining_refs < 0) {
+        throw JException("JEvent's own refcount has gone negative!");
+    }
+}
+
+void JEvent::Reset() {
+    mReferenceCount = 1;
+}

--- a/src/libraries/JANA/JEvent.cc
+++ b/src/libraries/JANA/JEvent.cc
@@ -1,0 +1,13 @@
+
+#include <JANA/JEvent.h>
+#include <JANA/Services/JComponentManager.h>
+
+JEvent::JEvent(JApplication* app) : mInspector(&(*this)) {
+    if (app != nullptr) {
+        app->GetService<JComponentManager>()->configure_event(*this);
+    }
+    else {
+        mFactorySet = new JFactorySet();
+    }
+}
+

--- a/src/libraries/JANA/JEvent.cc
+++ b/src/libraries/JANA/JEvent.cc
@@ -110,7 +110,7 @@ void JEvent::Release() {
 
 void JEvent::Clear() {
     if (mEventSource != nullptr) {
-        mEventSource->DoFinish(*this);
+        mEventSource->DoFinishEvent(*this);
     }
     mFactorySet->Clear();
     mInspector.Reset();

--- a/src/libraries/JANA/JEvent.cc
+++ b/src/libraries/JANA/JEvent.cc
@@ -14,7 +14,11 @@ JEvent::JEvent(JApplication* app) : mInspector(this) {
 }
 
 JEvent::~JEvent() {
-    if (mFactorySet != nullptr) mFactorySet->Release();
+    if (mFactorySet != nullptr) {
+        // Prevent memory leaks of factory contents
+        mFactorySet->Clear();
+        // We mustn't call EndRun() or Finish() here because that would give us an excepting destructor
+    }
     delete mFactorySet;
 }
 
@@ -104,8 +108,18 @@ void JEvent::Release() {
     }
 }
 
-void JEvent::Reset() {
+void JEvent::Clear() {
+    if (mEventSource != nullptr) {
+        mEventSource->DoFinish(*this);
+    }
+    mFactorySet->Clear();
+    mInspector.Reset();
+    mCallGraph.Reset();
     mReferenceCount = 1;
+}
+
+void JEvent::Finish() {
+    mFactorySet->Finish();
 }
 
 

--- a/src/libraries/JANA/JEvent.cc
+++ b/src/libraries/JANA/JEvent.cc
@@ -9,6 +9,7 @@ JEvent::JEvent() : mInspector(this){
 
 JEvent::JEvent(JApplication* app) : mInspector(this) {
     // Furnish the JEvent with the parameter values and factory generators provided to the JApplication
+    app->Initialize();
     app->GetService<JComponentManager>()->configure_event(*this);
 }
 

--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -34,111 +34,325 @@ class JApplication;
 class JEventSource;
 
 
-class JEvent : public std::enable_shared_from_this<JEvent>
-{
-    public:
+class JEvent : public std::enable_shared_from_this<JEvent> {
 
-        explicit JEvent(JApplication* app=nullptr);
+private:
+    JApplication* mApplication = nullptr;
+    int32_t mRunNumber = 0;
+    uint64_t mEventNumber = 0;
+    mutable JFactorySet* mFactorySet = nullptr;
+    mutable JCallGraphRecorder mCallGraph;
+    mutable JInspector mInspector;
+    bool mUseDefaultTags = false;
+    std::map<std::string, std::string> mDefaultTags;
+    JEventSource* mEventSource = nullptr;
+    bool mIsBarrierEvent = false;
 
-        virtual ~JEvent() {
-            if (mFactorySet != nullptr) mFactorySet->Release();
-            delete mFactorySet;
-        }
-
-        void SetFactorySet(JFactorySet* aFactorySet);
-        JFactorySet* GetFactorySet() const { return mFactorySet; }
-
-        JFactory* GetFactory(const std::string& object_name, const std::string& tag) const;
-        std::vector<JFactory*> GetAllFactories() const;
-        template<class T> JFactoryT<T>* GetFactory(const std::string& tag = "", bool throw_on_missing=false) const;
-        template<class T> std::vector<JFactoryT<T>*> GetFactoryAll(bool throw_on_missing = false) const;
-
-        //OBJECTS
-        // C style getters
-        template<class T> JFactoryT<T>* Get(const T** item, const std::string& tag="") const;
-        template<class T> JFactoryT<T>* Get(std::vector<const T*> &vec, const std::string& tag = "", bool strict=true) const;
-        template<class T> void GetAll(std::vector<const T*> &vec) const;
-
-        // C++ style getters
-        template<class T> const T* GetSingle(const std::string& tag = "") const;
-        template<class T> const T* GetSingleStrict(const std::string& tag = "") const;
-        template<class T> std::vector<const T*> Get(const std::string& tag = "", bool strict=true) const;
-        template<class T> typename JFactoryT<T>::PairType GetIterators(const std::string& aTag = "") const;
-        template<class T> std::vector<const T*> GetAll() const;
-        template<class T> std::map<std::pair<std::string,std::string>,std::vector<T*>> GetAllChildren() const;
-
-        // JANA1 compatibility getters
-        template<class T> JFactoryT<T>* GetSingle(const T* &t, const char *tag="", bool exception_if_not_one=true) const;
-
-        // Insert
-        template <class T> JFactoryT<T>* Insert(T* item, const std::string& aTag = "") const;
-        template <class T> JFactoryT<T>* Insert(const std::vector<T*>& items, const std::string& tag = "") const;
-
-        // PODIO
-#if JANA2_HAVE_PODIO
-        std::vector<std::string> GetAllCollectionNames() const;
-        const podio::CollectionBase* GetCollectionBase(std::string name, bool throw_on_missing=true) const;
-        template <typename T> const typename JFactoryPodioT<T>::CollectionT* GetCollection(std::string name, bool throw_on_missing=true) const;
-        template <typename T> JFactoryPodioT<T>* InsertCollection(typename JFactoryPodioT<T>::CollectionT&& collection, std::string name);
-        template <typename T> JFactoryPodioT<T>* InsertCollectionAlreadyInFrame(const podio::CollectionBase* collection, std::string name);
-#endif
-
-        //SETTERS
-        void SetRunNumber(int32_t aRunNumber){mRunNumber = aRunNumber;}
-        void SetEventNumber(uint64_t aEventNumber){mEventNumber = aEventNumber;}
-        void SetJApplication(JApplication* app){mApplication = app;}
-        void SetJEventSource(JEventSource* aSource){mEventSource = aSource;}
-        void SetDefaultTags(std::map<std::string, std::string> aDefaultTags){mDefaultTags=aDefaultTags; mUseDefaultTags = !mDefaultTags.empty();}
-        void SetSequential(bool isSequential) {mIsBarrierEvent = isSequential;}
-
-        //GETTERS
-        int32_t GetRunNumber() const {return mRunNumber;}
-        uint64_t GetEventNumber() const {return mEventNumber;}
-        JApplication* GetJApplication() const {return mApplication;}
-        JEventSource* GetJEventSource() const {return mEventSource; }
-        JCallGraphRecorder* GetJCallGraphRecorder() const {return &mCallGraph;}
-        JInspector* GetJInspector() const {return &mInspector;}
-        void Inspect() const { mInspector.Loop();}
-        bool GetSequential() const {return mIsBarrierEvent;}
-        friend class JEventPool;
-
-
-        // Hierarchical
-        JEventLevel GetLevel() const { return mFactorySet->GetLevel(); }
-        void SetLevel(JEventLevel level) { mFactorySet->SetLevel(level); }
-        void SetEventIndex(int event_index) { mEventIndex = event_index; }
-        int64_t GetEventIndex() const { return mEventIndex; }
-
-        bool HasParent(JEventLevel level) const;
-        const JEvent& GetParent(JEventLevel level) const;
-        void SetParent(std::shared_ptr<JEvent>* parent);
-        std::shared_ptr<JEvent>* ReleaseParent(JEventLevel level);
-        void Release();
-        void Reset();
-
-    private:
-        JApplication* mApplication = nullptr;
-        int32_t mRunNumber = 0;
-        uint64_t mEventNumber = 0;
-        mutable JFactorySet* mFactorySet = nullptr;
-        mutable JCallGraphRecorder mCallGraph;
-        mutable JInspector mInspector;
-        bool mUseDefaultTags = false;
-        std::map<std::string, std::string> mDefaultTags;
-        JEventSource* mEventSource = nullptr;
-        bool mIsBarrierEvent = false;
-
-        // Hierarchical stuff
-        std::vector<std::pair<JEventLevel, std::shared_ptr<JEvent>*>> mParents;
-        std::atomic_int mReferenceCount {1};
-        int64_t mEventIndex = -1;
-
-
+    // Hierarchical event memory management
+    std::vector<std::pair<JEventLevel, std::shared_ptr<JEvent>*>> mParents;
+    std::atomic_int mReferenceCount {1};
+    int64_t mEventIndex = -1;
 
 #if JANA2_HAVE_PODIO
-        std::map<std::string, JFactory*> mPodioFactories;
+    std::map<std::string, JFactory*> mPodioFactories;
 #endif
+
+
+public:
+    JEvent();
+    explicit JEvent(JApplication* app);
+    virtual ~JEvent();
+
+    void SetFactorySet(JFactorySet* aFactorySet);
+    void SetRunNumber(int32_t aRunNumber){mRunNumber = aRunNumber;}
+    void SetEventNumber(uint64_t aEventNumber){mEventNumber = aEventNumber;}
+    void SetJApplication(JApplication* app){mApplication = app;}
+    void SetJEventSource(JEventSource* aSource){mEventSource = aSource;}
+    void SetDefaultTags(std::map<std::string, std::string> aDefaultTags){mDefaultTags=aDefaultTags; mUseDefaultTags = !mDefaultTags.empty();}
+    void SetSequential(bool isSequential) {mIsBarrierEvent = isSequential;}
+
+    JFactorySet* GetFactorySet() const { return mFactorySet; }
+    int32_t GetRunNumber() const {return mRunNumber;}
+    uint64_t GetEventNumber() const {return mEventNumber;}
+    JApplication* GetJApplication() const {return mApplication;}
+    JEventSource* GetJEventSource() const {return mEventSource; }
+    JCallGraphRecorder* GetJCallGraphRecorder() const {return &mCallGraph;}
+    JInspector* GetJInspector() const {return &mInspector;}
+    void Inspect() const { mInspector.Loop();}
+    bool GetSequential() const {return mIsBarrierEvent;}
+
+    // Hierarchical
+    JEventLevel GetLevel() const { return mFactorySet->GetLevel(); }
+    void SetLevel(JEventLevel level) { mFactorySet->SetLevel(level); }
+    void SetEventIndex(int event_index) { mEventIndex = event_index; }
+    int64_t GetEventIndex() const { return mEventIndex; }
+
+    bool HasParent(JEventLevel level) const;
+    const JEvent& GetParent(JEventLevel level) const;
+    void SetParent(std::shared_ptr<JEvent>* parent);
+    std::shared_ptr<JEvent>* ReleaseParent(JEventLevel level);
+    void Release();
+    void Reset();
+
+    JFactory* GetFactory(const std::string& object_name, const std::string& tag) const;
+    std::vector<JFactory*> GetAllFactories() const;
+
+
+    template<class T> JFactoryT<T>* GetFactory(const std::string& tag = "", bool throw_on_missing=false) const;
+    template<class T> std::vector<JFactoryT<T>*> GetFactoryAll(bool throw_on_missing = false) const;
+
+    // C style getters
+    template<class T> JFactoryT<T>* GetSingle(const T* &t, const char *tag="", bool exception_if_not_one=true) const;
+    template<class T> JFactoryT<T>* Get(const T** item, const std::string& tag="") const;
+    template<class T> JFactoryT<T>* Get(std::vector<const T*> &vec, const std::string& tag = "", bool strict=true) const;
+    template<class T> void GetAll(std::vector<const T*> &vec) const;
+
+    // C++ style getters
+    template<class T> const T* GetSingle(const std::string& tag = "") const;
+    template<class T> const T* GetSingleStrict(const std::string& tag = "") const;
+    template<class T> std::vector<const T*> Get(const std::string& tag = "", bool strict=true) const;
+    template<class T> typename JFactoryT<T>::PairType GetIterators(const std::string& aTag = "") const;
+    template<class T> std::vector<const T*> GetAll() const;
+    template<class T> std::map<std::pair<std::string,std::string>,std::vector<T*>> GetAllChildren() const;
+
+    // Insert
+    template <class T> JFactoryT<T>* Insert(T* item, const std::string& aTag = "") const;
+    template <class T> JFactoryT<T>* Insert(const std::vector<T*>& items, const std::string& tag = "") const;
+
+    // PODIO
+#if JANA2_HAVE_PODIO
+    std::vector<std::string> GetAllCollectionNames() const;
+    const podio::CollectionBase* GetCollectionBase(std::string name, bool throw_on_missing=true) const;
+    template <typename T> const typename JFactoryPodioT<T>::CollectionT* GetCollection(std::string name, bool throw_on_missing=true) const;
+    template <typename T> JFactoryPodioT<T>* InsertCollection(typename JFactoryPodioT<T>::CollectionT&& collection, std::string name);
+    template <typename T> JFactoryPodioT<T>* InsertCollectionAlreadyInFrame(const podio::CollectionBase* collection, std::string name);
+#endif
+
+
 };
+
+
+/// GetFactory() should be used with extreme care because it subverts the JEvent abstraction.
+/// Most historical uses of GetFactory are far better served by JMultifactory.
+template<class T>
+inline JFactoryT<T>* JEvent::GetFactory(const std::string& tag, bool throw_on_missing) const
+{
+    std::string resolved_tag = tag;
+    if (mUseDefaultTags && tag.empty()) {
+        auto defaultTag = mDefaultTags.find(JTypeInfo::demangle<T>());
+        if (defaultTag != mDefaultTags.end()) resolved_tag = defaultTag->second;
+    }
+    auto factory = mFactorySet->GetFactory<T>(resolved_tag);
+    if (factory == nullptr) {
+        if (throw_on_missing) {
+            JException ex("Could not find JFactoryT<" + JTypeInfo::demangle<T>() + "> with tag=" + tag);
+            ex.show_stacktrace = false;
+            throw ex;
+        }
+    };
+    return factory;
+}
+
+
+/// GetFactoryAll returns all JFactoryT's for type T (each corresponds to a different tag).
+/// This is useful when there are many different tags, or the tags are unknown, and the user
+/// wishes to examine them all together.
+template<class T>
+inline std::vector<JFactoryT<T>*> JEvent::GetFactoryAll(bool throw_on_missing) const {
+    auto factories = mFactorySet->GetAllFactories<T>();
+    if (factories.size() == 0) {
+        if (throw_on_missing) {
+            JException ex("Could not find any JFactoryT<" + JTypeInfo::demangle<T>() + "> (from any tag)");
+            ex.show_stacktrace = false;
+            throw ex;
+        }
+    };
+    return factories;
+}
+
+
+/// C-style getters
+
+template<class T>
+JFactoryT<T>* JEvent::GetSingle(const T* &t, const char *tag, bool exception_if_not_one) const
+{
+    /// This is a convenience method that can be used to get a pointer to the single
+    /// object of type T from the specified factory. It simply calls the Get(vector<...>) method
+    /// and copies the first pointer into "t" (or NULL if something other than 1 object is returned).
+    ///
+    /// This is intended to address the common situation in which there is an interest
+    /// in the event if and only if there is exactly 1 object of type T. If the event
+    /// has no objects of that type or more than 1 object of that type (for the specified
+    /// factory) then an exception of type "unsigned long" is thrown with the value
+    /// being the number of objects of type T. You can supress the exception by setting
+    /// exception_if_not_one to false. In that case, you will have to check if t==NULL to
+    /// know if the call succeeded.
+
+    std::vector<const T*> v;
+    auto fac = GetFactory<T>(tag, true); // throw exception if factory not found
+    JCallGraphEntryMaker cg_entry(mCallGraph, fac); // times execution until this goes out of scope
+    Get(v, tag);
+    if(v.size()!=1){
+        t = NULL;
+        if(exception_if_not_one) throw v.size();
+    }
+    t = v[0];
+    return fac;
+}
+
+/// Get conveniently returns one item from inside the JFactory. This should be used when the data in question
+/// is optional and the caller wants to examine the result and decide how to proceed. The caller should embed this
+/// inside an if-block. Get updates the `destination` out parameter and returns a pointer to the enclosing JFactory.
+/// - If the factory is missing, GetSingle throws an exception.
+/// - If the factory exists but contains no items, GetSingle updates the `destination` to point to nullptr.
+/// - If the factory contains exactly one item, GetSingle updates the `destination` to point to that item.
+/// - If the factory contains more than one item, GetSingle updates the `destination` to point to the first time.
+template<class T>
+JFactoryT<T>* JEvent::Get(const T** destination, const std::string& tag) const
+{
+    auto factory = GetFactory<T>(tag, true);
+    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
+    auto iterators = factory->CreateAndGetData(this->shared_from_this());
+    if (std::distance(iterators.first, iterators.second) == 0) {
+        *destination = nullptr;
+    }
+    else {
+        *destination = *iterators.first;
+    }
+    return factory;
+}
+
+
+template<class T>
+JFactoryT<T>* JEvent::Get(std::vector<const T*>& destination, const std::string& tag, bool strict) const
+{
+    auto factory = GetFactory<T>(tag, strict);
+    if (factory == nullptr) return nullptr; // Will have thrown already if strict==true
+    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
+    auto iterators = factory->CreateAndGetData(this->shared_from_this());
+    for (auto it=iterators.first; it!=iterators.second; it++) {
+        destination.push_back(*it);
+    }
+    return factory;
+}
+
+
+/// GetAll returns all JObjects of (child) type T, regardless of tag.
+template<class T>
+void JEvent::GetAll(std::vector<const T*>& destination) const {
+    auto factories = GetFactoryAll<T>(true);
+    for (auto factory : factories) {
+        auto iterators = factory->CreateAndGetData(this->shared_from_this());
+        for (auto it = iterators.first; it != iterators.second; it++) {
+            destination.push_back(*it);
+        }
+    }
+}
+
+
+
+/// C++ style getters
+
+/// GetSingle conveniently returns one item from inside the JFactory. This should be used when the data in question
+/// is optional and the caller wants to examine the result and decide how to proceed. The caller should embed this
+/// inside an if-block.
+/// - If the factory is missing, GetSingle throws an exception
+/// - If the factory exists but contains no items, GetSingle returns nullptr
+/// - If the factory contains more than one item, GetSingle returns the first item
+
+template<class T> const T* JEvent::GetSingle(const std::string& tag) const {
+    auto factory = GetFactory<T>(tag, true);
+    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
+    auto iterators = factory->CreateAndGetData(this->shared_from_this());
+    if (std::distance(iterators.first, iterators.second) == 0) {
+        return nullptr;
+    }
+    return *iterators.first;
+}
+
+
+
+/// GetSingleStrict conveniently returns one item from inside the JFactory. This should be used when the data in
+/// question is mandatory, and its absence indicates an error which should stop execution. The caller does not need
+/// to embed this in an if- or try-catch block; it can be a one-liner.
+/// - If the factory is missing, GetSingleStrict throws an exception
+/// - If the factory exists but contains no items, GetSingleStrict throws an exception
+/// - If the factory contains more than one item, GetSingleStrict throws an exception
+template<class T> const T* JEvent::GetSingleStrict(const std::string& tag) const {
+    auto factory = GetFactory<T>(tag, true);
+    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
+    auto iterators = factory->CreateAndGetData(this->shared_from_this());
+    if (std::distance(iterators.first, iterators.second) == 0) {
+        JException ex("GetSingle failed due to missing %d", NAME_OF(T));
+        ex.show_stacktrace = false;
+        throw ex;
+    }
+    else if (std::distance(iterators.first, iterators.second) > 1) {
+        JException ex("GetSingle failed due to too many %d", NAME_OF(T));
+        ex.show_stacktrace = false;
+        throw ex;
+    }
+    return *iterators.first;
+}
+
+
+template<class T>
+std::vector<const T*> JEvent::Get(const std::string& tag, bool strict) const {
+
+    auto factory = GetFactory<T>(tag, strict);
+    std::vector<const T*> vec;
+    if (factory == nullptr) return vec; // Will have thrown already if strict==true
+    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
+    auto iters = factory->CreateAndGetData(this->shared_from_this());
+    for (auto it=iters.first; it!=iters.second; ++it) {
+        vec.push_back(*it);
+    }
+    return vec; // Assumes RVO
+}
+
+template<class T>
+typename JFactoryT<T>::PairType JEvent::GetIterators(const std::string& tag) const {
+    auto factory = GetFactory<T>(tag, true);
+    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
+    auto iters = factory->CreateAndGetData(this->shared_from_this());
+    return iters;
+}
+
+/// GetAll returns all JObjects of (child) type T, regardless of tag.
+template<class T>
+std::vector<const T*> JEvent::GetAll() const {
+    std::vector<const T*> vec;
+    auto factories = GetFactoryAll<T>(true);
+
+    for (auto factory : factories) {
+        auto iters = factory->CreateAndGetData(this->shared_from_this());
+        std::vector<const T*> vec;
+        for (auto it = iters.first; it != iters.second; ++it) {
+            vec.push_back(*it);
+        }
+    }
+    return vec; // Assumes RVO
+}
+
+// GetAllChildren will furnish a map { (type_name,tag_name) : [BaseClass*] } containing all JFactoryT<T> data where
+// T inherits from BaseClass. Note that this _won't_ compute any results (unlike GetAll) because this is meant for
+// things like visualizing and persisting DSTs.
+// TODO: This is conceptually inconsistent with GetAll. Reconcile.
+
+template<class S>
+std::map<std::pair<std::string, std::string>, std::vector<S*>> JEvent::GetAllChildren() const {
+    std::map<std::pair<std::string, std::string>, std::vector<S*>> results;
+    for (JFactory* factory : mFactorySet->GetAllFactories()) {
+        auto val = factory->GetAs<S>();
+        if (!val.empty()) {
+            auto key = std::make_pair(factory->GetObjectName(), factory->GetTag());
+            results.insert(std::make_pair(key, val));
+        }
+    }
+    return results;
+}
+
+
 
 /// Insert() allows an EventSource to insert items directly into the JEvent,
 /// removing the need for user-extended JEvents and/or JEventSource::GetObjects(...)
@@ -188,236 +402,7 @@ inline JFactoryT<T>* JEvent::Insert(const std::vector<T*>& items, const std::str
     return factory;
 }
 
-/// GetFactory() should be used with extreme care because it subverts the JEvent abstraction.
-/// Most historical uses of GetFactory are far better served by JMultifactory
-inline JFactory* JEvent::GetFactory(const std::string& object_name, const std::string& tag) const {
-    return mFactorySet->GetFactory(object_name, tag);
-}
 
-/// GetAllFactories() should be used with extreme care because it subverts the JEvent abstraction.
-/// Most historical uses of GetFactory are far better served by JMultifactory
-inline std::vector<JFactory*> JEvent::GetAllFactories() const {
-    return mFactorySet->GetAllFactories();
-}
-
-/// GetFactory() should be used with extreme care because it subverts the JEvent abstraction.
-/// Most historical uses of GetFactory are far better served by JMultifactory.
-template<class T>
-inline JFactoryT<T>* JEvent::GetFactory(const std::string& tag, bool throw_on_missing) const
-{
-    std::string resolved_tag = tag;
-    if (mUseDefaultTags && tag.empty()) {
-        auto defaultTag = mDefaultTags.find(JTypeInfo::demangle<T>());
-        if (defaultTag != mDefaultTags.end()) resolved_tag = defaultTag->second;
-    }
-    auto factory = mFactorySet->GetFactory<T>(resolved_tag);
-    if (factory == nullptr) {
-        if (throw_on_missing) {
-            JException ex("Could not find JFactoryT<" + JTypeInfo::demangle<T>() + "> with tag=" + tag);
-            ex.show_stacktrace = false;
-            throw ex;
-        }
-    };
-    return factory;
-}
-
-
-
-/// C-style getters
-
-/// Get conveniently returns one item from inside the JFactory. This should be used when the data in question
-/// is optional and the caller wants to examine the result and decide how to proceed. The caller should embed this
-/// inside an if-block. Get updates the `destination` out parameter and returns a pointer to the enclosing JFactory.
-/// - If the factory is missing, GetSingle throws an exception.
-/// - If the factory exists but contains no items, GetSingle updates the `destination` to point to nullptr.
-/// - If the factory contains exactly one item, GetSingle updates the `destination` to point to that item.
-/// - If the factory contains more than one item, GetSingle updates the `destination` to point to the first time.
-template<class T>
-JFactoryT<T>* JEvent::Get(const T** destination, const std::string& tag) const
-{
-    auto factory = GetFactory<T>(tag, true);
-    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iterators = factory->CreateAndGetData(this->shared_from_this());
-    if (std::distance(iterators.first, iterators.second) == 0) {
-        *destination = nullptr;
-    }
-    else {
-        *destination = *iterators.first;
-    }
-    return factory;
-}
-
-
-template<class T>
-JFactoryT<T>* JEvent::Get(std::vector<const T*>& destination, const std::string& tag, bool strict) const
-{
-    auto factory = GetFactory<T>(tag, strict);
-    if (factory == nullptr) return nullptr; // Will have thrown already if strict==true
-    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iterators = factory->CreateAndGetData(this->shared_from_this());
-    for (auto it=iterators.first; it!=iterators.second; it++) {
-        destination.push_back(*it);
-    }
-    return factory;
-}
-
-
-/// C++ style getters
-
-/// GetSingle conveniently returns one item from inside the JFactory. This should be used when the data in question
-/// is optional and the caller wants to examine the result and decide how to proceed. The caller should embed this
-/// inside an if-block.
-/// - If the factory is missing, GetSingle throws an exception
-/// - If the factory exists but contains no items, GetSingle returns nullptr
-/// - If the factory contains more than one item, GetSingle returns the first item
-
-template<class T> const T* JEvent::GetSingle(const std::string& tag) const {
-    auto factory = GetFactory<T>(tag, true);
-    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iterators = factory->CreateAndGetData(this->shared_from_this());
-    if (std::distance(iterators.first, iterators.second) == 0) {
-        return nullptr;
-    }
-    return *iterators.first;
-}
-
-/// GetSingleStrict conveniently returns one item from inside the JFactory. This should be used when the data in
-/// question is mandatory, and its absence indicates an error which should stop execution. The caller does not need
-/// to embed this in an if- or try-catch block; it can be a one-liner.
-/// - If the factory is missing, GetSingleStrict throws an exception
-/// - If the factory exists but contains no items, GetSingleStrict throws an exception
-/// - If the factory contains more than one item, GetSingleStrict throws an exception
-template<class T> const T* JEvent::GetSingleStrict(const std::string& tag) const {
-    auto factory = GetFactory<T>(tag, true);
-    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iterators = factory->CreateAndGetData(this->shared_from_this());
-    if (std::distance(iterators.first, iterators.second) == 0) {
-        JException ex("GetSingle failed due to missing %d", NAME_OF(T));
-        ex.show_stacktrace = false;
-        throw ex;
-    }
-    else if (std::distance(iterators.first, iterators.second) > 1) {
-        JException ex("GetSingle failed due to too many %d", NAME_OF(T));
-        ex.show_stacktrace = false;
-        throw ex;
-    }
-    return *iterators.first;
-}
-
-
-template<class T>
-std::vector<const T*> JEvent::Get(const std::string& tag, bool strict) const {
-
-    auto factory = GetFactory<T>(tag, strict);
-    std::vector<const T*> vec;
-    if (factory == nullptr) return vec; // Will have thrown already if strict==true
-    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iters = factory->CreateAndGetData(this->shared_from_this());
-    for (auto it=iters.first; it!=iters.second; ++it) {
-        vec.push_back(*it);
-    }
-    return vec; // Assumes RVO
-}
-
-/// GetFactoryAll returns all JFactoryT's for type T (each corresponds to a different tag).
-/// This is useful when there are many different tags, or the tags are unknown, and the user
-/// wishes to examine them all together.
-template<class T>
-inline std::vector<JFactoryT<T>*> JEvent::GetFactoryAll(bool throw_on_missing) const {
-    auto factories = mFactorySet->GetAllFactories<T>();
-    if (factories.size() == 0) {
-        if (throw_on_missing) {
-            JException ex("Could not find any JFactoryT<" + JTypeInfo::demangle<T>() + "> (from any tag)");
-            ex.show_stacktrace = false;
-            throw ex;
-        }
-    };
-    return factories;
-}
-
-/// GetAll returns all JObjects of (child) type T, regardless of tag.
-template<class T>
-void JEvent::GetAll(std::vector<const T*>& destination) const {
-    auto factories = GetFactoryAll<T>(true);
-    for (auto factory : factories) {
-        auto iterators = factory->CreateAndGetData(this->shared_from_this());
-        for (auto it = iterators.first; it != iterators.second; it++) {
-            destination.push_back(*it);
-        }
-    }
-}
-
-/// GetAll returns all JObjects of (child) type T, regardless of tag.
-template<class T>
-std::vector<const T*> JEvent::GetAll() const {
-    std::vector<const T*> vec;
-    auto factories = GetFactoryAll<T>(true);
-
-    for (auto factory : factories) {
-        auto iters = factory->CreateAndGetData(this->shared_from_this());
-        std::vector<const T*> vec;
-        for (auto it = iters.first; it != iters.second; ++it) {
-            vec.push_back(*it);
-        }
-    }
-    return vec; // Assumes RVO
-}
-
-
-// GetAllChildren will furnish a map { (type_name,tag_name) : [BaseClass*] } containing all JFactoryT<T> data where
-// T inherits from BaseClass. Note that this _won't_ compute any results (unlike GetAll) because this is meant for
-// things like visualizing and persisting DSTs.
-// TODO: This is conceptually inconsistent with GetAll. Reconcile.
-
-template<class S>
-std::map<std::pair<std::string, std::string>, std::vector<S*>> JEvent::GetAllChildren() const {
-    std::map<std::pair<std::string, std::string>, std::vector<S*>> results;
-    for (JFactory* factory : mFactorySet->GetAllFactories()) {
-        auto val = factory->GetAs<S>();
-        if (!val.empty()) {
-            auto key = std::make_pair(factory->GetObjectName(), factory->GetTag());
-            results.insert(std::make_pair(key, val));
-        }
-    }
-    return results;
-}
-
-
-template<class T>
-typename JFactoryT<T>::PairType JEvent::GetIterators(const std::string& tag) const {
-    auto factory = GetFactory<T>(tag, true);
-    JCallGraphEntryMaker cg_entry(mCallGraph, factory); // times execution until this goes out of scope
-    auto iters = factory->CreateAndGetData(this->shared_from_this());
-    return iters;
-}
-
-
-template<class T>
-JFactoryT<T>* JEvent::GetSingle(const T* &t, const char *tag, bool exception_if_not_one) const
-{
-    /// This is a convenience method that can be used to get a pointer to the single
-    /// object of type T from the specified factory. It simply calls the Get(vector<...>) method
-    /// and copies the first pointer into "t" (or NULL if something other than 1 object is returned).
-    ///
-    /// This is intended to address the common situation in which there is an interest
-    /// in the event if and only if there is exactly 1 object of type T. If the event
-    /// has no objects of that type or more than 1 object of that type (for the specified
-    /// factory) then an exception of type "unsigned long" is thrown with the value
-    /// being the number of objects of type T. You can supress the exception by setting
-    /// exception_if_not_one to false. In that case, you will have to check if t==NULL to
-    /// know if the call succeeded.
-
-    std::vector<const T*> v;
-    auto fac = GetFactory<T>(tag, true); // throw exception if factory not found
-    JCallGraphEntryMaker cg_entry(mCallGraph, fac); // times execution until this goes out of scope
-    Get(v, tag);
-    if(v.size()!=1){
-        t = NULL;
-        if(exception_if_not_one) throw v.size();
-    }
-    t = v[0];
-    return fac;
-}
 
 #if JANA2_HAVE_PODIO
 
@@ -447,8 +432,8 @@ inline const podio::CollectionBase* JEvent::GetCollectionBase(std::string name, 
     JCallGraphEntryMaker cg_entry(mCallGraph, it->second); // times execution until this goes out of scope
     it->second->Create(this->shared_from_this());
     return factory->GetCollection();
-    // TODO: Might be cheaper/simpler to obtain factory from mPodioFactories instead of mFactorySet
 }
+
 
 template <typename T>
 const typename JFactoryPodioT<T>::CollectionT* JEvent::GetCollection(std::string name, bool throw_on_missing) const {

--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -92,7 +92,10 @@ public:
     void SetParent(std::shared_ptr<JEvent>* parent);
     std::shared_ptr<JEvent>* ReleaseParent(JEventLevel level);
     void Release();
-    void Reset();
+
+    // Lifecycle
+    void Clear();
+    void Finish();
 
     JFactory* GetFactory(const std::string& object_name, const std::string& tag) const;
     std::vector<JFactory*> GetAllFactories() const;

--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -41,10 +41,8 @@ class JEvent : public std::enable_shared_from_this<JEvent>
 {
     public:
 
-        explicit JEvent(JApplication* aApplication=nullptr) : mInspector(&(*this)) {
-            mApplication = aApplication;
-            mFactorySet = new JFactorySet();
-        }
+        explicit JEvent(JApplication* app=nullptr);
+
         virtual ~JEvent() {
             if (mFactorySet != nullptr) mFactorySet->Release();
             delete mFactorySet;

--- a/src/libraries/JANA/JEventSource.cc
+++ b/src/libraries/JANA/JEventSource.cc
@@ -249,7 +249,7 @@ JEventSource::Result JEventSource::DoNextCompatibility(std::shared_ptr<JEvent> e
 }
 
 
-void JEventSource::DoFinish(JEvent& event) {
+void JEventSource::DoFinishEvent(JEvent& event) {
 
     m_events_finished.fetch_add(1);
     if (m_enable_finish_event) {

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -188,7 +188,7 @@ public:
 
     Result DoNextCompatibility(std::shared_ptr<JEvent> event);
 
-    void DoFinish(JEvent& event);
+    void DoFinishEvent(JEvent& event);
 
     void Summarize(JComponentSummary& summary) const override;
 

--- a/src/libraries/JANA/JFactory.cc
+++ b/src/libraries/JANA/JFactory.cc
@@ -78,6 +78,14 @@ void JFactory::DoInit() {
     mStatus = Status::Unprocessed;
 }
 
+void JFactory::DoFinish() {
+    if (mStatus == Status::Unprocessed || mStatus == Status::Processed) {
+        mStatus = Status::Finished;
+        CallWithJExceptionWrapper("JFactory::EndRun", [&](){ EndRun(); });
+        CallWithJExceptionWrapper("JFactory::Finish", [&](){ Finish(); });
+    }
+}
+
 void JFactory::Summarize(JComponentSummary& summary) const {
 
     auto fs = new JComponentSummary::Component(

--- a/src/libraries/JANA/JFactory.cc
+++ b/src/libraries/JANA/JFactory.cc
@@ -45,15 +45,10 @@ void JFactory::Create(const std::shared_ptr<const JEvent>& event) {
 
     if (mStatus == Status::Unprocessed) {
         auto run_number = event->GetRunNumber();
-        if (mPreviousRunNumber == -1) {
-            // This is the very first run
-            CallWithJExceptionWrapper("JFactory::ChangeRun", [&](){ ChangeRun(event); });
-            CallWithJExceptionWrapper("JFactory::BeginRun", [&](){ BeginRun(event); });
-            mPreviousRunNumber = run_number;
-        }
-        else if (mPreviousRunNumber != run_number) {
-            // This is a later run, and it has changed
-            CallWithJExceptionWrapper("JFactory::EndRun", [&](){ EndRun(); });
+        if (mPreviousRunNumber != run_number) {
+            if (mPreviousRunNumber != -1) {
+                CallWithJExceptionWrapper("JFactory::EndRun", [&](){ EndRun(); });
+            }
             CallWithJExceptionWrapper("JFactory::ChangeRun", [&](){ ChangeRun(event); });
             CallWithJExceptionWrapper("JFactory::BeginRun", [&](){ BeginRun(event); });
             mPreviousRunNumber = run_number;
@@ -80,9 +75,11 @@ void JFactory::DoInit() {
 
 void JFactory::DoFinish() {
     if (mStatus == Status::Unprocessed || mStatus == Status::Processed) {
-        mStatus = Status::Finished;
-        CallWithJExceptionWrapper("JFactory::EndRun", [&](){ EndRun(); });
+        if (mPreviousRunNumber != -1) {
+            CallWithJExceptionWrapper("JFactory::EndRun", [&](){ EndRun(); });
+        }
         CallWithJExceptionWrapper("JFactory::Finish", [&](){ Finish(); });
+        mStatus = Status::Finished;
     }
 }
 

--- a/src/libraries/JANA/JFactory.h
+++ b/src/libraries/JANA/JFactory.h
@@ -25,7 +25,7 @@ class JApplication;
 class JFactory : public jana::components::JComponent {
 public:
 
-    enum class Status {Uninitialized, Unprocessed, Processed, Inserted};
+    enum class Status {Uninitialized, Unprocessed, Processed, Inserted, Finished};
     enum class CreationStatus { NotCreatedYet, Created, Inserted, InsertedViaGetObjects, NeverCreated };
 
     enum JFactory_Flags_t {
@@ -171,6 +171,7 @@ public:
     /// type of object contained. In order to access these objects when all you have is a JFactory*, use JFactory::GetAs().
     virtual void Create(const std::shared_ptr<const JEvent>& event);
     void DoInit();
+    void DoFinish();
     void Summarize(JComponentSummary& summary) const override;
 
 

--- a/src/libraries/JANA/JFactorySet.cc
+++ b/src/libraries/JANA/JFactorySet.cc
@@ -165,12 +165,27 @@ void JFactorySet::Print() const
     }
 }
 
-/// Release() loops over all contained factories, clearing their data
-void JFactorySet::Release() {
+//---------------------------------
+// Clear
+//---------------------------------
+void JFactorySet::Clear() {
 
     for (const auto& sFactoryPair : mFactories) {
         auto sFactory = sFactoryPair.second;
         sFactory->ClearData();
+        // This automatically clears multifactories because their data is stored in helper factories!
+    }
+}
+
+//---------------------------------
+// Finish
+//---------------------------------
+void JFactorySet::Finish() {
+    for (auto& p : mFactories) {
+        p.second->DoFinish();
+    }
+    for (auto& multifac : mMultifactories) {
+        multifac->DoFinish();
     }
 }
 

--- a/src/libraries/JANA/JFactorySet.h
+++ b/src/libraries/JANA/JFactorySet.h
@@ -26,8 +26,9 @@ class JFactorySet {
 
         bool Add(JFactory* aFactory);
         bool Add(JMultifactory* multifactory);
-        void Print(void) const;
-        void Release(void);
+        void Print() const;
+        void Clear();
+        void Finish();
 
         JFactory* GetFactory(const std::string& object_name, const std::string& tag="") const;
         template<typename T> JFactoryT<T>* GetFactory(const std::string& tag = "") const;

--- a/src/libraries/JANA/JMultifactory.cc
+++ b/src/libraries/JANA/JMultifactory.cc
@@ -46,14 +46,14 @@ void JMultifactory::Execute(const std::shared_ptr<const JEvent>& event) {
     });
 }
 
-void JMultifactory::Release() {
+void JMultifactory::DoFinish() {
     std::lock_guard<std::mutex> lock(m_mutex);
     // Only call Finish() if we actually initialized
     // Only call Finish() once
+    
     if (m_status == Status::Initialized) {
-        CallWithJExceptionWrapper("JMultifactory::Finish", [&](){
-            Finish();
-        });
+        CallWithJExceptionWrapper("JMultifactory::EndRun", [&](){ EndRun(); });
+        CallWithJExceptionWrapper("JMultifactory::Finish", [&](){ Finish(); });
         m_status = Status::Finalized;
     }
 }

--- a/src/libraries/JANA/JMultifactory.h
+++ b/src/libraries/JANA/JMultifactory.h
@@ -118,12 +118,9 @@ public:
     
     void DoInit();
 
-    void Execute(const std::shared_ptr<const JEvent>&);
-    // Should this be execute or create? Who is tracking that this is called at most once per event?
-    // Do we need something like JFactory::Status? Also, how do we ensure that CreationStatus is correct as well?
+    void DoFinish();
 
-    void Release();
-    // Release makes sure Finish() is called exactly once
+    void Execute(const std::shared_ptr<const JEvent>&);
 
     JFactorySet* GetHelpers();
     // This exposes the mHelpers JFactorySet, which contains a JFactoryT<T> for each declared output of the multifactory.

--- a/src/libraries/JANA/Services/JParameterManager.cc
+++ b/src/libraries/JANA/Services/JParameterManager.cc
@@ -111,15 +111,9 @@ void JParameterManager::PrintParameters(int verbosity, int strictness) {
         return;
     }
 
-    bool warnings_present = false;
     bool strictness_violation = false;
 
-    // We don't need to show "Advanced" as a warning unless we are using full verbosity
-    if (verbosity == 3) {
-        warnings_present = true;
-    }
-
-    // Check for warnings and unused parameters first 
+    // Unused parameters first 
     // The former might change the table columns and the latter might change the filter verbosity
     for (auto& pair : m_parameters) {
         const auto& key = pair.first;
@@ -127,12 +121,10 @@ void JParameterManager::PrintParameters(int verbosity, int strictness) {
         
         if ((strictness > 0) && (!param->IsDefault()) && (!param->IsUsed())) {
             strictness_violation = true;
-            warnings_present = true;
             LOG_ERROR(m_logger) << "Parameter '" << key << "' appears to be unused. Possible typo?" << LOG_END;
         }
         if ((!param->IsDefault()) && (param->IsDeprecated())) {
             LOG_ERROR(m_logger) << "Parameter '" << key << "' has been deprecated and may no longer be supported in future releases." << LOG_END;
-            warnings_present = true;
         }
     }
 
@@ -165,25 +157,17 @@ void JParameterManager::PrintParameters(int verbosity, int strictness) {
         return;
     }
 
-    // Print table
-    JTablePrinter table;
-    table.AddColumn("Name", JTablePrinter::Justify::Left, 20);
-    if (warnings_present) {
-        table.AddColumn("Warnings");  // IsDeprecated column
-    }
-    table.AddColumn("Value", JTablePrinter::Justify::Left, 25);
-    table.AddColumn("Default", JTablePrinter::Justify::Left, 25);
-    table.AddColumn("Description", JTablePrinter::Justify::Left, 50);
-
     std::ostringstream ss;
     for (JParameter* p: params_to_print) {
 
         ss << std::endl;
         ss << " - key:         \"" << p->GetKey() << "\"" << std::endl;
-        ss << "   value:       \"" << p->GetValue() << "\"" << std::endl;
+        if (!p->IsDefault()) {
+            ss << "   value:       \"" << p->GetValue() << "\"" << std::endl;
+        }
         ss << "   default:     \"" << p->GetDefault() << "\"" << std::endl;
         if (!p->GetDescription().empty()) {
-            ss << "   description: \"";
+            ss << "   description: ";
             std::istringstream iss(p->GetDescription());
             std::string line;
             bool is_first_line =  true;
@@ -196,19 +180,22 @@ void JParameterManager::PrintParameters(int verbosity, int strictness) {
                 }
                 is_first_line = false;
             }
-            ss << "\"" << std::endl;
+            ss << std::endl;
+        }
+        if (p->IsConflicted()) {
+            ss << "   warning:     Conflicting defaults" << std::endl;
         }
         if (p->IsDeprecated()) {
-            ss << "   warning:      \"Deprecated\"" << std::endl;
+            ss << "   warning:     Deprecated" << std::endl;
             // If deprecated, it no longer matters whether it is advanced or not. If unused, won't show up here anyway.
         }
-        else if (!p->IsUsed()) {
+        if (!p->IsUsed()) {
             // Can't be both deprecated and unused, since JANA only finds out that it is deprecated by trying to use it
             // Can't be both advanced and unused, since JANA only finds out that it is advanced by trying to use it
-            ss << "   warning:     \"Unused\"" << std::endl;
+            ss << "   warning:     Unused" << std::endl;
         }
-        else if (p->IsAdvanced()) {
-            ss << "   warning:     \"Advanced\"" << std::endl;
+        if (p->IsAdvanced()) {
+            ss << "   warning:     Advanced" << std::endl;
         }
     }
     LOG_WARN(m_logger) << "Configuration Parameters\n"  << ss.str() << LOG_END;

--- a/src/libraries/JANA/Services/JParameterManager.cc
+++ b/src/libraries/JANA/Services/JParameterManager.cc
@@ -139,10 +139,10 @@ void JParameterManager::PrintParameters(int verbosity, int strictness) {
     for (auto& pair : m_parameters) {
         auto param = pair.second;
 
-        if (param->IsDeprecated() && (param->IsDefault())) continue;      
+        if (param->IsDeprecated() && (param->IsDefault())) continue;
         // Always hide deprecated parameters that are NOT in use
         
-        if ((verbosity == 1) && (param->IsDefault())) continue;           
+        if ((verbosity == 1) && (param->IsDefault())) continue;
         // At verbosity level 1, hide all default-valued parameters
         
         if ((verbosity == 2) && (param->IsDefault()) && (param->IsAdvanced())) continue;
@@ -157,48 +157,48 @@ void JParameterManager::PrintParameters(int verbosity, int strictness) {
         return;
     }
 
-    std::ostringstream ss;
+    LOG_WARN(m_logger) << "Configuration Parameters" << LOG_END;
     for (JParameter* p: params_to_print) {
 
-        ss << std::endl;
-        ss << " - key:         \"" << p->GetKey() << "\"" << std::endl;
+        LOG_WARN(m_logger) << LOG_END;
+        LOG_WARN(m_logger) << " - key:         " << p->GetKey() << LOG_END;
         if (!p->IsDefault()) {
-            ss << "   value:       \"" << p->GetValue() << "\"" << std::endl;
+            LOG_WARN(m_logger) << "   value:       " << p->GetValue() << LOG_END;
         }
-        ss << "   default:     \"" << p->GetDefault() << "\"" << std::endl;
+        if (p->HasDefault()) {
+            LOG_WARN(m_logger) << "   default:     " << p->GetDefault() << LOG_END;
+        }
         if (!p->GetDescription().empty()) {
-            ss << "   description: ";
             std::istringstream iss(p->GetDescription());
             std::string line;
             bool is_first_line =  true;
             while (std::getline(iss, line)) {
-                if (!is_first_line) {
-                    ss << std::endl << "                 " << line;
+                if (is_first_line) {
+                    LOG_INFO(m_logger) << "   description: " << line << LOG_END;
                 }
                 else {
-                    ss << line;
+                    LOG_INFO(m_logger) << "                " << line << LOG_END;
                 }
                 is_first_line = false;
             }
-            ss << std::endl;
         }
         if (p->IsConflicted()) {
-            ss << "   warning:     Conflicting defaults" << std::endl;
+            LOG_WARN(m_logger) << "   warning:     Conflicting defaults" << LOG_END;
         }
         if (p->IsDeprecated()) {
-            ss << "   warning:     Deprecated" << std::endl;
+            LOG_WARN(m_logger) << "   warning:     Deprecated" << LOG_END;
             // If deprecated, it no longer matters whether it is advanced or not. If unused, won't show up here anyway.
         }
         if (!p->IsUsed()) {
             // Can't be both deprecated and unused, since JANA only finds out that it is deprecated by trying to use it
             // Can't be both advanced and unused, since JANA only finds out that it is advanced by trying to use it
-            ss << "   warning:     Unused" << std::endl;
+            LOG_WARN(m_logger) << "   warning:     Unused" << LOG_END;
         }
         if (p->IsAdvanced()) {
-            ss << "   warning:     Advanced" << std::endl;
+            LOG_WARN(m_logger) << "   warning:     Advanced" << LOG_END;
         }
     }
-    LOG_WARN(m_logger) << "Configuration Parameters\n"  << ss.str() << LOG_END;
+    LOG_WARN(m_logger) << LOG_END;
 
     // Now that we've printed the table, we can throw an exception if we are being super strict
     if (strictness_violation && strictness > 1) {

--- a/src/libraries/JANA/Topology/JEventPool.h
+++ b/src/libraries/JANA/Topology/JEventPool.h
@@ -7,7 +7,7 @@
 
 #include <JANA/JEvent.h>
 #include <JANA/Services/JComponentManager.h>
-#include <JANA/JEvent.h>
+#include <JANA/JMultifactory.h>
 #include <mutex>
 #include <vector>
 
@@ -73,6 +73,18 @@ public:
         (*item)->Reset();
     }
 
+    void finalize() {
+        for (size_t pool_idx = 0; pool_idx < m_location_count; ++pool_idx) {
+            for (auto& event : m_pools[pool_idx].items) {
+                for (auto* fac : event->GetFactorySet()->GetAllFactories()) {
+                    fac->DoFinish();
+                }
+                for (auto* multifac : event->GetFactorySet()->GetAllMultifactories()) {
+                    multifac->DoFinish();
+                }
+            }
+        }
+    }
 
     std::shared_ptr<JEvent>* get(size_t location=0) {
 

--- a/src/programs/unit_tests/Components/JEventGetAllTests.cc
+++ b/src/programs/unit_tests/Components/JEventGetAllTests.cc
@@ -159,7 +159,6 @@ TEST_CASE("JFactoryGetAs") {
 TEST_CASE("JEventGetAllChildren") {
 
     auto event = std::make_shared<JEvent>();
-    event->SetFactorySet(new JFactorySet);
 
     SECTION("Single-item JEvent::Insert() can be retrieved via JEvent::GetAllChildren()") {
         auto b = new Base(22);

--- a/src/programs/unit_tests/Components/JEventProcessorTests.cc
+++ b/src/programs/unit_tests/Components/JEventProcessorTests.cc
@@ -4,6 +4,9 @@
 #include <JANA/JEventProcessor.h>
 #include <JANA/JEventSource.h>
 
+namespace jana::jeventprocessortests {
+
+
 struct MyEventProcessor : public JEventProcessor {
     int init_count = 0;
     int process_count = 0;
@@ -85,3 +88,110 @@ TEST_CASE("JEventProcessor_Exception") {
     REQUIRE(found_throw == true);
 
 }
+
+
+struct SourceWithRunNumberChange : public JEventSource {
+    SourceWithRunNumberChange() {
+        SetCallbackStyle(CallbackStyle::ExpertMode);
+    }
+    Result Emit(JEvent& event) {
+        if (GetEmittedEventCount() < 2) {
+            event.SetRunNumber(48);
+        }
+        else {
+            event.SetRunNumber(49);
+        }
+        return Result::Success;
+    }
+};
+
+
+struct ProcWithExceptionsAndLogging : public JEventProcessor {
+    Parameter<bool> except_on_init {this, "except_on_init", false, "Except on init"};
+    Parameter<bool> except_on_beginrun {this, "except_on_beginrun", false, "Except on beginrun"};
+    Parameter<bool> except_on_process {this, "except_on_process", false, "Except on process"};
+    Parameter<bool> except_on_endrun {this, "except_on_endrun", false, "Except on endrun"};
+    Parameter<bool> except_on_finish {this, "except_on_finish", false, "Except on finish"};
+
+    std::vector<std::string> log;
+
+    void Init() override {
+        LOG_INFO(GetLogger()) << "ProcWithExceptionsAndLogging::Init" << LOG_END;
+        log.push_back("init");
+        if (*except_on_init) throw std::runtime_error("Mystery");
+    }
+    void BeginRun(const std::shared_ptr<const JEvent>&) override {
+        LOG_INFO(GetLogger()) << "ProcWithExceptionsAndLogging::BeginRun" << LOG_END;
+        log.push_back("beginrun");
+        if (*except_on_beginrun) throw std::runtime_error("Mystery");
+    }
+    void Process(const std::shared_ptr<const JEvent>&) override {
+        LOG_INFO(GetLogger()) << "ProcWithExceptionsAndLogging::Process" << LOG_END;
+        log.push_back("process");
+        if (*except_on_process) throw std::runtime_error("Mystery");
+    }
+    void EndRun() override {
+        LOG_INFO(GetLogger()) << "ProcWithExceptionsAndLogging::EndRun" << LOG_END;
+        log.push_back("endrun");
+        if (*except_on_endrun) throw std::runtime_error("Mystery");
+    }
+    void Finish() override {
+        LOG_INFO(GetLogger()) << "ProcWithExceptionsAndLogging::Finish" << LOG_END;
+        log.push_back("finish");
+        if (*except_on_finish) throw std::runtime_error("Mystery");
+    }
+};
+
+TEST_CASE("JEventProcessor_CallbackSequence") {
+    JApplication app;
+    auto sut = new ProcWithExceptionsAndLogging;
+    app.Add(sut);
+    // JApplication takes ownership of sut, so our pointer will become invalid when JApplication is destroyed
+
+    SECTION("NoRunNumber") {
+        app.Add(new JEventSource);
+        app.SetParameterValue("jana:nevents", 2);
+        app.Run();
+        REQUIRE(sut->log.size() == 6);
+        REQUIRE(sut->log.at(0) == "init");
+        REQUIRE(sut->log.at(1) == "beginrun");
+        REQUIRE(sut->log.at(2) == "process");
+        REQUIRE(sut->log.at(3) == "process");
+        REQUIRE(sut->log.at(4) == "endrun");
+        REQUIRE(sut->log.at(5) == "finish");
+    }
+    SECTION("ConstantRunNumber") {
+        app.Add(new SourceWithRunNumberChange);
+        app.SetParameterValue("jana:nevents", 2);
+        app.Run();
+        REQUIRE(sut->log.size() == 6);
+        REQUIRE(sut->log.at(0) == "init");
+        REQUIRE(sut->log.at(1) == "beginrun");
+        REQUIRE(sut->log.at(2) == "process");
+        REQUIRE(sut->log.at(3) == "process");
+        REQUIRE(sut->log.at(4) == "endrun");
+        REQUIRE(sut->log.at(5) == "finish");
+    }
+    SECTION("MultipleRunNumbers") {
+        app.Add(new SourceWithRunNumberChange);
+        app.SetParameterValue("jana:nevents", 5);
+        app.Run();
+        REQUIRE(sut->log.size() == 11);
+        REQUIRE(sut->log.at(0) == "init");
+        REQUIRE(sut->log.at(1) == "beginrun");
+        REQUIRE(sut->log.at(2) == "process");
+        REQUIRE(sut->log.at(3) == "process");
+        REQUIRE(sut->log.at(4) == "endrun");
+        REQUIRE(sut->log.at(5) == "beginrun");
+        REQUIRE(sut->log.at(6) == "process");
+        REQUIRE(sut->log.at(7) == "process");
+        REQUIRE(sut->log.at(8) == "process");
+        REQUIRE(sut->log.at(9) == "endrun");
+        REQUIRE(sut->log.at(10) == "finish");
+    }
+}
+
+
+
+
+} // namespace jana::jeventprocessortests

--- a/src/programs/unit_tests/Components/JEventProcessorTests.cc
+++ b/src/programs/unit_tests/Components/JEventProcessorTests.cc
@@ -18,14 +18,17 @@ struct MyEventProcessor : public JEventProcessor {
         (*destroy_count)++;
     }
     void Init() override {
+        REQUIRE(GetApplication() != nullptr);
         LOG_INFO(GetLogger()) << "Init() called" << LOG_END;
         init_count++;
     }
     void Process(const JEvent&) override {
+        REQUIRE(GetApplication() != nullptr);
         process_count++;
         LOG_INFO(GetLogger()) << "Process() called" << LOG_END;
     }
     void Finish() override {
+        REQUIRE(GetApplication() != nullptr);
         LOG_INFO(GetLogger()) << "Finish() called" << LOG_END;
         finish_count++;
     }

--- a/src/programs/unit_tests/Components/JEventSourceTests.cc
+++ b/src/programs/unit_tests/Components/JEventSourceTests.cc
@@ -10,12 +10,13 @@ struct MyEventSource : public JEventSource {
     size_t events_in_file = 5;
 
     void Open() override {
+        REQUIRE(GetApplication() != nullptr);
         LOG_INFO(GetLogger()) << "Open() called" << LOG_END;
         open_count++;
     }
     Result Emit(JEvent&) override {
         emit_count++;
-
+        REQUIRE(GetApplication() != nullptr);
         if (GetEmittedEventCount() >= events_in_file) {
             LOG_INFO(GetLogger()) << "Emit() called, returning FailureFinished" << LOG_END;
             return Result::FailureFinished;
@@ -24,6 +25,7 @@ struct MyEventSource : public JEventSource {
         return Result::Success;
     }
     void Close() override {
+        REQUIRE(GetApplication() != nullptr);
         LOG_INFO(GetLogger()) << "Close() called" << LOG_END;
         close_count++;
     }

--- a/src/programs/unit_tests/Components/JEventTests.cc
+++ b/src/programs/unit_tests/Components/JEventTests.cc
@@ -13,7 +13,6 @@ TEST_CASE("JEventInsertTests") {
 
 
     auto event = std::make_shared<JEvent>();
-    event->SetFactorySet(new JFactorySet);
 
     SECTION("Single-item JEvent::Insert() can be retrieved via JEvent::Get()") {
         auto input = new FakeJObject(22);
@@ -85,7 +84,6 @@ TEST_CASE("JEventInsertTests") {
         bool deleted = false;
         obj->deleted = &deleted;
         JEvent* event_ptr = new JEvent();
-        event_ptr->SetFactorySet(new JFactorySet);
         event_ptr->Insert(obj, "tag");
         REQUIRE(deleted == false);
         delete event_ptr;

--- a/src/programs/unit_tests/Components/JFactoryDefTagsTests.cc
+++ b/src/programs/unit_tests/Components/JFactoryDefTagsTests.cc
@@ -93,10 +93,7 @@ TEST_CASE("MediumDefTags") {
     app.Add(new JFactoryGeneratorT<Fac1>);
     app.Add(new JFactoryGeneratorT<Fac2>);
     app.SetParameterValue("DEFTAG:deftagstest::Obj", "tagB");
-    app.Initialize();
-    auto event = std::make_shared<JEvent>();
-    auto jcm = app.GetService<JComponentManager>();
-    jcm->configure_event(*event);
+    auto event = std::make_shared<JEvent>(&app);
     auto objs = event->Get<Obj>();
     REQUIRE(objs[0]->E == 33.3);
 }

--- a/src/programs/unit_tests/Components/JFactoryGeneratorTests.cc
+++ b/src/programs/unit_tests/Components/JFactoryGeneratorTests.cc
@@ -34,9 +34,7 @@ class MyFacGen : public JFactoryGenerator {
 TEST_CASE("JFactoryGeneratorTests_UserDefined") {
     JApplication app;
     app.Add(new MyFacGen());
-    app.Initialize();
-    auto event = std::make_shared<JEvent>();
-    app.GetService<JComponentManager>()->configure_event(*event);
+    auto event = std::make_shared<JEvent>(&app);
 
     auto data = event->Get<MyData>();
     REQUIRE(data.at(0)->x == 22);

--- a/src/programs/unit_tests/Components/JFactoryTests.cc
+++ b/src/programs/unit_tests/Components/JFactoryTests.cc
@@ -3,6 +3,7 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
 
+#include "JANA/JFactory.h"
 #include "catch.hpp"
 #include "JFactoryTests.h"
 
@@ -40,22 +41,22 @@ TEST_CASE("JFactoryTests") {
 
     }
 
-/*
     SECTION("If no factory is present and nothing inserted, GetObjects called") {
 
         // The event hasn't been given any DummyFactory, nor has anything been inserted.
         // Instead, the JEvent knows to go down to the JEventSource.
         auto event = std::make_shared<JEvent>();
-        DummySource sut;
-        event->SetJEventSource(&sut);
-        event->SetFactorySet(new JFactorySet());
+        JFactoryTestDummySource sut;
 
-        auto data = event->Get<DummyObject>("");
+        // Empty factory needed for GetObjects() to work
+        event->GetFactorySet()->Add(new JFactoryT<JFactoryTestDummyObject>());
+        event->SetJEventSource(&sut);
+
+        auto data = event->Get<JFactoryTestDummyObject>("");
         REQUIRE(data[0]->data == 8);
         REQUIRE(data[1]->data == 88);
     }
 
-*/
     SECTION("ChangeRun called only when run number changes") {
         auto event = std::make_shared<JEvent>();
         JFactoryTestDummyFactory sut;
@@ -263,9 +264,7 @@ TEST_CASE("JFactoryTests_ExceptingInit") {
     JApplication app;
     app.SetParameterValue("jana:loglevel", "error");
     app.Add(new JFactoryGeneratorT<ExceptingInitFactory>());
-    app.Initialize();
-    auto event = std::make_shared<JEvent>();
-    app.GetService<JComponentManager>()->configure_event(*event);
+    auto event = std::make_shared<JEvent>(&app);
 
     bool found_throw = false;
     try {

--- a/src/programs/unit_tests/Components/JFactoryTests.h
+++ b/src/programs/unit_tests/Components/JFactoryTests.h
@@ -71,6 +71,7 @@ struct JFactoryTestDummySource: public JEventSource {
 
     JFactoryTestDummySource() {
         SetCallbackStyle(CallbackStyle::ExpertMode);
+        EnableGetObjects();
     }
 
     Result Emit(JEvent&) override {

--- a/src/programs/unit_tests/Components/JMultiFactoryTests.cc
+++ b/src/programs/unit_tests/Components/JMultiFactoryTests.cc
@@ -82,10 +82,7 @@ TEST_CASE("MultiFactoryTests") {
 
     SECTION("Multifactories work with JFactoryGeneratorT") {
         app.Add(new JFactoryGeneratorT<MyMultifactory>());
-        app.Initialize();
-        auto jcm = app.GetService<JComponentManager>();
         auto event = std::make_shared<JEvent>(&app);
-        jcm->configure_event(*event);
         auto as = event->Get<A>("first");
         REQUIRE(as.size() == 2);
         REQUIRE(as[1]->x == 5.5);
@@ -93,10 +90,7 @@ TEST_CASE("MultiFactoryTests") {
 
     SECTION("Test that multifactory Process() is only called once") {
         app.Add(new JFactoryGeneratorT<MyMultifactory>());
-        app.Initialize();
-        auto jcm = app.GetService<JComponentManager>();
         auto event = std::make_shared<JEvent>(&app);
-        jcm->configure_event(*event);
 
         auto helper_fac = dynamic_cast<JMultifactoryHelper<A>*>(event->GetFactory<A>("first"));
         REQUIRE(helper_fac != nullptr);

--- a/src/programs/unit_tests/Components/JMultiFactoryTests.cc
+++ b/src/programs/unit_tests/Components/JMultiFactoryTests.cc
@@ -37,6 +37,7 @@ public:
     }
 
     void Process(const std::shared_ptr<const JEvent>&) override {
+        REQUIRE(GetApplication() != nullptr);
         m_process_call_count += 1;
         std::vector<A*> as;
         std::vector<B*> bs;

--- a/src/programs/unit_tests/Components/PodioTests.cc
+++ b/src/programs/unit_tests/Components/PodioTests.cc
@@ -4,6 +4,7 @@
 #include <type_traits>
 #include <PodioDatamodel/ExampleClusterCollection.h>
 #include <JANA/JEvent.h>
+#include <JANA/JFactoryGenerator.h>
 
 namespace podiotests {
 
@@ -150,10 +151,9 @@ struct TestFac : public JFactoryPodioT<ExampleCluster> {
 TEST_CASE("JFactoryPodioT::Init gets called") {
 
     JApplication app;
+    app.Add(new JFactoryGeneratorT<jana2_tests_podiotests_init::TestFac>());
     auto event = std::make_shared<JEvent>(&app);
-    auto fs = new JFactorySet;
-    fs->Add(new jana2_tests_podiotests_init::TestFac);
-    event->SetFactorySet(fs);
+
     event->GetFactorySet()->Release();  // Simulate a trip to the JEventPool
 
     auto r = event->GetCollectionBase("clusters");

--- a/src/programs/unit_tests/Components/PodioTests.cc
+++ b/src/programs/unit_tests/Components/PodioTests.cc
@@ -153,8 +153,7 @@ TEST_CASE("JFactoryPodioT::Init gets called") {
     JApplication app;
     app.Add(new JFactoryGeneratorT<jana2_tests_podiotests_init::TestFac>());
     auto event = std::make_shared<JEvent>(&app);
-
-    event->GetFactorySet()->Release();  // Simulate a trip to the JEventPool
+    event->Clear();  // Simulate a trip to the JEventPool
 
     auto r = event->GetCollectionBase("clusters");
     REQUIRE(r != nullptr);

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -432,6 +432,49 @@ TEST_CASE("JParameterManager_Strictness") {
 
 
 
+TEST_CASE("JParameterManager_ConflictingDefaults") {
+
+    int x1 = 3;
+    int x2 = 4;
+    int x3 = 3;
+    int x4 = 4;
+
+    JParameterManager sut;
+    sut.SetLogger(JLogger());
+
+    // Simulate a FactorySet containing two JFactories, each of which declares the same parameter with different default values
+    auto p1 = sut.SetDefaultParameter("my_param_name", x1, "Tests how conflicting defaults are handled");
+    REQUIRE(p1->HasDefault() == true);
+    REQUIRE(p1->IsDefault() == true);
+    REQUIRE(p1->GetDefault() == "3"); // Should be the _latest_ default found
+    REQUIRE(p1->GetValue() == "3"); // Should be the _latest_ default value
+    REQUIRE(x1 == 3);
+    auto p2 = sut.SetDefaultParameter("my_param_name", x2, "Tests how conflicting defaults are handled");
+    REQUIRE(p2->HasDefault() == true);
+    REQUIRE(p2->IsDefault() == true);
+    REQUIRE(p2->GetDefault() == "4"); // Should be the _latest_ default found
+    REQUIRE(p2->GetValue() == "4"); // Should be the _latest_ default value
+    REQUIRE(x2 == 4);
+    
+    // Simulate a _second_ FactorySet containing fresh instances of the same two JFactories, 
+    auto p3 = sut.SetDefaultParameter("my_param_name", x3, "Tests how conflicting defaults are handled");
+    REQUIRE(p3->HasDefault() == true);
+    REQUIRE(p3->IsDefault() == true);
+    REQUIRE(p3->GetDefault() == "3"); // Should be the _latest_ default found
+    REQUIRE(p3->GetValue() == "3"); // Should be the _latest_ default value
+    REQUIRE(x3 == 3);
+    auto p4 = sut.SetDefaultParameter("my_param_name", x4, "Tests how conflicting defaults are handled");
+    REQUIRE(p4->HasDefault() == true);
+    REQUIRE(p4->IsDefault() == true);
+    REQUIRE(p4->GetDefault() == "4"); // Should be the _latest_ default value found
+    REQUIRE(p4->GetValue() == "4"); // Should be the _latest_ default value
+    REQUIRE(x4 == 4);
+
+    sut.PrintParameters(2,1);
+}
+
+
+
 
 
 

--- a/src/programs/unit_tests/Utils/JCallGraphRecorderTests.cc
+++ b/src/programs/unit_tests/Utils/JCallGraphRecorderTests.cc
@@ -5,6 +5,7 @@
 #include <catch.hpp>
 #include <JANA/Utils/JCallGraphRecorder.h>
 #include "JANA/JEvent.h"
+#include "JANA/JFactoryGenerator.h"
 
 TEST_CASE("Test topological sort algorithm in isolation") {
 
@@ -68,13 +69,11 @@ struct FacD: public JFactoryT<ObjD> {
 
 TEST_CASE("Test topological sort algorithm using actual Factories") {
     JApplication app;
-    JFactorySet* factories = new JFactorySet;
-    factories->Add(new FacA());
-    factories->Add(new FacB());
-    factories->Add(new FacC());
-    factories->Add(new FacD());
+    app.Add(new JFactoryGeneratorT<FacA>());
+    app.Add(new JFactoryGeneratorT<FacB>());
+    app.Add(new JFactoryGeneratorT<FacC>());
+    app.Add(new JFactoryGeneratorT<FacD>());
     auto event = std::make_shared<JEvent>(&app);
-    event->SetFactorySet(factories);
     event->GetJCallGraphRecorder()->SetEnabled();
     event->Get<ObjD>();
     auto result = event->GetJCallGraphRecorder()->TopologicalSort();


### PR DESCRIPTION
This PR includes several bugfixes:
- JFactory::Finish() wasn't getting called
- The final JFactory::EndRun() wasn't getting called
- JFactory::BeginRun() was getting called spuriously when no run number was set
- JParameterManager::SetDefaultParameter() with conflicting defaults had an edge case where they use the wrong default value

This PR adds:
- the parameter `jana:show_ticker`
- a warning about conflicting defaults to the parameter summary

This PR includes several refactorings:
- Event clearing and finishing logic is now encapsulated on the JEvent itself instead of the JEventPool
- JEvents are automatically configured when the constructor is passed a JApplication
