### PR TITLE
Add JService test cases

### DIFF
--- a/cmake/AddJanaPlugin.cmake
+++ b/cmake/AddJanaPlugin.cmake
@@ -93,16 +93,16 @@ macro(add_jana_plugin plugin_name)
 
     # Handle tests
     if (PLUGIN_TESTS)
-        add_executable(${plugin_name}_tests ${PLUGIN_TESTS})
-        target_link_libraries(${plugin_name}_tests PRIVATE ${plugin_name} "${JANA_NAMESPACE}VendoredCatch2")
-        set_target_properties(${plugin_name}_tests PROPERTIES
+        add_executable(${plugin_name}-tests ${PLUGIN_TESTS})
+        target_link_libraries(${plugin_name}-tests PRIVATE ${plugin_name} "${JANA_NAMESPACE}VendoredCatch2")
+        set_target_properties(${plugin_name}-tests PROPERTIES
             SKIP_BUILD_RPATH FALSE
             BUILD_WITH_INSTALL_RPATH TRUE
             INSTALL_RPATH_USE_LINK_PATH TRUE
             INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/lib/${INSTALL_NAMESPACE}/plugins"
         )
-        #install(TARGETS ${plugin_name}_tests RUNTIME DESTINATION bin)
-        add_test(NAME ${plugin_name}_tests COMMAND ${plugin_name}_tests)
+        #install(TARGETS ${plugin_name}-tests RUNTIME DESTINATION bin)
+        add_test(NAME ${plugin_name}-tests COMMAND ${plugin_name}-tests)
     endif()
 endmacro()
 

--- a/src/libraries/JANA/Components/JOmniFactory.h
+++ b/src/libraries/JANA/Components/JOmniFactory.h
@@ -251,7 +251,7 @@ public:
                variadic_output_count += 1;
             }
         }
-        size_t variadic_output_collection_count = FindVariadicCollectionCount(m_outputs.size(), variadic_output_count, output_collection_names.size(), true);
+        size_t variadic_output_collection_count = FindVariadicCollectionCount(m_outputs.size(), variadic_output_count, output_collection_names.size(), false);
 
         // Set output collection names and create corresponding helper factories
         i = 0;

--- a/src/plugins/janacontrol/CMakeLists.txt
+++ b/src/plugins/janacontrol/CMakeLists.txt
@@ -24,8 +24,8 @@ if (${USE_ZEROMQ})
 
     target_include_directories(janacontrol PUBLIC ${ZeroMQ_INCLUDE_DIRS})
     target_link_libraries(janacontrol PUBLIC ${ZeroMQ_LIBRARIES})
-    target_include_directories(janacontrol_tests PUBLIC ${ZeroMQ_INCLUDE_DIRS})
-    target_link_libraries(janacontrol_tests PUBLIC ${ZeroMQ_LIBRARIES})
+    target_include_directories(janacontrol-tests PUBLIC ${ZeroMQ_INCLUDE_DIRS})
+    target_link_libraries(janacontrol-tests PUBLIC ${ZeroMQ_LIBRARIES})
 
 else()
     message(STATUS "Skipping plugins/janacontrol because USE_ZEROMQ=Off")

--- a/src/plugins/janacontrol/janacontrol_tests.cc
+++ b/src/plugins/janacontrol/janacontrol_tests.cc
@@ -24,7 +24,7 @@ TEST_CASE("JANAControlIntegrationTests") {
     app->Add(new JControlEventProcessor);
 
     // Set test parameters
-    app->SetParameterValue("nevents", 10);
+    app->SetParameterValue("jana:nevents", 10);
 
     // Run everything, blocking until finished
     app->Run();

--- a/src/programs/unit_tests/CMakeLists.txt
+++ b/src/programs/unit_tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SOURCES
     Components/JFactoryTests.cc
     Components/JFactoryGeneratorTests.cc
     Components/JMultiFactoryTests.cc
+    Components/JServiceTests.cc
     Components/UnfoldTests.cc
     Components/UserExceptionTests.cc
 

--- a/src/programs/unit_tests/Components/JServiceTests.cc
+++ b/src/programs/unit_tests/Components/JServiceTests.cc
@@ -1,0 +1,82 @@
+
+#include <catch.hpp>
+#include <JANA/JApplication.h>
+#include <JANA/JService.h>
+#include <JANA/Components/JOmniFactory.h>
+#include <JANA/Components/JOmniFactoryGeneratorT.h>
+
+namespace jana::jservicetests {
+
+class DummyService: public JService {
+    bool init_started = false;
+    bool init_finished = false;
+public:
+    void Init() override {
+        LOG_INFO(GetLogger()) << "Starting DummyService::Init()" << LOG_END;
+        init_started = true;
+        throw std::runtime_error("Something goes wrong");
+        init_finished = true;
+        LOG_INFO(GetLogger()) << "Finishing DummyService::Init()" << LOG_END;
+    }
+};
+
+TEST_CASE("JServiceTests_ExceptionInInit") {
+    JApplication app;
+    app.ProvideService(std::make_shared<DummyService>());
+    try {
+        app.Initialize();
+        REQUIRE(1 == 0); // Shouldn't be reachable
+
+        auto sut = app.GetService<DummyService>();
+        REQUIRE(1 == 0); // Definitely shouldn't be reachable
+    }
+    catch (JException& e) {
+        REQUIRE(e.GetMessage() == "Something goes wrong");
+        REQUIRE(e.type_name == "jana::jservicetests::DummyService");
+        REQUIRE(e.function_name == "JService::Init");
+    }
+}
+
+struct DummyData {int x;};
+
+struct DummyOmniFactory: public jana::components::JOmniFactory<DummyOmniFactory> {
+
+    Service<DummyService> m_svc {this};
+    Output<DummyData> m_output {this};
+
+    void Configure() {
+    }
+
+    void ChangeRun(int32_t /*run_nr*/) {
+    }
+
+    void Execute(int32_t /*run_nr*/, uint64_t /*evt_nr*/) {
+        m_output().push_back(new DummyData{22});
+    }
+};
+
+TEST_CASE("JServiceTests_ExceptionInInit_Issue381") {
+    JApplication app;
+    app.ProvideService(std::make_shared<DummyService>());
+
+    auto gen = new components::JOmniFactoryGeneratorT<DummyOmniFactory>();
+    gen->AddWiring("dummy", {}, {"data"});
+    app.Add(gen);
+
+    try {
+        app.Initialize();
+        REQUIRE(1 == 0); // Shouldn't be reachable
+        auto event = std::make_shared<JEvent>(&app);
+        auto data = event->Get<DummyData>("data");
+        REQUIRE(1 == 0); // Definitely shouldn't be reachable
+        REQUIRE(data.at(0)->x == 22);
+    }
+    catch (JException& e) {
+        REQUIRE(e.GetMessage() == "Something goes wrong");
+        REQUIRE(e.type_name == "jana::jservicetests::DummyService");
+        REQUIRE(e.function_name == "JService::Init");
+    }
+}
+
+} // namespace jana::jservicetests
+


### PR DESCRIPTION
Disproves issue #381

Includes the following small fixes:
- JOmniFactory error message incorrectly printed 'input' instead of 'output'
- Inconsistent naming convention for tests
- janacontrol tests now terminate
