### PR TITLE
Bugfix: Skipped events not cleared

### DIFF
--- a/src/libraries/JANA/Topology/JArrow.cc
+++ b/src/libraries/JANA/Topology/JArrow.cc
@@ -58,9 +58,7 @@ void JArrow::push(OutputData& outputs, size_t output_count, size_t location_id) 
             port.queue->Push(event, location_id);
         }
         else if (port.pool != nullptr) {
-            if (!port.is_input) {
-                event->Clear();
-            }
+            event->Clear();
             port.pool->Push(event, location_id);
         }
         else {

--- a/src/programs/unit_tests/Components/NEventNSkipTests.cc
+++ b/src/programs/unit_tests/Components/NEventNSkipTests.cc
@@ -6,6 +6,10 @@
 
 #include <JANA/JEventSource.h>
 
+struct EventData : public JObject {
+    int event_nr=0;
+    EventData(int event_nr) : event_nr(event_nr){}
+};
 
 struct NEventNSkipBoundedSource : public JEventSource {
 
@@ -19,11 +23,14 @@ struct NEventNSkipBoundedSource : public JEventSource {
         SetCallbackStyle(CallbackStyle::ExpertMode);
     }
 
-    Result Emit(JEvent&) override {
+    Result Emit(JEvent& event) override {
+
+        REQUIRE(event.Get<EventData>("", false).size() == 0);
         if (event_count >= event_bound) {
             return Result::FailureFinished;
         }
         event_count += 1;
+        event.Insert(new EventData {event_count});
         events_emitted.push_back(event_count);
         return Result::Success;
     }


### PR DESCRIPTION
When using the `nskip` feature, events weren't being cleared before being returned to the pool. This addresses issue #403. 