### PR TITLE
Feature: JParameter comma escaping

### DIFF
--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -567,11 +567,7 @@ inline std::string JParameterManager::Stringify(const std::vector<std::string> &
                     }
                     break;
                 }
-                ssv << s;
-                if (s.back() != '\\') {
-                    ssv << '\\';
-                }
-                ssv << ',';
+                ssv << s << "\\,";
                 continue;
             }
         } else {
@@ -618,11 +614,7 @@ inline std::string JParameterManager::Stringify(const std::array<std::string,N> 
                     }
                     break;
                 }
-                ssv << s;
-                if (s.back() != '\\') {
-                    ssv << '\\';
-                }
-                ssv << ',';
+                ssv << s << "\\,";
                 continue;
             }
         } else {

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -373,7 +373,6 @@ template<typename T, size_t N>
 inline void JParameterManager::Parse(const std::string& value,std::array<T,N> &val) {
     std::string s;
     std::stringstream ss(value);
-    std::string temp = "";   // creating a temp var allows us to store the string s where the escape character was used
     int indx = 0;
     while (getline(ss, s, ',')) {
         T t;
@@ -391,8 +390,8 @@ inline void JParameterManager::Parse(const std::string& value,std::array<std::st
     int indx = 0;
     while (getline(ss, s, ',')) {
         std::string t;
-        if (s.find('\\') != std::string::npos) {
-            s.erase(s.find('\\'));
+        if (s.back() == '\\') {
+            s.pop_back();
             temp += s + ',';
             continue;
         }
@@ -414,7 +413,6 @@ inline void JParameterManager::Parse(const std::string& value, std::vector<T> &v
     std::stringstream ss(value);
     std::string s;
     val.clear(); // clearing the input vector to ensure no dulication which can be caused due to val.push_back(t);
-    std::string temp = "";   // creating a temp var allows us to store the string s where the escape character was used
     while (getline(ss, s, ',')) {
         T t;
         Parse(s, t);
@@ -431,8 +429,8 @@ inline void JParameterManager::Parse(const std::string& value, std::vector<std::
     std::string temp = "";   // creating a temp var allows us to store the string s where the escape character was used
     while (getline(ss, s, ',')) {
         std::string t;
-        if (s.find('\\') != std::string::npos) {
-            s.erase(s.find('\\'));
+        if (s.back() == '\\') {
+            s.pop_back();
             temp += s + ',';
             continue;
         }

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -4,9 +4,7 @@
 
 #pragma once
 
-#include <cstdio>
 #include <limits>
-#include <sstream>
 #include <string>
 #include <algorithm>
 #include <vector>
@@ -374,7 +372,7 @@ inline void JParameterManager::Parse(const std::string& value, bool& val) {
 }
 
 // @brief Template to parse a string and return in an array
-template <typename T, size_t N>
+template<typename T, size_t N>
 inline void JParameterManager::Parse(const std::string& value,std::array<T,N> &val) {
     std::string s;
     std::stringstream ss(value);
@@ -387,7 +385,7 @@ inline void JParameterManager::Parse(const std::string& value,std::array<T,N> &v
 }
 
 // @brief Template to parse a string and return in an array of strings
-template <size_t N>
+template<size_t N>
 inline void JParameterManager::Parse(const std::string& value,std::array<std::string,N> &val) {
     std::string s;
     std::stringstream ss(value);
@@ -413,7 +411,7 @@ inline void JParameterManager::Parse(const std::string& value,std::array<std::st
 }
 
 /// @brief Specialization for std::vector<std::string>
-template <typename T>
+template<typename T>
 inline void JParameterManager::Parse(const std::string& value, std::vector<T> &val) {
     std::stringstream ss(value);
     std::string s;
@@ -426,7 +424,7 @@ inline void JParameterManager::Parse(const std::string& value, std::vector<T> &v
 }
 
 /// @brief Specialization for std::vector<std::string> with escape commas
-template <>
+template<>
 inline void JParameterManager::Parse(const std::string& value, std::vector<std::string> &val) {
     std::stringstream ss(value);
     std::string s;
@@ -608,21 +606,29 @@ inline std::string JParameterManager::Stringify(const std::array<std::string,N> 
     size_t len = values.size();
     std::stringstream ssv;
     for (size_t i = 0; i < len; ++i) {
-        std::stringstream ss(values[i]);
-        std::string s;
-        std::string temp;
-        while (getline(ss, s, ',')) {
-            if (s.back() == '\\') {
-                s.pop_back();
-                temp += s + ',';
+        if (values[i].find(',') != std::string::npos) {
+            std::stringstream ss(values[i]);
+            std::string s;
+            std::string s_end = values[i].substr(values[i].rfind(',')+1);
+            while (getline(ss, s, ',')) {
+                if (s == s_end) {
+                    ssv << s;
+                    if (i != len-1) {
+                        ssv << ',';
+                    }
+                    break;
+                }
+                ssv << s;
+                if (s.back() != '\\') {
+                    ssv << '\\';
+                }
+                ssv << ',';
                 continue;
             }
-            if (!temp.empty()) {
-                ssv << temp + s;
-                temp.clear();
-            }
-            else {
-                ssv << s;
+        } else {
+            ssv << values[i];
+            if (i != len-1) {
+                ssv << ',';
             }
         }
     }

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -383,10 +383,24 @@ inline void JParameterManager::Parse(const std::string& value, std::vector<T> &v
     std::stringstream ss(value);
     std::string s;
     val.clear(); // clearing the input vector to ensure no dulication which can be caused due to val.push_back(t);
+      // we find an escape character
+    std::string temp = "";   // creating a temp var allows us to store the string s where the escape character was used
     while (getline(ss, s, ',')) {
         T t;
-        Parse(s, t);
-        val.push_back(t);
+        // Parse(s, t);
+        // val.push_back(t);
+        if (!temp.empty()) {
+            Parse(temp + s, t);
+            val.push_back(t);
+            temp.clear();
+        }
+        if (s.find('\\') != std::string::npos) {
+            temp = s + ',';
+        }
+        else {
+            Parse(s, t);
+            val.push_back(t);
+        }
     }
 }
 

--- a/src/libraries/JANA/Services/JParameterManager.h
+++ b/src/libraries/JANA/Services/JParameterManager.h
@@ -120,9 +120,6 @@ public:
     template<typename T>
     static inline void Parse(const std::string& value, std::vector<T>& out);
 
-    template<>
-    static inline void Parse(const std::string& value, std::vector<std::string>& out);
-
     template<typename T, size_t arrSize>
     static inline void Parse(const std::string& value, std::array<T,arrSize>& out); 
 

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -304,7 +304,6 @@ TEST_CASE("JParameterManager_ArrayParams") {
         REQUIRE(vals[1] == "whitespace in middle");
         REQUIRE(vals[2] == " also with whitespace padding ");
     }
-
     SECTION("Writing a array of strings") {
         std::array<std::string,3> inputs = {"first", "second one" , " third one "};
         jpm.SetDefaultParameter("test", inputs);
@@ -346,17 +345,17 @@ TEST_CASE("JParameterManager_ArrayParams") {
     }
     SECTION("Reading a array of functions with commas") {
         // As of Mon Jan 27, JParameterManager does not allow an escape key to prevent splitting on the next comma)
-        jpm.SetParameter("test", "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"); // Issue #380 (Feature request)
+        jpm.SetParameter("test", "theta-fmod(phi-fmod(phi\\,5)\\,7),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"); // Issue #380 (Feature request)
         std::array<std::string, 3> vals;
         jpm.GetParameter("test", vals);
 
-        REQUIRE(vals[0] == "phi-fmod(phi,5)");
+        REQUIRE(vals[0] == "theta-fmod(phi-fmod(phi,5),7)");
         REQUIRE(vals[1] == "theta-fmod(theta,10)");
         REQUIRE(vals[2] == "omega-fmod(omega,15)");
     }
     SECTION("Writing a array of functions with commas") {
         std::array<std::string, 3> inputs = {
-            "phi-fmod(phi\\,5)",
+            "theta-fmod(phi-fmod(phi\\,5)\\,7)",
             "theta-fmod(theta\\,10)",
             "omega-fmod(omega\\,15)"
         };
@@ -364,10 +363,10 @@ TEST_CASE("JParameterManager_ArrayParams") {
         jpm.SetDefaultParameter("test", inputs);
         std::array<float,3> outputs;
         auto param = jpm.GetParameter("test", outputs);
-        REQUIRE(param->GetValue() == "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
+        REQUIRE(param->GetValue() == "theta-fmod(phi-fmod(phi\\,5)\\,7),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
 
         std::array<float,3> temp;
-        jpm.Parse(jpm.Stringify("phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"), temp);
+        jpm.Parse(jpm.Stringify("theta-fmod(phi-fmod(phi\\,5)\\,7),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"), temp);
         REQUIRE(temp == outputs);
     }
 }

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -4,6 +4,7 @@
 
 
 #include <JANA/Services/JParameterManager.h>
+#include <string>
 #include <vector>
 #include "catch.hpp"
 
@@ -242,7 +243,11 @@ TEST_CASE("JParameterManager_VectorParams") {
         // As of Mon Jan 27, JParameterManager does not allow an escape key to prevent splitting on the next comma)
         jpm.SetParameter("test", "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"); // Issue #380 (Feature request)
         std::vector<std::string> vals;
+        std::cout << "Problem detected" << std::endl;
         jpm.GetParameter<std::vector<std::string>>("test", vals);
+        auto stringification = jpm.Stringify(vals);
+
+        REQUIRE(stringification == "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
 
         REQUIRE(vals[0] == "phi-fmod(phi,5)");
         REQUIRE(vals[1] == "theta-fmod(theta,10)");

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -391,20 +391,18 @@ TEST_CASE("JParameterManager_ArrayParams") {
     }
     SECTION("Writing a array of functions with commas") {
         std::array<std::string, 3> inputs = {
-            "theta-fmod(phi-fmod(phi\\,5)\\,7)",
-            "theta-fmod(theta\\,10)",
-            "omega-fmod(omega\\,15)"
+            "theta-fmod(phi-fmod(phi,5),7)",
+            "theta-fmod(theta,10)",
+            "omega-fmod(omega,15)"
         };
-        std::array<std::string,3> temp1 = inputs;
 
         jpm.SetDefaultParameter("test", inputs);
         std::array<std::string,3> outputs;
-        auto param = jpm.GetParameter("test", outputs);
-        REQUIRE(param->GetValue() == "theta-fmod(phi-fmod(phi\\,5)\\,7),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
 
-        std::array<std::string,3> temp2;
-        jpm.Parse(jpm.Stringify(temp1), temp2);
-        REQUIRE(temp2 == outputs);
+        auto param = jpm.GetParameter("test", outputs);
+
+        REQUIRE(outputs == inputs);
+        REQUIRE(param->GetValue() == "theta-fmod(phi-fmod(phi\\,5)\\,7),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
     }
     SECTION("ParseArrayOfStrings") {
 

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -4,6 +4,7 @@
 
 
 #include <JANA/Services/JParameterManager.h>
+#include <vector>
 #include "catch.hpp"
 
 TEST_CASE("JParameterManager::SetDefaultParameter") {
@@ -185,6 +186,16 @@ TEST_CASE("JParameterManager_VectorParams") {
         REQUIRE(vals[1] == "whitespace in middle");
         REQUIRE(vals[2] == " also with whitespace padding ");
     }
+    SECTION("Reading a vector of functions with commas") {
+        // As of Mon Jan 27, JParameterManager does not allow an escape key to prevent splitting on the next comma)
+        jpm.SetParameter("test", "phi-fmod(phi\\,5), theta-fmod(theta\\,10), omega-fmod(omega\\,15)"); // Issue #380 (Feature request)
+        std::vector<std::string> vals;
+        jpm.GetParameter<std::vector<std::string>>("test", vals);
+
+        REQUIRE(vals[0] == "phi-fmod(phi,5)");
+        REQUIRE(vals[1] == "theta-fmod(theta,5)");
+        REQUIRE(vals[2] == "phi-fmod(phi,5)");
+    }
     SECTION("Writing a vector of strings") {
         std::vector<std::string> inputs;
         inputs.emplace_back("first");
@@ -277,6 +288,7 @@ TEST_CASE("JParameterManager_ArrayParams") {
         REQUIRE(vals[1] == "whitespace in middle");
         REQUIRE(vals[2] == " also with whitespace padding ");
     }
+
     SECTION("Writing a array of strings") {
         std::array<std::string,3> inputs = {"first", "second one" , " third one "};
         jpm.SetDefaultParameter("test", inputs);

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -186,16 +186,6 @@ TEST_CASE("JParameterManager_VectorParams") {
         REQUIRE(vals[1] == "whitespace in middle");
         REQUIRE(vals[2] == " also with whitespace padding ");
     }
-    SECTION("Reading a vector of functions with commas") {
-        // As of Mon Jan 27, JParameterManager does not allow an escape key to prevent splitting on the next comma)
-        jpm.SetParameter("test", "phi-fmod(phi\\,5), theta-fmod(theta\\,10), omega-fmod(omega\\,15)"); // Issue #380 (Feature request)
-        std::vector<std::string> vals;
-        jpm.GetParameter<std::vector<std::string>>("test", vals);
-
-        REQUIRE(vals[0] == "phi-fmod(phi,5)");
-        REQUIRE(vals[1] == "theta-fmod(theta,5)");
-        REQUIRE(vals[2] == "phi-fmod(phi,5)");
-    }
     SECTION("Writing a vector of strings") {
         std::vector<std::string> inputs;
         inputs.emplace_back("first");
@@ -247,6 +237,28 @@ TEST_CASE("JParameterManager_VectorParams") {
         std::vector<float> outputs;
         auto param = jpm.GetParameter("test", outputs);
         REQUIRE(param->GetValue() == "22,49.2,42");
+    }
+    SECTION("Reading a vector of functions with commas") {
+        // As of Mon Jan 27, JParameterManager does not allow an escape key to prevent splitting on the next comma)
+        jpm.SetParameter("test", "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"); // Issue #380 (Feature request)
+        std::vector<std::string> vals;
+        jpm.GetParameter<std::vector<std::string>>("test", vals);
+
+        REQUIRE(vals[0] == "phi-fmod(phi,5)");
+        REQUIRE(vals[1] == "theta-fmod(theta,10)");
+        REQUIRE(vals[2] == "omega-fmod(omega,15)");
+    }
+    SECTION("Writing a vector of functions with commas") {
+        std::vector<std::string> inputs;
+        inputs.emplace_back("phi-fmod(phi\\,5)");
+        inputs.emplace_back("theta-fmod(theta\\,10)");
+        inputs.emplace_back("omega-fmod(omega\\,15)");
+
+        jpm.SetDefaultParameter("test", inputs);
+        std::vector<std::string> outputs;
+        auto param = jpm.GetParameter("test", outputs);
+        REQUIRE(param->GetValue() == "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
+        REQUIRE(inputs.size()==3);
     }
 }
 

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -255,9 +255,9 @@ TEST_CASE("JParameterManager_VectorParams") {
     }
     SECTION("Writing a vector of functions with commas") {
         std::vector<std::string> inputs;
-        inputs.emplace_back("phi-fmod(phi\\,5)");
-        inputs.emplace_back("theta-fmod(theta\\,10)");
-        inputs.emplace_back("omega-fmod(omega\\,15)");
+        inputs.emplace_back("phi-fmod(phi,5)");
+        inputs.emplace_back("theta-fmod(theta,10)");
+        inputs.emplace_back("omega-fmod(omega,15)");
         std::vector<std::string> temp1 = inputs;
 
 
@@ -289,6 +289,12 @@ TEST_CASE("JParameterManager_VectorParams") {
         jpm.Parse(s2, v2);
         REQUIRE(v2.size() == 2);
         REQUIRE(v2.at(0) == "This,is");
+        
+        auto s3 = "This\\,is,a\\\\,test"; // Should have 2 elements in vector
+        std::vector<std::string> v3;
+        jpm.Parse(s3, v3);
+        REQUIRE(v3.size() == 2);
+        REQUIRE(v3.at(1) == "a\\,test");
     }
     SECTION("StringifyVectorOfStrings") {
 
@@ -299,6 +305,10 @@ TEST_CASE("JParameterManager_VectorParams") {
         std::vector<std::string> v2 {"This,is", "a,test"};
         auto s2 = jpm.Stringify(v2);
         REQUIRE(s2 == "This\\,is,a\\,test");
+        
+        std::vector<std::string> v3 {"This,is", "a\\,test"};
+        auto s3 = jpm.Stringify(v3);
+        REQUIRE(s3 == "This\\,is,a\\\\,test");
     }
 }
 
@@ -417,6 +427,12 @@ TEST_CASE("JParameterManager_ArrayParams") {
         jpm.Parse(s2, v2);
         REQUIRE(v2.size() == 2);
         REQUIRE(v2.at(0) == "This,is");
+
+        auto s3 = "This\\,is,a\\\\,test"; // Should have 2 elements in vector
+        std::array<std::string, 2> v3;
+        jpm.Parse(s3, v3);
+        REQUIRE(v3.size() == 2);
+        REQUIRE(v3.at(1) == "a\\,test");
     }
     SECTION("StringifyArrayOfStrings") {
 
@@ -427,6 +443,10 @@ TEST_CASE("JParameterManager_ArrayParams") {
         std::array<std::string, 2> v2 {"This,is", "a,test"};
         auto s2 = jpm.Stringify(v2);
         REQUIRE(s2 == "This\\,is,a\\,test");
+
+        std::array<std::string, 2> v3 {"This,is", "a\\,test"};
+        auto s3 = jpm.Stringify(v3);
+        REQUIRE(s3 == "This\\,is,a\\\\,test");
     }
 }
 

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -259,6 +259,10 @@ TEST_CASE("JParameterManager_VectorParams") {
         auto param = jpm.GetParameter("test", outputs);
         REQUIRE(param->GetValue() == "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
         REQUIRE(inputs.size()==3);
+
+        std::vector<std::string> temp;
+        jpm.Parse(jpm.Stringify("phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"), temp);
+        REQUIRE(temp == outputs);
     }
 }
 
@@ -339,6 +343,32 @@ TEST_CASE("JParameterManager_ArrayParams") {
         std::array<float,3> outputs;
         auto param = jpm.GetParameter("test", outputs);
         REQUIRE(param->GetValue() == "22,49.2,42");
+    }
+    SECTION("Reading a array of functions with commas") {
+        // As of Mon Jan 27, JParameterManager does not allow an escape key to prevent splitting on the next comma)
+        jpm.SetParameter("test", "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"); // Issue #380 (Feature request)
+        std::array<std::string, 3> vals;
+        jpm.GetParameter("test", vals);
+
+        REQUIRE(vals[0] == "phi-fmod(phi,5)");
+        REQUIRE(vals[1] == "theta-fmod(theta,10)");
+        REQUIRE(vals[2] == "omega-fmod(omega,15)");
+    }
+    SECTION("Writing a array of functions with commas") {
+        std::array<std::string, 3> inputs = {
+            "phi-fmod(phi\\,5)",
+            "theta-fmod(theta\\,10)",
+            "omega-fmod(omega\\,15)"
+        };
+
+        jpm.SetDefaultParameter("test", inputs);
+        std::array<float,3> outputs;
+        auto param = jpm.GetParameter("test", outputs);
+        REQUIRE(param->GetValue() == "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
+
+        std::array<float,3> temp;
+        jpm.Parse(jpm.Stringify("phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"), temp);
+        REQUIRE(temp == outputs);
     }
 }
 

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -253,6 +253,7 @@ TEST_CASE("JParameterManager_VectorParams") {
         inputs.emplace_back("phi-fmod(phi\\,5)");
         inputs.emplace_back("theta-fmod(theta\\,10)");
         inputs.emplace_back("omega-fmod(omega\\,15)");
+        std::vector<std::string> temp1 = inputs;
 
         jpm.SetDefaultParameter("test", inputs);
         std::vector<std::string> outputs;
@@ -260,9 +261,9 @@ TEST_CASE("JParameterManager_VectorParams") {
         REQUIRE(param->GetValue() == "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
         REQUIRE(inputs.size()==3);
 
-        std::vector<std::string> temp;
-        jpm.Parse(jpm.Stringify("phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"), temp);
-        REQUIRE(temp == outputs);
+        std::vector<std::string> temp2;
+        jpm.Parse(jpm.Stringify(temp1), temp2);
+        REQUIRE(temp2 == outputs);
     }
 }
 
@@ -359,15 +360,16 @@ TEST_CASE("JParameterManager_ArrayParams") {
             "theta-fmod(theta\\,10)",
             "omega-fmod(omega\\,15)"
         };
+        std::array<std::string,3> temp1 = inputs;
 
         jpm.SetDefaultParameter("test", inputs);
         std::array<std::string,3> outputs;
         auto param = jpm.GetParameter("test", outputs);
         REQUIRE(param->GetValue() == "theta-fmod(phi-fmod(phi\\,5)\\,7),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
 
-        std::array<std::string,3> temp;
-        jpm.Parse(jpm.Stringify("theta-fmod(phi-fmod(phi\\,5)\\,7),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"), temp);
-        REQUIRE(temp == outputs);
+        std::array<std::string,3> temp2;
+        jpm.Parse(jpm.Stringify(temp1), temp2);
+        REQUIRE(temp2 == outputs);
     }
 }
 

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -255,7 +255,13 @@ TEST_CASE("JParameterManager_VectorParams") {
         inputs.emplace_back("omega-fmod(omega\\,15)");
         std::vector<std::string> temp1 = inputs;
 
+
         jpm.SetDefaultParameter("test", inputs);
+        auto stringified = jpm.Stringify(inputs);
+        std::vector<std::string> mangled_inputs;
+        jpm.Parse(stringified, mangled_inputs);
+        REQUIRE(inputs == mangled_inputs);
+
         std::vector<std::string> outputs;
         auto param = jpm.GetParameter("test", outputs);
         REQUIRE(param->GetValue() == "phi-fmod(phi\\,5),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
@@ -264,6 +270,30 @@ TEST_CASE("JParameterManager_VectorParams") {
         std::vector<std::string> temp2;
         jpm.Parse(jpm.Stringify(temp1), temp2);
         REQUIRE(temp2 == outputs);
+    }
+    SECTION("ParseVectorOfStrings") {
+
+        auto s1 = "This,is,a,test"; // Should have 4 elements in vector
+        std::vector<std::string> v1;
+        jpm.Parse(s1, v1);
+        REQUIRE(v1.size() == 4);
+        REQUIRE(v1.at(0) == "This");
+
+        auto s2 = "This\\,is,a\\,test"; // Should have 2 elements in vector
+        std::vector<std::string> v2;
+        jpm.Parse(s2, v2);
+        REQUIRE(v2.size() == 2);
+        REQUIRE(v2.at(0) == "This,is");
+    }
+    SECTION("StringifyVectorOfStrings") {
+
+        std::vector<std::string> v1 {"This", "is", "a", "test"};
+        auto s1 = jpm.Stringify(v1);
+        REQUIRE(s1 == "This,is,a,test");
+
+        std::vector<std::string> v2 {"This,is", "a,test"};
+        auto s2 = jpm.Stringify(v2);
+        REQUIRE(s2 == "This\\,is,a\\,test");
     }
 }
 

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -361,11 +361,11 @@ TEST_CASE("JParameterManager_ArrayParams") {
         };
 
         jpm.SetDefaultParameter("test", inputs);
-        std::array<float,3> outputs;
+        std::array<std::string,3> outputs;
         auto param = jpm.GetParameter("test", outputs);
         REQUIRE(param->GetValue() == "theta-fmod(phi-fmod(phi\\,5)\\,7),theta-fmod(theta\\,10),omega-fmod(omega\\,15)");
 
-        std::array<float,3> temp;
+        std::array<std::string,3> temp;
         jpm.Parse(jpm.Stringify("theta-fmod(phi-fmod(phi\\,5)\\,7),theta-fmod(theta\\,10),omega-fmod(omega\\,15)"), temp);
         REQUIRE(temp == outputs);
     }

--- a/src/programs/unit_tests/Services/JParameterManagerTests.cc
+++ b/src/programs/unit_tests/Services/JParameterManagerTests.cc
@@ -340,7 +340,7 @@ TEST_CASE("JParameterManager_ArrayParams") {
         REQUIRE(vals[1] == "whitespace in middle");
         REQUIRE(vals[2] == " also with whitespace padding ");
     }
-    SECTION("Writing a array of strings") {
+    SECTION("Writing an array of strings") {
         std::array<std::string,3> inputs = {"first", "second one" , " third one "};
         jpm.SetDefaultParameter("test", inputs);
         std::array<std::string,3> outputs;
@@ -405,6 +405,30 @@ TEST_CASE("JParameterManager_ArrayParams") {
         std::array<std::string,3> temp2;
         jpm.Parse(jpm.Stringify(temp1), temp2);
         REQUIRE(temp2 == outputs);
+    }
+    SECTION("ParseArrayOfStrings") {
+
+        auto s1 = "This,is,a,test"; // Should have 4 elements in vector
+        std::array<std::string,4> v1;
+        jpm.Parse(s1, v1);
+        REQUIRE(v1.size() == 4);
+        REQUIRE(v1.at(0) == "This");
+
+        auto s2 = "This\\,is,a\\,test"; // Should have 2 elements in vector
+        std::array<std::string, 2> v2;
+        jpm.Parse(s2, v2);
+        REQUIRE(v2.size() == 2);
+        REQUIRE(v2.at(0) == "This,is");
+    }
+    SECTION("StringifyArrayOfStrings") {
+
+        std::array<std::string, 4> v1 {"This", "is", "a", "test"};
+        auto s1 = jpm.Stringify(v1);
+        REQUIRE(s1 == "This,is,a,test");
+
+        std::array<std::string, 2> v2 {"This,is", "a,test"};
+        auto s2 = jpm.Stringify(v2);
+        REQUIRE(s2 == "This\\,is,a\\,test");
     }
 }
 


### PR DESCRIPTION
Parameters that are `std::vector<std::string>` and `std::array<std::string>` now escape commas. This addresses issue #380. Moved from PR #401