### PR TITLE
fix: avoid warnings for regular operations

### DIFF
--- a/src/libraries/JANA/Engine/JExecutionEngine.cc
+++ b/src/libraries/JANA/Engine/JExecutionEngine.cc
@@ -262,7 +262,7 @@ void JExecutionEngine::RunSupervisor() {
             last_event_count = perf.event_count;
 
             // Print rates
-            LOG_WARN(m_logger) << "Status: " << perf.event_count << " events processed at "
+            LOG_INFO(m_logger) << "Status: " << perf.event_count << " events processed at "
                             << JTypeInfo::to_string_with_si_prefix(latest_throughput_hz) << "Hz ("
                             << JTypeInfo::to_string_with_si_prefix(perf.throughput_hz) << "Hz avg)" << LOG_END;
         }
@@ -662,7 +662,7 @@ void JExecutionEngine::PrintFinalReport() {
 
     LOG_INFO(GetLogger()) << LOG_END;
 
-    LOG_WARN(GetLogger()) << "Final report: " << event_count << " events processed at "
+    LOG_INFO(GetLogger()) << "Final report: " << event_count << " events processed at "
                           << JTypeInfo::to_string_with_si_prefix(throughput_hz) << "Hz" << LOG_END;
 
 }

--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -126,14 +126,14 @@ void JApplication::Initialize() {
         std::ostringstream oss;
         oss << "Initializing..." << std::endl << std::endl;
         JVersion::PrintVersionDescription(oss);
-        LOG_WARN(m_logger) << oss.str() << LOG_END;
+        LOG_INFO(m_logger) << oss.str() << LOG_END;
     }
     else {
         std::ostringstream oss;
         oss << "Initializing..." << std::endl;
         JVersion::PrintSplash(oss);
         JVersion::PrintVersionDescription(oss);
-        LOG_WARN(m_logger) << oss.str() << LOG_END;
+        LOG_INFO(m_logger) << oss.str() << LOG_END;
     }
 
     // Attach all plugins

--- a/src/libraries/JANA/Services/JParameterManager.cc
+++ b/src/libraries/JANA/Services/JParameterManager.cc
@@ -124,7 +124,7 @@ void JParameterManager::PrintParameters(int verbosity, int strictness) {
     }
 
     if (strictness_violation) {
-        LOG_WARN(m_logger) << "Printing parameter table with full verbosity due to strictness warning" << LOG_END;
+        LOG_INFO(m_logger) << "Printing parameter table with full verbosity due to strictness warning" << LOG_END;
         verbosity = 3; // Crank up verbosity before printing out table
     }
 
@@ -157,16 +157,16 @@ void JParameterManager::PrintParameters(int verbosity, int strictness) {
         return;
     }
 
-    LOG_WARN(m_logger) << "Configuration Parameters" << LOG_END;
+    LOG_INFO(m_logger) << "Configuration Parameters" << LOG_END;
     for (JParameter* p: params_to_print) {
 
-        LOG_WARN(m_logger) << LOG_END;
-        LOG_WARN(m_logger) << " - key:         " << p->GetKey() << LOG_END;
+        LOG_INFO(m_logger) << LOG_END;
+        LOG_INFO(m_logger) << " - key:         " << p->GetKey() << LOG_END;
         if (!p->IsDefault()) {
-            LOG_WARN(m_logger) << "   value:       " << p->GetValue() << LOG_END;
+            LOG_INFO(m_logger) << "   value:       " << p->GetValue() << LOG_END;
         }
         if (p->HasDefault()) {
-            LOG_WARN(m_logger) << "   default:     " << p->GetDefault() << LOG_END;
+            LOG_INFO(m_logger) << "   default:     " << p->GetDefault() << LOG_END;
         }
         if (!p->GetDescription().empty()) {
             std::istringstream iss(p->GetDescription());
@@ -183,22 +183,22 @@ void JParameterManager::PrintParameters(int verbosity, int strictness) {
             }
         }
         if (p->IsConflicted()) {
-            LOG_WARN(m_logger) << "   warning:     Conflicting defaults" << LOG_END;
+            LOG_WARN(m_logger) << "   warning:     " << p->GetKey() << ": Conflicting defaults" << LOG_END;
         }
         if (p->IsDeprecated()) {
-            LOG_WARN(m_logger) << "   warning:     Deprecated" << LOG_END;
+            LOG_WARN(m_logger) << "   warning:     " << p->GetKey() << ": Deprecated" << LOG_END;
             // If deprecated, it no longer matters whether it is advanced or not. If unused, won't show up here anyway.
         }
         if (!p->IsUsed()) {
             // Can't be both deprecated and unused, since JANA only finds out that it is deprecated by trying to use it
             // Can't be both advanced and unused, since JANA only finds out that it is advanced by trying to use it
-            LOG_WARN(m_logger) << "   warning:     Unused" << LOG_END;
+            LOG_WARN(m_logger) << "   warning:     " << p->GetKey() << ": Unused" << LOG_END;
         }
         if (p->IsAdvanced()) {
-            LOG_WARN(m_logger) << "   warning:     Advanced" << LOG_END;
+            LOG_WARN(m_logger) << "   warning:     " << p->GetKey() << ": Advanced" << LOG_END;
         }
     }
