### PR TITLE
Change jana-generate.py c++ standard to 17

### DIFF
--- a/scripts/jana-generate.py
+++ b/scripts/jana-generate.py
@@ -328,7 +328,7 @@ cmake_minimum_required(VERSION 3.9)
 project({name}_project)
 
 if(NOT "${{CMAKE_CXX_STANDARD}}")
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)   # Enable -fPIC for all targets
 


### PR DESCRIPTION
Updated the default C++ standard for skeleton code of a plugin created with jana-generate.py to 17 in order to match current defaults of JANA2 and ROOT.

This is just a stop-gap solution.

