### PR TITLE
Fix typo in jana-generate.py

### DIFF
--- a/scripts/jana-generate.py
+++ b/scripts/jana-generate.py
@@ -365,7 +365,7 @@ plugin_cmakelists_txt = """
 if(true)
   # Automatically determine source file list.
   file(GLOB mysourcefiles *.cpp *.cc *.c  *.hpp *.hh *.h)
-  set( JANAGPUTest_PLUGIN_SOURCES ${{mysourcefiles}} )    
+  set( {name}_PLUGIN_SOURCES ${{mysourcefiles}} )    
 else()
   # Manually manage source file list
   set ({name}_PLUGIN_SOURCES


### PR DESCRIPTION
Fix typo in jana-generate that sets wrong variable for sources when using GLOB.