-    LOG_WARN(m_logger) << LOG_END;
+    LOG_INFO(m_logger) << LOG_END;
 
     // Now that we've printed the table, we can throw an exception if we are being super strict
     if (strictness_violation && strictness > 1) {

--- a/src/libraries/JANA/Services/JPluginLoader.cc
+++ b/src/libraries/JANA/Services/JPluginLoader.cc
@@ -189,7 +189,7 @@ void JPluginLoader::attach_plugin(std::string name, std::string path) {
     }
 
     // Run InitPlugin() and wrap exceptions as needed
-    LOG_WARN(m_logger) << "Loading plugin '" << name << "' from '" << path << "'" << LOG_END;
+    LOG_INFO(m_logger) << "Loading plugin '" << name << "' from '" << path << "'" << LOG_END;
 
     try {
         (*initialize_proc)(GetApplication());


### PR DESCRIPTION
Right now, JANA2 seems to use `LOG_WARN` rather generously. This leads to EICrecon starting with 50 lines of warnings:
```
16:01:49 wdconinc@menelaos ~/git/EICrecon (acts-38 *$%=) $ ./reconstruct.sh 

16:12:21.787  [warn] Setting signal handler USR1. Use to write status info to the named pipe.
16:12:21.788  [warn] Setting signal handler SIGINT (Ctrl-C). Use a single SIGINT to enter the Inspector, or multiple SIGINTs for an immediate shutdown.
16:12:21.788  [warn] Initializing...
16:12:21.788  [warn] 
16:12:21.788  [warn]        |    \      \  |     \    ___ \   
16:12:21.788  [warn]        |   _ \      \ |    _ \      ) |
16:12:21.788  [warn]    \   |  ___ \   |\  |   ___ \    __/
16:12:21.788  [warn]   \___/ _/    _\ _| \_| _/    _\ _____|
16:12:21.788  [warn] 
16:12:21.788  [warn]   JANA2 version:   2.4.0  (unknown git status)
16:12:21.788  [warn]   Install prefix:  /opt/software/linux-ubuntu25.04-skylake/gcc-14.2.0/jana2-2.4.0-62ocx7s5h525fnjkjwlcaaiu7z5ibvtt
16:12:21.788  [warn]   Optional deps:   Podio ROOT 
16:12:21.788  [warn] 
16:12:21.791  [warn] Loading plugin 'log' from '/opt/local/lib/EICrecon/plugins/log.so'
16:12:21.860  [warn] Loading plugin 'dd4hep' from '/opt/local/lib/EICrecon/plugins/dd4hep.so'
16:12:21.883  [warn] Loading plugin 'acts' from '/opt/local/lib/EICrecon/plugins/acts.so'
16:12:21.886  [warn] Loading plugin 'algorithms_init' from '/opt/local/lib/EICrecon/plugins/algorithms_init.so'
16:12:21.888  [warn] Loading plugin 'evaluator' from '/opt/local/lib/EICrecon/plugins/evaluator.so'
16:12:21.890  [warn] Loading plugin 'pid_lut' from '/opt/local/lib/EICrecon/plugins/pid_lut.so'
16:12:21.891  [warn] Loading plugin 'richgeo' from '/opt/local/lib/EICrecon/plugins/richgeo.so'
16:12:21.892  [warn] Loading plugin 'rootfile' from '/opt/local/lib/EICrecon/plugins/rootfile.so'
16:12:21.893  [warn] Loading plugin 'beam' from '/opt/local/lib/EICrecon/plugins/beam.so'
16:12:21.927  [warn] Loading plugin 'reco' from '/opt/local/lib/EICrecon/plugins/reco.so'
16:12:21.931  [warn] Loading plugin 'tracking' from '/opt/local/lib/EICrecon/plugins/tracking.so'
[dd4hep] [info] Loading DD4hep geometry from 1 files
[dd4hep] [info]   - loading geometry file:  '/opt/software/linux-ubuntu25.04-skylake/gcc-14.2.0/epic-main-4qdyfcmh6n34nyryevkdnixjgjlosklh/share/epic/epic_craterlake.xml' (patience ....)
Error in <TGeoVoxelFinder::SortAll>: Volume EcalEndcapPInsert: Cannot make slices on any axis
[dd4hep] [info] Geometry successfully loaded.
16:12:54.399  [warn] Loading plugin 'pid' from '/opt/local/lib/EICrecon/plugins/pid.so'
16:12:54.403  [warn] Loading plugin 'EEMC' from '/opt/local/lib/EICrecon/plugins/EEMC.so'
16:12:54.416  [warn] Loading plugin 'BEMC' from '/opt/local/lib/EICrecon/plugins/BEMC.so'
16:12:54.419  [warn] Loading plugin 'FEMC' from '/opt/local/lib/EICrecon/plugins/FEMC.so'
16:12:54.422  [warn] Loading plugin 'EHCAL' from '/opt/local/lib/EICrecon/plugins/EHCAL.so'
16:12:54.424  [warn] Loading plugin 'BHCAL' from '/opt/local/lib/EICrecon/plugins/BHCAL.so'
16:12:54.427  [warn] Loading plugin 'FHCAL' from '/opt/local/lib/EICrecon/plugins/FHCAL.so'
16:12:54.430  [warn] Loading plugin 'B0ECAL' from '/opt/local/lib/EICrecon/plugins/B0ECAL.so'
16:12:54.433  [warn] Loading plugin 'ZDC' from '/opt/local/lib/EICrecon/plugins/ZDC.so'
16:12:54.434  [warn] Loading plugin 'BTRK' from '/opt/local/lib/EICrecon/plugins/BTRK.so'
16:12:54.436  [warn] Loading plugin 'BVTX' from '/opt/local/lib/EICrecon/plugins/BVTX.so'
16:12:54.438  [warn] Loading plugin 'PFRICH' from '/opt/local/lib/EICrecon/plugins/PFRICH.so'
16:12:54.440  [warn] Loading plugin 'DIRC' from '/opt/local/lib/EICrecon/plugins/DIRC.so'
16:12:54.443  [warn] Loading plugin 'DRICH' from '/opt/local/lib/EICrecon/plugins/DRICH.so'
16:12:54.446  [warn] Loading plugin 'ECTRK' from '/opt/local/lib/EICrecon/plugins/ECTRK.so'
16:12:54.447  [warn] Loading plugin 'MPGD' from '/opt/local/lib/EICrecon/plugins/MPGD.so'
16:12:54.449  [warn] Loading plugin 'B0TRK' from '/opt/local/lib/EICrecon/plugins/B0TRK.so'
16:12:54.491  [warn] Loading plugin 'RPOTS' from '/opt/local/lib/EICrecon/plugins/RPOTS.so'
16:12:54.494  [warn] Loading plugin 'FOFFMTRK' from '/opt/local/lib/EICrecon/plugins/FOFFMTRK.so'
16:12:54.496  [warn] Loading plugin 'BTOF' from '/opt/local/lib/EICrecon/plugins/BTOF.so'
16:12:54.498  [warn] Loading plugin 'ECTOF' from '/opt/local/lib/EICrecon/plugins/ECTOF.so'
16:12:54.502  [warn] Loading plugin 'LOWQ2' from '/opt/local/lib/EICrecon/plugins/LOWQ2.so'
16:12:54.506  [warn] Loading plugin 'LUMISPECCAL' from '/opt/local/lib/EICrecon/plugins/LUMISPECCAL.so'
16:12:54.529  [warn] Loading plugin 'podio' from '/opt/local/lib/EICrecon/plugins/podio.so'
16:12:54.530  [warn] Loading plugin 'janatop' from '/opt/local/lib/EICrecon/plugins/janatop.so'
16:12:54.531  [warn] Loading plugin 'janadot' from '/opt/software/linux-ubuntu25.04-skylake/gcc-14.2.0/jana2-2.4.0-62ocx7s5h525fnjkjwlcaaiu7z5ibvtt/lib/JANA/plugins/janadot.so'
```
with more warnings for every time tick.

These are all informational messages and this PR changes them to `LOG_INFO`.