### PR TITLE
Make JLogMessage consistent with JStreamLog

### DIFF
--- a/src/libraries/JANA/JLogger.h
+++ b/src/libraries/JANA/JLogger.h
@@ -14,7 +14,6 @@
 #include <time.h>
 
 
-
 struct JLogger {
     enum class Level { TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF };
     Level level;
@@ -40,8 +39,10 @@ struct JLogger {
     void ShowThreadstamp(bool show) {show_threadstamp = show; }
 };
 
+
 static JLogger default_cout_logger = JLogger(JLogger::Level::TRACE, &std::cout, "JANA");
 static JLogger default_cerr_logger = JLogger(JLogger::Level::TRACE, &std::cerr, "JERR");
+
 
 inline std::ostream& operator<<(std::ostream& s, JLogger::Level l) {
     switch (l) {
@@ -55,25 +56,23 @@ inline std::ostream& operator<<(std::ostream& s, JLogger::Level l) {
     }
 }
 
-///
-struct JLogMessage {
 
-    /// Message terminator
-    struct End {};
+class JLogMessage : public std::stringstream {
+public:
+    struct Flush {};
 
-    const JLogger& logger;
-    JLogger::Level level;
-    std::ostringstream builder;
+private:
+    std::string m_prefix;
 
+public:
+    JLogMessage(const std::string& prefix="") : m_prefix(prefix){
+    }
 
-    JLogMessage(const JLogger& logger = default_cout_logger,
-                JLogger::Level level = JLogger::Level::INFO)
-                : logger(logger), level(level) {
-
+    JLogMessage(const JLogger& logger, JLogger::Level level) {
+        std::ostringstream builder;
         if (logger.show_timestamp) {
             auto now = std::chrono::system_clock::now();
             std::time_t current_time = std::chrono::system_clock::to_time_t(now);
-            
             tm tm_buf;
             localtime_r(&current_time, &tm_buf);
 
@@ -86,8 +85,8 @@ struct JLogMessage {
             switch (level) {
                 case JLogger::Level::TRACE: builder << "[trace] "; break;
                 case JLogger::Level::DEBUG: builder << "[debug] "; break;
-                case JLogger::Level::INFO:  builder << "[info]  "; break;
-                case JLogger::Level::WARN:  builder << "[warn]  "; break;
+                case JLogger::Level::INFO:  builder << " [info] "; break;
+                case JLogger::Level::WARN:  builder << " [warn] "; break;
                 case JLogger::Level::ERROR: builder << "[error] "; break;
                 case JLogger::Level::FATAL: builder << "[fatal] "; break;
                 default: builder << "[?????] ";
@@ -96,47 +95,53 @@ struct JLogMessage {
         if (logger.show_threadstamp) {
             builder << std::this_thread::get_id() << " ";
         }
-        if (logger.show_group) {
-            builder << "[" << logger.group << "] ";
+        if (logger.show_group && !logger.group.empty()) {
+            builder << logger.group << " > ";
         }
+        m_prefix = builder.str();
     }
 
-    // Helper function for truncating long strings to keep our log readable
-    // This should probably live somewhere else
-    std::string ltrunc(std::string original, size_t desired_length) {
-        auto n = original.length();
-        if (n <= desired_length) return original;
-        return "\u2026" + original.substr(n - desired_length, desired_length - 1);
+    void do_flush() {
+        std::string line;
+        std::ostringstream oss;
+        if (this->str().empty()) {
+            // This way, `LOG_INFO(GetLogger()) << LOG_END;` produces a blank line
+            oss << m_prefix << std::endl;
+        }
+        else {
+            while (std::getline(*this, line)) {
+                oss << m_prefix << line << std::endl;
+            }
+        }
+        std::cout << oss.str();
+        std::cout.flush();
+        this->str("");
+        this->clear();
+    }
+
+    virtual ~JLogMessage() {
+        if (!this->str().empty()) {
+            do_flush();
+        }
     }
 };
 
 
 /// Stream operators
 
-template <typename T>
-inline JLogMessage operator<<(JLogger& l, const T& t) {
-    JLogMessage m(l);
-    m.builder << t;
-    return m;
+inline JLogMessage& operator<<(JLogMessage& msg, const JLogMessage::Flush&) {
+    // This lets us force a flush
+    msg.do_flush();
+    return msg;
 }
 
-template<typename T>
-inline JLogMessage& operator<<(JLogMessage& m, const T& t) {
-    m.builder << t;
-    return m;
-}
-
-template<typename T>
-inline JLogMessage&& operator<<(JLogMessage&& m, const T& t) {
-    m.builder << t;
-    return std::move(m);
-}
-
-inline void operator<<(JLogMessage&& m, JLogMessage::End const&) {
-    std::ostream& dest = *m.logger.destination;
-    m.builder << std::endl;
-    dest << m.builder.str();
-    dest.flush();
+inline std::ostream& operator<<(std::ostream& msg, const JLogMessage::Flush&) {
+    // This lets us force a flush
+    auto* logmsg = dynamic_cast<JLogMessage*>(&msg);
+    if (logmsg != nullptr) {
+        logmsg->do_flush();
+    }
+    return msg;
 }
 
 /// Macros
@@ -145,7 +150,7 @@ inline void operator<<(JLogMessage&& m, JLogMessage::End const&) {
 
 #define LOG_IF(predicate) if (predicate) JLogMessage()
 
-#define LOG_END JLogMessage::End();
+#define LOG_END JLogMessage::Flush()
 
 #define LOG_AT_LEVEL(logger, msglevel) if ((logger).level <= msglevel) JLogMessage((logger), msglevel)
 

--- a/src/libraries/JANA/JVersion.cc
+++ b/src/libraries/JANA/JVersion.cc
@@ -57,6 +57,7 @@ void JVersion::PrintVersionDescription(std::ostream& os) {
         if (JVersion::HasXerces()) os << "Xerces ";
         os << std::endl;
     }
+    os << std::endl;
 }
 
 

--- a/src/libraries/JANA/JVersion.cc
+++ b/src/libraries/JANA/JVersion.cc
@@ -57,7 +57,6 @@ void JVersion::PrintVersionDescription(std::ostream& os) {
         if (JVersion::HasXerces()) os << "Xerces ";
         os << std::endl;
     }
-    os << std::endl;
 }
 
 

--- a/src/plugins/janacontrol/JControlZMQ.cc
+++ b/src/plugins/janacontrol/JControlZMQ.cc
@@ -86,7 +86,7 @@ JControlZMQ::JControlZMQ(JApplication *app, int port):_japp(app), _port(port)
 {
     // This is called from jcontrol plugin's InitPlugin() routine
 
-    LOG << "Launching JControlZMQ thread ..." << LOG_END
+    LOG << "Launching JControlZMQ thread ..." << LOG_END;
 
     // Create new zmq context, get the current host name, and launch server thread
     _zmq_context = zmq_ctx_new();
@@ -110,10 +110,10 @@ JControlZMQ::~JControlZMQ()
     // Tell server thread to quit and wait for it to finish
     _done =true;
     if(_thr != nullptr) {
-        LOG << "Joining JControlZMQ thread ..." << LOG_END
+        LOG << "Joining JControlZMQ thread ..." << LOG_END;
         _thr->join();
         delete _thr;
-        LOG << "JControlZMQ thread joined." << LOG_END
+        LOG << "JControlZMQ thread joined." << LOG_END;
     }
 
     // Delete the zmq context
@@ -132,7 +132,7 @@ void JControlZMQ::ServerLoop()
     /// indefinitely until the internal _done member is set to true.
     /// Currently, that is done only by calling the destructor.
 
-    LOG << "JControlZMQ server starting ..." << LOG_END
+    LOG << "JControlZMQ server starting ..." << LOG_END;
 
     // This just makes it easier to identify this thread while debugging.
     // Linux and Mac OS X use different calling signatures for pthread_setname_np
@@ -148,7 +148,7 @@ void JControlZMQ::ServerLoop()
 	void *responder = zmq_socket( _zmq_context, ZMQ_REP );
 	auto ret = zmq_bind( responder, bind_str);
 	if( ret != 0 ){
-		LOG << "JControlZMQ: Unable to bind zeroMQ control socket " << _port << "!" << LOG_END
+		LOG << "JControlZMQ: Unable to bind zeroMQ control socket " << _port << "!" << LOG_END;
 		perror("zmq_bind");
 		return;
 	}
@@ -164,7 +164,7 @@ void JControlZMQ::ServerLoop()
 				std::this_thread::sleep_for(std::chrono::milliseconds(250));
 				continue;
 			}else{
-				LOG << "JControlZMQ: ERROR listening on control socket: errno=" << errno << LOG_END
+				LOG << "JControlZMQ: ERROR listening on control socket: errno=" << errno << LOG_END;
 				_done = true;
 				continue;
 			}

--- a/src/programs/unit_tests/CMakeLists.txt
+++ b/src/programs/unit_tests/CMakeLists.txt
@@ -39,7 +39,7 @@ set(TEST_SOURCES
     Utils/JTablePrinterTests.cc
     Utils/JStatusBitsTests.cc
     Utils/JCallGraphRecorderTests.cc
-
+    Utils/JLoggerTests.cc
     )
 
 if (${USE_PODIO})

--- a/src/programs/unit_tests/Utils/JLoggerTests.cc
+++ b/src/programs/unit_tests/Utils/JLoggerTests.cc
@@ -3,77 +3,11 @@
 #include <iostream>
 #include <JANA/JLogger.h>
 
-class JLogMsg : public std::stringstream {
-public:
-    struct Flush {};
-    std::string m_prefix;
-    JLogger* m_logger = nullptr;
-
-public:
-    JLogMsg(const std::string& prefix="") : m_prefix(prefix){
-    }
-
-    JLogMsg(const JLogger& logger, JLogger::Level level) {
-        std::ostringstream builder;
-        if (logger.show_timestamp) {
-            auto now = std::chrono::system_clock::now();
-            std::time_t current_time = std::chrono::system_clock::to_time_t(now);
-            tm tm_buf;
-            localtime_r(&current_time, &tm_buf);
-
-            // Extract milliseconds by calculating the duration since the last whole second
-            auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
-            builder << std::put_time(&tm_buf, "%H:%M:%S.");
-            builder << std::setfill('0') << std::setw(3) << milliseconds.count() << std::setfill(' ') << " ";
-        }
-        if (logger.show_level) {
-            switch (level) {
-                case JLogger::Level::TRACE: builder << "[trace] "; break;
-                case JLogger::Level::DEBUG: builder << "[debug] "; break;
-                case JLogger::Level::INFO:  builder << " [info] "; break;
-                case JLogger::Level::WARN:  builder << " [warn] "; break;
-                case JLogger::Level::ERROR: builder << "[error] "; break;
-                case JLogger::Level::FATAL: builder << "[fatal] "; break;
-                default: builder << "[?????] ";
-            }
-        }
-        if (logger.show_threadstamp) {
-            builder << std::this_thread::get_id() << " ";
-        }
-        if (logger.show_group && !logger.group.empty()) {
-            builder << logger.group << " > ";
-        }
-        m_prefix = builder.str();
-    }
-
-    void do_flush() {
-        std::string line;
-        std::ostringstream oss;
-        while (std::getline(*this, line)) {
-            oss << m_prefix << line << std::endl;
-        }
-        std::cout << oss.str();
-        std::cout.flush();
-        this->str("");
-        this->clear();
-    }
-
-    virtual ~JLogMsg() {
-        do_flush();
-    }
-};
-
-inline JLogMsg& operator<<(JLogMsg& msg, const JLogMsg::Flush&) {
-    // This lets us force a flush e.g. for use with LOG_END.
-    msg.do_flush();
-    return msg;
-}
-
 
 TEST_CASE("JLogMessage_DestructorOrdering") {
 
     {
-        JLogMsg m("JANA: ");
+        JLogMessage m("JANA: ");
         // This will destruct immediately, but only because it's in its own scope
         m << "1. This is a test";
         REQUIRE(m.str() == "1. This is a test");
@@ -87,7 +21,7 @@ TEST_CASE("JLogMessage_DestructorOrdering") {
     JLogger logger {JLogger::Level::WARN, &std::cout, "jana"};
     logger.show_group = true;
     if (logger.level >= JLogger::Level::WARN) {
-        JLogMsg msg(logger, JLogger::Level::INFO);
+        JLogMessage msg(logger, JLogger::Level::INFO);
         msg << "2. This will print at level INFO and include" << std::endl;
         msg << "   multiple lines and the group name 'jana'" << std::endl;
         msg << "   It will destruct immediately because it is inside an if-block";
@@ -95,25 +29,50 @@ TEST_CASE("JLogMessage_DestructorOrdering") {
 
     std::cout << std::endl;
 
-    if (logger.level >= JLogger::Level::WARN) JLogMsg("jaanaa >> ") << "3. This destructs immediately even without enclosing braces";
+    if (logger.level >= JLogger::Level::WARN) JLogMessage("jaanaa >> ") << "3. This destructs immediately even without enclosing braces";
 
     std::cout << std::endl;
 
-    JLogMsg("Silly: ") << "4. This message will destruct immediately because it is an rvalue";
+    JLogMessage("Silly: ") << "4. This message will destruct immediately because it is an rvalue";
 
     std::cout << std::endl;
 
-    JLogMsg m("JANA: ");
+    JLogMessage m("JANA: ");
     // This will destruct immediately because we include a LOG_END-style flush
     m << "5. This is a JLogMsg that is NOT in its own scope, but we will manually flush it at the right time.";
-    m << JLogMsg::Flush();
+    m << JLogMessage::Flush();
     m << "   This is a line that got emitted as part of the same JLogMsg, but after the flush." << std::endl;
     m << "   It needs one final flush, else it will destruct too late and these lines will be printed out of order.";
-    m << JLogMsg::Flush();
+    m << JLogMessage::Flush();
 
     std::cout << std::endl;
 
     std::cout << "6. This should be the last thing printed, assuming our destructors behave" << std::endl;
 
+}
+
+TEST_CASE("JLogMessage_Newlines") {
+
+    JLogMessage("jaanaa> ") << "1. This message has a trailing newline in the code but shouldn't in the output" << std::endl;
+    JLogMessage("jaanaa> ") << "2. This message has no trailing newline in either the code or the output";
+
+    std::cout << "--------" << std::endl;
+    std::cout << "The following line should just be log metadata with no log message" << std::endl;
+    JLogMessage("jaanaa> ") << std::endl;
+    std::cout << "--------" << std::endl;
+
+    JLogMessage("jaanaa> ") << "There should be a line of just log metadata below this one" << std::endl << std::endl;
+    JLogMessage("jaanaa> ") << "This should be the last line prefixed with 'jaanaa'.";
+
+    JLogger logger {JLogger::Level::DEBUG, &std::cout, "jana"};
+
+    LOG_INFO(logger) << "This message has a trailing newline in the code but shouldn't in the output" << std::endl;
+    LOG_INFO(logger) << "This message has a trailing newline in the code but shouldn't in the output" << LOG_END;
+
+    LOG_INFO(logger) << "This message has a trailing newline containing log metadata" << std::endl << std::endl;
+    LOG_INFO(logger) << "This message has a trailing newline containing log metadata" << LOG_END << LOG_END;
+
+    LOG_INFO(logger) << "This message does _not_ have a trailing newline containing log metadata " << std::endl << JLogMessage::Flush();
+    LOG_INFO(logger) << "This message has a trailing newline containing log metadata " << std::endl << std::endl << JLogMessage::Flush();
 }
 

--- a/src/programs/unit_tests/Utils/JLoggerTests.cc
+++ b/src/programs/unit_tests/Utils/JLoggerTests.cc
@@ -1,0 +1,119 @@
+
+#include <catch.hpp>
+#include <iostream>
+#include <JANA/JLogger.h>
+
+class JLogMsg : public std::stringstream {
+public:
+    struct Flush {};
+    std::string m_prefix;
+    JLogger* m_logger = nullptr;
+
+public:
+    JLogMsg(const std::string& prefix="") : m_prefix(prefix){
+    }
+
+    JLogMsg(const JLogger& logger, JLogger::Level level) {
+        std::ostringstream builder;
+        if (logger.show_timestamp) {
+            auto now = std::chrono::system_clock::now();
+            std::time_t current_time = std::chrono::system_clock::to_time_t(now);
+            tm tm_buf;
+            localtime_r(&current_time, &tm_buf);
+
+            // Extract milliseconds by calculating the duration since the last whole second
+            auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+            builder << std::put_time(&tm_buf, "%H:%M:%S.");
+            builder << std::setfill('0') << std::setw(3) << milliseconds.count() << std::setfill(' ') << " ";
+        }
+        if (logger.show_level) {
+            switch (level) {
+                case JLogger::Level::TRACE: builder << "[trace] "; break;
+                case JLogger::Level::DEBUG: builder << "[debug] "; break;
+                case JLogger::Level::INFO:  builder << " [info] "; break;
+                case JLogger::Level::WARN:  builder << " [warn] "; break;
+                case JLogger::Level::ERROR: builder << "[error] "; break;
+                case JLogger::Level::FATAL: builder << "[fatal] "; break;
+                default: builder << "[?????] ";
+            }
+        }
+        if (logger.show_threadstamp) {
+            builder << std::this_thread::get_id() << " ";
+        }
+        if (logger.show_group && !logger.group.empty()) {
+            builder << logger.group << " > ";
+        }
+        m_prefix = builder.str();
+    }
+
+    void do_flush() {
+        std::string line;
+        std::ostringstream oss;
+        while (std::getline(*this, line)) {
+            oss << m_prefix << line << std::endl;
+        }
+        std::cout << oss.str();
+        std::cout.flush();
+        this->str("");
+        this->clear();
+    }
+
+    virtual ~JLogMsg() {
+        do_flush();
+    }
+};
+
+inline JLogMsg& operator<<(JLogMsg& msg, const JLogMsg::Flush&) {
+    // This lets us force a flush e.g. for use with LOG_END.
+    msg.do_flush();
+    return msg;
+}
+
+
+TEST_CASE("JLogMessage_DestructorOrdering") {
+
+    {
+        JLogMsg m("JANA: ");
+        // This will destruct immediately, but only because it's in its own scope
+        m << "1. This is a test";
+        REQUIRE(m.str() == "1. This is a test");
+
+        m << std::endl << "   which continues on the second line";
+        REQUIRE(m.str() == "1. This is a test\n   which continues on the second line");
+    }
+
+    std::cout << std::endl;
+
+    JLogger logger {JLogger::Level::WARN, &std::cout, "jana"};
+    logger.show_group = true;
+    if (logger.level >= JLogger::Level::WARN) {
+        JLogMsg msg(logger, JLogger::Level::INFO);
+        msg << "2. This will print at level INFO and include" << std::endl;
+        msg << "   multiple lines and the group name 'jana'" << std::endl;
+        msg << "   It will destruct immediately because it is inside an if-block";
+    }
+
+    std::cout << std::endl;
+
+    if (logger.level >= JLogger::Level::WARN) JLogMsg("jaanaa >> ") << "3. This destructs immediately even without enclosing braces";
+
+    std::cout << std::endl;
+
+    JLogMsg("Silly: ") << "4. This message will destruct immediately because it is an rvalue";
+
+    std::cout << std::endl;
+
+    JLogMsg m("JANA: ");
+    // This will destruct immediately because we include a LOG_END-style flush
+    m << "5. This is a JLogMsg that is NOT in its own scope, but we will manually flush it at the right time.";
+    m << JLogMsg::Flush();
+    m << "   This is a line that got emitted as part of the same JLogMsg, but after the flush." << std::endl;
+    m << "   It needs one final flush, else it will destruct too late and these lines will be printed out of order.";
+    m << JLogMsg::Flush();
+
+    std::cout << std::endl;
+
+    std::cout << "6. This should be the last thing printed, assuming our destructors behave" << std::endl;
+
+}
+

--- a/src/programs/unit_tests/Utils/JLoggerTests.cc
+++ b/src/programs/unit_tests/Utils/JLoggerTests.cc
@@ -37,16 +37,6 @@ TEST_CASE("JLogMessage_DestructorOrdering") {
 
     std::cout << std::endl;
 
-    JLogMessage m("JANA: ");
-    // This will destruct immediately because we include a LOG_END-style flush
-    m << "5. This is a JLogMsg that is NOT in its own scope, but we will manually flush it at the right time.";
-    m << JLogMessage::Flush();
-    m << "   This is a line that got emitted as part of the same JLogMsg, but after the flush." << std::endl;
-    m << "   It needs one final flush, else it will destruct too late and these lines will be printed out of order.";
-    m << JLogMessage::Flush();
-
-    std::cout << std::endl;
-
     std::cout << "6. This should be the last thing printed, assuming our destructors behave" << std::endl;
 
 }
@@ -71,8 +61,6 @@ TEST_CASE("JLogMessage_Newlines") {
 
     LOG_INFO(logger) << "This message has a trailing newline containing log metadata" << std::endl << std::endl;
     LOG_INFO(logger) << "This message has a trailing newline containing log metadata" << LOG_END << LOG_END;
-
-    LOG_INFO(logger) << "This message does _not_ have a trailing newline containing log metadata " << std::endl << JLogMessage::Flush();
-    LOG_INFO(logger) << "This message has a trailing newline containing log metadata " << std::endl << std::endl << JLogMessage::Flush();
+    LOG_INFO(logger) << "This message has a trailing newline containing log metadata " << std::endl << LOG_END;
 }
 


### PR DESCRIPTION
- Adds support for appending log metadata to each line of a multi-line log message
- A special log message terminator is no longer needed: flushing to the output stream is handled by the JLogMessage destructor
- JLogMessage now supports stream manipulators, most notably std::endl
- In principle, `jout`, `jerr`, and `_DBG_` can now use JLogMessage under the hood.
