### PR TITLE
Feature: JApplication::RunOneEvent()

### DIFF
--- a/src/libraries/JANA/Engine/JExecutionEngine.cc
+++ b/src/libraries/JANA/Engine/JExecutionEngine.cc
@@ -100,7 +100,7 @@ void JExecutionEngine::RunTopology() {
     m_condvar.notify_one();
 }
 
-void JExecutionEngine::RunTopologyForOneEvent(JEventLevel level) {
+JArrow::FireResult JExecutionEngine::RunTopologyForOneEvent(JEventLevel level) {
     std::unique_lock<std::mutex> lock(m_mutex);
 
     if (m_runstatus != RunStatus::Paused) {
@@ -134,8 +134,9 @@ void JExecutionEngine::RunTopologyForOneEvent(JEventLevel level) {
     m_runstatus = RunStatus::Running;
 
     lock.unlock();
-    Fire(source_arrow_id); // This runs the source in the current (non-worker) thread.
+    auto fire_result = Fire(source_arrow_id); // This runs the source in the current (non-worker) thread.
     m_condvar.notify_one();
+    return fire_result;
 }
 
 void JExecutionEngine::ScaleWorkers(size_t nthreads) {

--- a/src/libraries/JANA/Engine/JExecutionEngine.h
+++ b/src/libraries/JANA/Engine/JExecutionEngine.h
@@ -127,7 +127,7 @@ public:
     void Init() override;
 
     void RunTopology();
-    void RunTopologyForOneEvent(JEventLevel level=JEventLevel::PhysicsEvent);
+    JArrow::FireResult RunTopologyForOneEvent(JEventLevel level=JEventLevel::PhysicsEvent);
     void PauseTopology();
     void DrainTopology();
     void FinishTopology();

--- a/src/libraries/JANA/Engine/JExecutionEngine.h
+++ b/src/libraries/JANA/Engine/JExecutionEngine.h
@@ -128,6 +128,7 @@ public:
     void Init() override;
 
     void RunTopology();
+    void RunTopologyForOneEvent(JEventLevel level=JEventLevel::PhysicsEvent);
     void PauseTopology();
     void DrainTopology();
     void FinishTopology();

--- a/src/libraries/JANA/Engine/JExecutionEngine.h
+++ b/src/libraries/JANA/Engine/JExecutionEngine.h
@@ -106,7 +106,6 @@ private:
     size_t m_next_arrow_id=0;
 
     // Metrics
-    size_t m_event_count_at_start = 0;
     size_t m_event_count_at_finish = 0;
     clock_t::time_point m_time_at_start;
     clock_t::time_point m_time_at_finish;

--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -197,6 +197,7 @@ void JApplication::Run(bool wait_until_stopped, bool finish) {
     LOG_WARN(m_logger) << "Starting processing with " << m_desired_nthreads << " threads requested..." << LOG_END;
     m_execution_engine->ScaleWorkers(m_desired_nthreads);
     m_execution_engine->RunTopology();
+    GetInstantaneousRate(); // Reset the inst rate counter
 
     if (!wait_until_stopped) {
         return;
@@ -218,6 +219,7 @@ void JApplication::Scale(int nthreads) {
     LOG_WARN(m_logger) << "Scaling to " << nthreads << " threads" << LOG_END;
     m_execution_engine->ScaleWorkers(nthreads);
     m_execution_engine->RunTopology();
+    GetInstantaneousRate(); // Reset the inst rate counter
 }
 
 void JApplication::Inspect() {

--- a/src/libraries/JANA/JApplicationFwd.h
+++ b/src/libraries/JANA/JApplicationFwd.h
@@ -72,6 +72,7 @@ public:
 
     void Initialize(void);
     void Run(bool wait_until_stopped=true, bool finish=true);
+    bool RunOneEvent(JEventLevel level=JEventLevel::PhysicsEvent, bool wait_until_stopped=true, bool finish=true);
     void Scale(int nthreads);
     void Stop(bool wait_until_stopped=false, bool finish=true);
     void Inspect();

--- a/src/programs/unit_tests/Engine/JExecutionEngineTests.cc
+++ b/src/programs/unit_tests/Engine/JExecutionEngineTests.cc
@@ -303,31 +303,43 @@ TEST_CASE("JExecutionEngine_RunTopologyForOneEvent") {
 
         sut->ScaleWorkers(1);
 
-        sut->RunTopologyForOneEvent();
+        JArrow::FireResult result = JArrow::FireResult::NotRunYet;
+
+        result = sut->RunTopologyForOneEvent();
+        REQUIRE(result == JArrow::FireResult::KeepGoing);
+
         sut->RunSupervisor();
         REQUIRE(sut->GetPerf().thread_count == 1);
         REQUIRE(sut->GetPerf().runstatus == JExecutionEngine::RunStatus::Paused);
         REQUIRE(sut->GetPerf().event_count == 1);
 
-        sut->RunTopologyForOneEvent();
+        result = sut->RunTopologyForOneEvent();
+        REQUIRE(result == JArrow::FireResult::KeepGoing);
+
         sut->RunSupervisor();
         REQUIRE(sut->GetPerf().thread_count == 1);
         REQUIRE(sut->GetPerf().runstatus == JExecutionEngine::RunStatus::Paused);
         REQUIRE(sut->GetPerf().event_count == 1);
 
-        sut->RunTopologyForOneEvent();
+        result = sut->RunTopologyForOneEvent();
+        REQUIRE(result == JArrow::FireResult::KeepGoing);
+
         sut->RunSupervisor();
         REQUIRE(sut->GetPerf().thread_count == 1);
         REQUIRE(sut->GetPerf().runstatus == JExecutionEngine::RunStatus::Paused);
         REQUIRE(sut->GetPerf().event_count == 1);
 
-        sut->RunTopologyForOneEvent();
+        result = sut->RunTopologyForOneEvent();
+        REQUIRE(result == JArrow::FireResult::KeepGoing);
+
         sut->RunSupervisor();
         REQUIRE(sut->GetPerf().thread_count == 1);
         REQUIRE(sut->GetPerf().runstatus == JExecutionEngine::RunStatus::Paused);
         REQUIRE(sut->GetPerf().event_count == 1);
 
-        sut->RunTopologyForOneEvent();
+        result = sut->RunTopologyForOneEvent();
+        REQUIRE(result == JArrow::FireResult::Finished);
+
         sut->RunSupervisor();
         REQUIRE(sut->GetPerf().thread_count == 1);
         REQUIRE(sut->GetPerf().runstatus == JExecutionEngine::RunStatus::Paused);

--- a/src/programs/unit_tests/Engine/JExecutionEngineTests.cc
+++ b/src/programs/unit_tests/Engine/JExecutionEngineTests.cc
@@ -240,12 +240,13 @@ TEST_CASE("JExecutionEngine_RunTopology") {
 }
 
 TEST_CASE("JExecutionEngine_RunTopologyForOneEvent") {
+    std::vector<int> event_log;
     JApplication app;
     app.SetParameterValue("jana:nevents", 4);
-    app.SetParameterValue("jana:loglevel", "debug");
+    app.SetParameterValue("jana:loglevel", "trace");
     app.SetParameterValue("jana:log:show_threadstamp", true);
     app.Add(new TestSource());
-    app.Add(new TestProc());
+    app.Add(new TestProc(&event_log));
     app.Initialize();
     auto sut = app.GetService<JExecutionEngine>();
 
@@ -260,12 +261,14 @@ TEST_CASE("JExecutionEngine_RunTopologyForOneEvent") {
         sut->RunSupervisor();
         REQUIRE(sut->GetPerf().thread_count == 1);
         REQUIRE(sut->GetPerf().runstatus == JExecutionEngine::RunStatus::Paused);
+        REQUIRE(event_log.size() == 1);
         REQUIRE(sut->GetPerf().event_count == 1);
 
         sut->RunTopologyForOneEvent();
         sut->RunSupervisor();
         REQUIRE(sut->GetPerf().thread_count == 1);
         REQUIRE(sut->GetPerf().runstatus == JExecutionEngine::RunStatus::Paused);
+        REQUIRE(event_log.size() == 2);
         REQUIRE(sut->GetPerf().event_count == 1);
 
         sut->FinishTopology();
@@ -288,12 +291,14 @@ TEST_CASE("JExecutionEngine_RunTopologyForOneEvent") {
         sut->RunSupervisor();
         REQUIRE(sut->GetPerf().thread_count == 4);
         REQUIRE(sut->GetPerf().runstatus == JExecutionEngine::RunStatus::Paused);
+        REQUIRE(event_log.size() == 1);
         REQUIRE(sut->GetPerf().event_count == 1);
 
         sut->RunTopologyForOneEvent();
         sut->RunSupervisor();
         REQUIRE(sut->GetPerf().thread_count == 4);
         REQUIRE(sut->GetPerf().runstatus == JExecutionEngine::RunStatus::Paused);
+        REQUIRE(event_log.size() == 2);
         REQUIRE(sut->GetPerf().event_count == 1);
 
         sut->FinishTopology();


### PR DESCRIPTION
This allows a program to step through events one-by-one synchronously. 

This is useful for interactive tools such as event viewers, where the GUI thread drives the interactions with JANA2 rather than vice versa. Previously, this had to be done either by (1) creating a JEventProcessor that blocks on each event and calls the GUI back, or (2) by using JEventGroups with a specialized JEventSource.