### PR TITLE
Put logger mutex behind a preprocessor flag

### DIFF
--- a/src/libraries/JANA/JLogger.h
+++ b/src/libraries/JANA/JLogger.h
@@ -14,6 +14,10 @@
 #include <time.h>
 #include <mutex>
 
+#ifndef JANA2_USE_LOGGER_MUTEX
+#define JANA2_USE_LOGGER_MUTEX 0
+#endif
+
 
 struct JLogger {
     enum class Level { TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF };
@@ -107,9 +111,10 @@ public:
     }
 
     virtual ~JLogMessage() {
+#if JANA2_USE_LOGGER_MUTEX
         static std::mutex cout_mutex;
         std::lock_guard<std::mutex> lock(cout_mutex);
-
+#endif
         std::string line;
         std::ostringstream oss;
         while (std::getline(*this, line)) {


### PR DESCRIPTION
The logger mutex is not necessary on the platforms we support. Omitting it causes lots and lots of false positives when running tools like Helgrind. However, including it causes some extremely weird behavior when Helgrind runs, such as segfaults and hanging. I speculate that this behavior is due to the ODR violation that happens with the static logger mutex when JANA is linked incorrectly