### PR TITLE
fix: CMake language C++ only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 cmake_policy(SET CMP0074 NEW) # find_package() uses <PackageName>_ROOT implicit hints
 
-project(jana2 VERSION 2.4.0)
+project(jana2 VERSION 2.4.0 LANGUAGES CXX)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)   # Enable -fPIC for all targets
 

--- a/src/external/md5/CMakeLists.txt
+++ b/src/external/md5/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(VendoredMD5 OBJECT md5.c)
+add_library(VendoredMD5 OBJECT md5.cc)
 target_include_directories(VendoredMD5 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 

--- a/src/external/md5/md5.cc
+++ b/src/external/md5/md5.cc
@@ -52,6 +52,7 @@
  */
 
 #include "md5.h"
+#include <cstdint>
 #include <string.h>
 
 #undef BYTE_ORDER	/* 1 = big-endian, -1 = little-endian, 0 = unknown */
@@ -161,14 +162,13 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 	     * On little-endian machines, we can process properly aligned
 	     * data without copying it.
 	     */
-	    if (!((data - (const md5_byte_t *)0) & 3)) {
-		/* data are properly aligned */
-		X = (const md5_word_t *)data;
-	    } else {
-		/* not aligned */
-		memcpy(xbuf, data, 64);
-		X = xbuf;
-	    }
+        if (reinterpret_cast<uintptr_t>(data) % alignof(md5_word_t) == 0) {
+            // data is aligned
+            X = reinterpret_cast<const md5_word_t*>(data);
+        } else {
+            memcpy(xbuf, data, 64);
+            X = xbuf;
+        }
 	}
 #endif
 #if BYTE_ORDER == 0


### PR DESCRIPTION
JANA2 is a C++ only project. By default CMake sets `LANGUAGES C CXX`, which causes JANA2 to search for and require a C compiler.