### PR TITLE
Fix conceptual problems with NSkip feature

### DIFF
--- a/src/libraries/JANA/JEvent.cc
+++ b/src/libraries/JANA/JEvent.cc
@@ -108,8 +108,8 @@ void JEvent::Release() {
     }
 }
 
-void JEvent::Clear() {
-    if (mEventSource != nullptr) {
+void JEvent::Clear(bool processed_successfully) {
+    if (processed_successfully && mEventSource != nullptr) {
         mEventSource->DoFinishEvent(*this);
     }
     mFactorySet->Clear();

--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -96,7 +96,7 @@ public:
     void Release();
 
     // Lifecycle
-    void Clear();
+    void Clear(bool processed_successfully=true);
     void Finish();
 
     JFactory* GetFactory(const std::string& object_name, const std::string& tag) const;

--- a/src/libraries/JANA/JEventSource.cc
+++ b/src/libraries/JANA/JEventSource.cc
@@ -82,28 +82,36 @@ void JEventSource::DoClose(bool with_lock) {
 JEventSource::Result JEventSource::DoNext(std::shared_ptr<JEvent> event) {
 
     std::lock_guard<std::mutex> lock(m_mutex); // In general, DoNext must be synchronized.
-    
+
     if (m_status == Status::Uninitialized) {
         throw JException("JEventSource has not been initialized!");
     }
-
-    if (m_callback_style == CallbackStyle::LegacyMode) {
-        return DoNextCompatibility(event);
-    }
-
-    auto first_evt_nr = m_nskip;
-    auto last_evt_nr = m_nevents + m_nskip;
-
     if (m_status == Status::Initialized) {
         DoOpen(false);
     }
     if (m_status == Status::Opened) {
-        if (m_nevents != 0 && (m_events_emitted == last_evt_nr)) {
-            // We exit early (and recycle) because we hit our jana:nevents limit
+
+        // First we check whether there are events to skip. If so, we skip as many as possible
+        if (m_nskip > 0) {
+            auto [result, remaining_events] = Skip(*event.get(), m_nskip);
+            m_events_skipped += (m_nskip - remaining_events);
+            m_nskip = remaining_events;
+
+            LOG_DEBUG(GetLogger()) << "Finished with Skip: " << m_events_skipped << " events skipped, " << m_nskip << " events to skip remain";
+
+            // If we encountered a problem, exit and let the arrow figure out when and whether to resume.
+            // Note that Skip() will call Close() on our behalf.
+            if (result != Result::Success) return result;
+        }
+
+        // Next we check whether we are limited by jana:nevents
+        if (m_nevents != 0 && m_events_emitted >= m_nevents) {
+            LOG_DEBUG(GetLogger()) << "Closing EventSource due to reaching nevent limit";
             DoClose(false);
             return Result::FailureFinished;
         }
-        // If we reach this point, we will need to actually read an event
+
+        // By this point we know that we are done skipping events and are ready to emit them
 
         // We configure the event
         event->SetEventNumber(m_events_emitted); // Default event number to event count
@@ -111,25 +119,70 @@ JEventSource::Result JEventSource::DoNext(std::shared_ptr<JEvent> event) {
         event->SetSequential(false);
         event->GetJCallGraphRecorder()->Reset();
 
-        // Now we call the new-style interface
-        auto previous_origin = event->GetJCallGraphRecorder()->SetInsertDataOrigin( JCallGraphRecorder::ORIGIN_FROM_SOURCE);  // (see note at top of JCallGraphRecorder.h)
-        JEventSource::Result result;
-        CallWithJExceptionWrapper("JEventSource::Emit", [&](){
-            result = Emit(*event);
-        });
-        event->GetJCallGraphRecorder()->SetInsertDataOrigin( previous_origin );
+
+        JEventSource::Result result = Result::Success;
+        try {
+            auto previous_origin = event->GetJCallGraphRecorder()->SetInsertDataOrigin( JCallGraphRecorder::ORIGIN_FROM_SOURCE);  // (see note at top of JCallGraphRecorder.h)
+            if (m_callback_style == CallbackStyle::LegacyMode) {
+                GetEvent(event);
+            }
+            else {
+                result = Emit(*event);
+            }
+            event->GetJCallGraphRecorder()->SetInsertDataOrigin( previous_origin );
+        }
+        catch (RETURN_STATUS rs) {
+
+            if (rs == RETURN_STATUS::kNO_MORE_EVENTS) {
+                DoClose(false);
+                result = Result::FailureFinished;
+            }
+            else if (rs == RETURN_STATUS::kTRY_AGAIN || rs == RETURN_STATUS::kBUSY) {
+                result = Result::FailureTryAgain;
+            }
+            else if (rs == RETURN_STATUS::kERROR || rs == RETURN_STATUS::kUNKNOWN) {
+                JException ex ("JEventSource threw RETURN_STATUS::kERROR or kUNKNOWN");
+                ex.plugin_name = m_plugin_name;
+                ex.type_name = m_type_name;
+                ex.function_name = "JEventSource::GetEvent";
+                ex.instance_name = m_resource_name;
+                throw ex;
+            }
+        }
+        catch (JException& ex) {
+            if (ex.function_name.empty()) ex.function_name = "JEventSource::GetEvent";
+            if (ex.type_name.empty()) ex.type_name = m_type_name;
+            if (ex.instance_name.empty()) ex.instance_name = m_prefix;
+            if (ex.plugin_name.empty()) ex.plugin_name = m_plugin_name;
+            throw ex;
+        }
+        catch (std::exception& e){
+            auto ex = JException(e.what());
+            ex.exception_type = JTypeInfo::demangle_current_exception_type();
+            ex.nested_exception = std::current_exception();
+            ex.function_name = "JEventSource::GetEvent";
+            ex.type_name = m_type_name;
+            ex.instance_name = m_prefix;
+            ex.plugin_name = m_plugin_name;
+            throw ex;
+        }
+        catch (...) {
+            auto ex = JException("Unknown exception");
+            ex.exception_type = JTypeInfo::demangle_current_exception_type();
+            ex.nested_exception = std::current_exception();
+            ex.function_name = "JEventSource::GetEvent";
+            ex.type_name = m_type_name;
+            ex.instance_name = m_prefix;
+            ex.plugin_name = m_plugin_name;
+            throw ex;
+        }
 
         if (result == Result::Success) {
-            m_events_emitted += 1; 
+            m_events_emitted += 1;
             // We end up here if we read an entry in our file or retrieved a message from our socket,
             // and believe we could obtain another one immediately if we wanted to
             for (auto* output : m_outputs) {
                 output->InsertCollection(*event);
-            }
-            if (m_events_emitted <= first_evt_nr) {
-                // We immediately throw away this whole event because of nskip 
-                // (although really we should be handling this with Seek())
-                return Result::FailureTryAgain;
             }
             return Result::Success;
         }
@@ -150,101 +203,6 @@ JEventSource::Result JEventSource::DoNext(std::shared_ptr<JEvent> event) {
     }
     else { // status == Closed
         return Result::FailureFinished;
-    }
-}
-
-JEventSource::Result JEventSource::DoNextCompatibility(std::shared_ptr<JEvent> event) {
-
-    auto first_evt_nr = m_nskip;
-    auto last_evt_nr = m_nevents + m_nskip;
-
-    try {
-        if (m_status == Status::Initialized) {
-            DoOpen(false);
-        }
-        if (m_status == Status::Opened) {
-            if (m_events_emitted < first_evt_nr) {
-                // Skip these events due to nskip
-                event->SetEventNumber(m_events_emitted); // Default event number to event count
-                auto previous_origin = event->GetJCallGraphRecorder()->SetInsertDataOrigin( JCallGraphRecorder::ORIGIN_FROM_SOURCE);  // (see note at top of JCallGraphRecorder.h)
-                GetEvent(event);
-                event->GetJCallGraphRecorder()->SetInsertDataOrigin( previous_origin );
-                m_events_emitted += 1;
-                return Result::FailureTryAgain;  // Reject this event and recycle it
-            } else if (m_nevents != 0 && (m_events_emitted == last_evt_nr)) {
-                // Declare ourselves finished due to nevents
-                DoClose(false); // Close out the event source as soon as it declares itself finished
-                return Result::FailureFinished;
-            } else {
-                // Actually emit an event.
-                // GetEvent() expects the following things from its incoming JEvent
-                event->SetEventNumber(m_events_emitted);
-                event->SetJApplication(m_app);
-                event->SetJEventSource(this);
-                event->SetSequential(false);
-                event->GetJCallGraphRecorder()->Reset();
-                auto previous_origin = event->GetJCallGraphRecorder()->SetInsertDataOrigin( JCallGraphRecorder::ORIGIN_FROM_SOURCE);  // (see note at top of JCallGraphRecorder.h)
-                GetEvent(event);
-                for (auto* output : m_outputs) {
-                    output->InsertCollection(*event);
-                }
-                event->GetJCallGraphRecorder()->SetInsertDataOrigin( previous_origin );
-                m_events_emitted += 1;
-                return Result::Success; // Don't reject this event!
-            }
-        } else if (m_status == Status::Closed) {
-            return Result::FailureFinished;
-        } else {
-            throw JException("Invalid m_status");
-        }
-    }
-    catch (RETURN_STATUS rs) {
-
-        if (rs == RETURN_STATUS::kNO_MORE_EVENTS) {
-            DoClose(false);
-            return Result::FailureFinished;
-        }
-        else if (rs == RETURN_STATUS::kTRY_AGAIN || rs == RETURN_STATUS::kBUSY) {
-            return Result::FailureTryAgain;
-        }
-        else if (rs == RETURN_STATUS::kERROR || rs == RETURN_STATUS::kUNKNOWN) {
-            JException ex ("JEventSource threw RETURN_STATUS::kERROR or kUNKNOWN");
-            ex.plugin_name = m_plugin_name;
-            ex.type_name = m_type_name;
-            ex.function_name = "JEventSource::GetEvent";
-            ex.instance_name = m_resource_name;
-            throw ex;
-        }
-        else {
-            return Result::Success;
-        }
-    }
-    catch (JException& ex) {
-        if (ex.function_name.empty()) ex.function_name = "JEventSource::GetEvent";
-        if (ex.type_name.empty()) ex.type_name = m_type_name;
-        if (ex.instance_name.empty()) ex.instance_name = m_prefix;
-        if (ex.plugin_name.empty()) ex.plugin_name = m_plugin_name;
-        throw ex;
-    }
-    catch (std::exception& e){
-        auto ex = JException(e.what());
-        ex.exception_type = JTypeInfo::demangle_current_exception_type();
-        ex.nested_exception = std::current_exception();
-        ex.function_name = "JEventSource::GetEvent";
-        ex.type_name = m_type_name;
-        ex.instance_name = m_prefix;
-        ex.plugin_name = m_plugin_name;
-        throw ex;
-    }
-    catch (...) {
-        auto ex = JException("Unknown exception");
-        ex.exception_type = JTypeInfo::demangle_current_exception_type();
-        ex.nested_exception = std::current_exception();
-        ex.function_name = "JEventSource::GetEvent";
-        ex.type_name = m_type_name;
-        ex.instance_name = m_prefix;
-        ex.plugin_name = m_plugin_name;
-        throw ex;
     }
 }
 
@@ -274,3 +232,84 @@ void JEventSource::Summarize(JComponentSummary& summary) const {
 
     summary.Add(result);
 }
+
+
+std::pair<JEventSource::Result, size_t> JEventSource::Skip(JEvent& event, size_t events_to_skip) {
+
+    // Return values
+    Result result = Result::Success;
+    size_t events_skipped = 0;
+
+    while (events_to_skip > 0 && result == Result::Success) {
+        try {
+            auto previous_origin = event.GetJCallGraphRecorder()->SetInsertDataOrigin( JCallGraphRecorder::ORIGIN_FROM_SOURCE);  // (see note at top of JCallGraphRecorder.h)
+            if (m_callback_style == CallbackStyle::LegacyMode) {
+                GetEvent(event.shared_from_this());
+            }
+            else {
+                result = Emit(event);
+            }
+            event.GetJCallGraphRecorder()->SetInsertDataOrigin( previous_origin );
+            // We need to call FinishEvent, but we don't want to call it from inside JEvent::Clear() because we are already inside the lock.
+            // So instead, we call it ourselves out here. This has the added benefit of letting us avoid updating m_events_finished.
+            if (m_enable_finish_event) {
+                CallWithJExceptionWrapper("JEventSource::FinishEvent", [&](){ FinishEvent(event); });
+            }
+            event.Clear(false);
+            events_skipped += 1;
+            events_to_skip -= 1;
+            m_events_emitted += 1; // For now skipped events count towards our emit count, but not our finished count.
+        }
+        catch (RETURN_STATUS rs) {
+
+            if (rs == RETURN_STATUS::kNO_MORE_EVENTS) {
+                DoClose(false);
+                result = Result::FailureFinished;
+            }
+            else if (rs == RETURN_STATUS::kTRY_AGAIN || rs == RETURN_STATUS::kBUSY) {
+                result = Result::FailureTryAgain;
+            }
+            else if (rs == RETURN_STATUS::kERROR || rs == RETURN_STATUS::kUNKNOWN) {
+                JException ex ("JEventSource threw RETURN_STATUS::kERROR or kUNKNOWN");
+                ex.plugin_name = m_plugin_name;
+                ex.type_name = m_type_name;
+                ex.function_name = (m_callback_style == CallbackStyle::LegacyMode) ? "JEventSource::GetEvent" : "JEventSource::Emit";
+                ex.instance_name = m_resource_name;
+                throw ex;
+            }
+        }
+        catch (JException& ex) {
+            if (ex.function_name.empty()) ex.function_name = (m_callback_style == CallbackStyle::LegacyMode) ? "JEventSource::GetEvent" : "JEventSource::Emit";
+            if (ex.type_name.empty()) ex.type_name = m_type_name;
+            if (ex.instance_name.empty()) ex.instance_name = m_prefix;
+            if (ex.plugin_name.empty()) ex.plugin_name = m_plugin_name;
+            throw ex;
+        }
+        catch (std::exception& e){
+            auto ex = JException(e.what());
+            ex.exception_type = JTypeInfo::demangle_current_exception_type();
+            ex.nested_exception = std::current_exception();
+            ex.function_name = (m_callback_style == CallbackStyle::LegacyMode) ? "JEventSource::GetEvent" : "JEventSource::Emit";
+            ex.type_name = m_type_name;
+            ex.instance_name = m_prefix;
+            ex.plugin_name = m_plugin_name;
+            throw ex;
+        }
+        catch (...) {
+            auto ex = JException("Unknown exception");
+            ex.exception_type = JTypeInfo::demangle_current_exception_type();
+            ex.nested_exception = std::current_exception();
+            ex.function_name = (m_callback_style == CallbackStyle::LegacyMode) ? "JEventSource::GetEvent" : "JEventSource::Emit";
+            ex.type_name = m_type_name;
+            ex.instance_name = m_prefix;
+            ex.plugin_name = m_plugin_name;
+            throw ex;
+        }
+    }
+
+    return {result, events_to_skip};
+}
+
+
+
+

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -31,6 +31,7 @@ public:
 private:
     std::string m_resource_name;
     std::atomic_ullong m_events_emitted {0};
+    std::atomic_ullong m_events_skipped {0};
     std::atomic_ullong m_events_finished {0};
     uint64_t m_nskip = 0;
     uint64_t m_nevents = 0;
@@ -127,6 +128,12 @@ public:
         return false;
     }
 
+    /// `Skip` allows the user to move forward in the file without having to read and discard entire events. It takes
+    /// as inputs an event object and the number of events to skip, and returns a pair containing a JEventSource::Result
+    /// and the number of events that still need to be skipped. The event object can be completely ignored. If it is
+    /// populated, however, it should be cleared before Skip() returns.
+    virtual std::pair<JEventSource::Result, size_t> Skip(JEvent& event, size_t events_to_skip);
+
 
     // Getters
     
@@ -135,6 +142,7 @@ public:
     [[deprecated]]
     uint64_t GetEventCount() const { return m_events_emitted; };
     uint64_t GetEmittedEventCount() const { return m_events_emitted; };
+    uint64_t GetSkippedEventCount() const { return m_events_skipped; };
     uint64_t GetFinishedEventCount() const { return m_events_finished; };
 
     [[deprecated]]

--- a/src/libraries/JANA/JEventSource.h
+++ b/src/libraries/JANA/JEventSource.h
@@ -32,7 +32,7 @@ private:
     std::string m_resource_name;
     std::atomic_ullong m_events_emitted {0};
     std::atomic_ullong m_events_skipped {0};
-    std::atomic_ullong m_events_finished {0};
+    std::atomic_ullong m_events_processed {0};
     uint64_t m_nskip = 0;
     uint64_t m_nevents = 0;
     bool m_enable_finish_event = false;
@@ -143,7 +143,7 @@ public:
     uint64_t GetEventCount() const { return m_events_emitted; };
     uint64_t GetEmittedEventCount() const { return m_events_emitted; };
     uint64_t GetSkippedEventCount() const { return m_events_skipped; };
-    uint64_t GetFinishedEventCount() const { return m_events_finished; };
+    uint64_t GetProcessedEventCount() const { return m_events_processed; };
 
     [[deprecated]]
     virtual std::string GetType() const { return m_type_name; }

--- a/src/libraries/JANA/JFactory.h
+++ b/src/libraries/JANA/JFactory.h
@@ -185,6 +185,7 @@ protected:
     std::string mTag;
     uint32_t mFlags = WRITE_TO_OUTPUT;
     int32_t mPreviousRunNumber = -1;
+    bool mInsideCreate = false; // Use this to detect cycles in factory dependencies
     std::unordered_map<std::type_index, std::unique_ptr<JAny>> mUpcastVTable;
 
     mutable Status mStatus = Status::Uninitialized;

--- a/src/libraries/JANA/Topology/JArrow.cc
+++ b/src/libraries/JANA/Topology/JArrow.cc
@@ -58,7 +58,7 @@ void JArrow::push(OutputData& outputs, size_t output_count, size_t location_id) 
             port.queue->Push(event, location_id);
         }
         else if (port.pool != nullptr) {
-            event->Clear();
+            event->Clear(!port.is_input);
             port.pool->Push(event, location_id);
         }
         else {

--- a/src/libraries/JANA/Topology/JEventSourceArrow.cc
+++ b/src/libraries/JANA/Topology/JEventSourceArrow.cc
@@ -25,7 +25,7 @@ void JEventSourceArrow::fire(JEvent* event, OutputData& outputs, size_t& output_
     if (m_barrier_active) {
 
         auto emitted_event_count = m_sources[m_current_source]->GetEmittedEventCount();
-        auto finished_event_count = m_sources[m_current_source]->GetFinishedEventCount();
+        auto finished_event_count = m_sources[m_current_source]->GetProcessedEventCount();
 
         // A barrier event has been emitted by the source.
         if (m_pending_barrier_event != nullptr) {

--- a/src/programs/unit_tests/Components/JEventSourceTests.cc
+++ b/src/programs/unit_tests/Components/JEventSourceTests.cc
@@ -7,7 +7,12 @@ struct MyEventSource : public JEventSource {
     int open_count = 0;
     int emit_count = 0;
     int close_count = 0;
+    int finish_event_count = 0;
     size_t events_in_file = 5;
+
+    MyEventSource() {
+        EnableFinishEvent();
+    }
 
     void Open() override {
         REQUIRE(GetApplication() != nullptr);
@@ -29,6 +34,10 @@ struct MyEventSource : public JEventSource {
         LOG_INFO(GetLogger()) << "Close() called" << LOG_END;
         close_count++;
     }
+    void FinishEvent(JEvent& event) override {
+        LOG_INFO(GetLogger()) << "FinishEvent() called" << LOG_END;
+        finish_event_count++;
+    }
 };
 
 TEST_CASE("JEventSource_ExpertMode_EmitCount") {
@@ -46,8 +55,10 @@ TEST_CASE("JEventSource_ExpertMode_EmitCount") {
         app.Run();
         REQUIRE(sut->open_count == 1);
         REQUIRE(sut->emit_count == 6);       // Emit called 5 times successfully and fails on the 6th
-        REQUIRE(sut->GetEmittedEventCount() == 5);  // Emits 5 events successfully (including skipped)
+        REQUIRE(sut->GetEmittedEventCount() == 5);  // Emits 5 events successfully
         REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 5);  // All emitted events were finished
+        REQUIRE(sut->GetFinishedEventCount() == 5); // This is reflected in the finished count
     }
 
     SECTION("LimitedByNEvents") {
@@ -58,6 +69,7 @@ TEST_CASE("JEventSource_ExpertMode_EmitCount") {
         REQUIRE(sut->emit_count == 3);        // Emit called 3 times successfully
         REQUIRE(sut->GetEmittedEventCount() == 3);   // Nevents limit discovered outside Emit
         REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 3);
     }
 
     SECTION("LimitedByNSkip") {
@@ -68,6 +80,8 @@ TEST_CASE("JEventSource_ExpertMode_EmitCount") {
         REQUIRE(sut->emit_count == 6);        // Emit called 5 times successfully and fails on the 6th
         REQUIRE(sut->GetEmittedEventCount() == 5);   // 5 events successfully emitted, 3 of which were (presumably) skipped
         REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 2);        // TODO: Should be 5 because every event that is Emit()ted must be FinishEvent()ted
+        REQUIRE(sut->GetFinishedEventCount() == 2);   // Only two events were successfully processed, the rest were skipped
     }
 }
 

--- a/src/programs/unit_tests/Components/JEventSourceTests.cc
+++ b/src/programs/unit_tests/Components/JEventSourceTests.cc
@@ -9,8 +9,10 @@ struct MyEventSource : public JEventSource {
     int close_count = 0;
     int finish_event_count = 0;
     size_t events_in_file = 5;
+    int events_per_barrier = 0;
 
     MyEventSource() {
+        SetTypeName("MyEventSource");
         EnableFinishEvent();
     }
 
@@ -19,8 +21,11 @@ struct MyEventSource : public JEventSource {
         LOG_INFO(GetLogger()) << "Open() called" << LOG_END;
         open_count++;
     }
-    Result Emit(JEvent&) override {
+    Result Emit(JEvent& event) override {
         emit_count++;
+        if ((events_per_barrier != 0) && ((emit_count % events_per_barrier) == 0)) {
+            event.SetSequential(true);
+        }
         REQUIRE(GetApplication() != nullptr);
         if (emit_count > events_in_file) {
             LOG_INFO(GetLogger()) << "Emit() called, iteration " << emit_count << ", returning FailureFinished" << LOG_END;
@@ -28,6 +33,18 @@ struct MyEventSource : public JEventSource {
         }
         LOG_INFO(GetLogger()) << "Emit() called, iteration " << emit_count << ", returning Success" << LOG_END;
         return Result::Success;
+    }
+    void GetEvent(std::shared_ptr<JEvent> event) override {
+        emit_count++;
+        if ((events_per_barrier != 0) && ((emit_count % events_per_barrier) == 0)) {
+            event->SetSequential(true);
+        }
+        REQUIRE(GetApplication() != nullptr);
+        if (emit_count > events_in_file) {
+            LOG_INFO(GetLogger()) << "GetEvent() called, iteration " << emit_count << ", returning FailureFinished" << LOG_END;
+            throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
+        }
+        LOG_INFO(GetLogger()) << "GetEvent() called, iteration " << emit_count << ", returning Success" << LOG_END;
     }
     void Close() override {
         REQUIRE(GetApplication() != nullptr);
@@ -40,18 +57,16 @@ struct MyEventSource : public JEventSource {
     }
 };
 
-TEST_CASE("JEventSource_ExpertMode_EmitCount") {
+TEST_CASE("JEventSource_EmitCount") {
 
     auto sut = new MyEventSource;
-    sut->SetCallbackStyle(MyEventSource::CallbackStyle::ExpertMode);
-    sut->SetTypeName("MyEventSource");
-
     JApplication app;
     app.SetParameterValue("jana:loglevel", "off");
     app.Add(sut);
 
-    SECTION("ShutsSelfOff") {
-        LOG << "Running test: JEventSource_ExpertMode_EmitCount :: ShutsSelfOff" << LOG_END;
+    SECTION("ShutsSelfOff_ExpertMode_NoBarriers") {
+        LOG << "Running test: JEventSource_EmitCount :: ShutsSelfOff_ExpertMode_NoBarriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::ExpertMode);
         app.Run();
         REQUIRE(sut->open_count == 1);
         REQUIRE(sut->emit_count == 6);       // Emit called 5 times successfully and fails on the 6th
@@ -61,8 +76,10 @@ TEST_CASE("JEventSource_ExpertMode_EmitCount") {
         REQUIRE(sut->GetProcessedEventCount() == 5); // This is reflected in the finished count
     }
 
-    SECTION("LimitedByNEvents") {
-        LOG << "Running test: JEventSource_ExpertMode_EmitCount :: LimitedByNEvents" << LOG_END;
+    SECTION("LimitedByNEvents_ExpertMode_NoBarriers") {
+        LOG << "Running test: JEventSource_EmitCount :: LimitedByNEvents_ExpertMode_NoBarriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::ExpertMode);
+
         app.SetParameterValue("jana:nevents", 3);
         app.Run();
         REQUIRE(sut->open_count == 1);
@@ -72,8 +89,10 @@ TEST_CASE("JEventSource_ExpertMode_EmitCount") {
         REQUIRE(sut->finish_event_count == 3);
     }
 
-    SECTION("LimitedByNSkip") {
-        LOG << "Running test: JEventSource_ExpertMode_EmitCount :: LimitedByNSkip" << LOG_END;
+    SECTION("LimitedByNSkip_ExpertMode_NoBarriers") {
+        LOG << "Running test: JEventSource_EmitCount :: LimitedByNSkip_ExpertMode_NoBarriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::ExpertMode);
+
         app.SetParameterValue("jana:nskip", 3);
         app.Run();
         REQUIRE(sut->open_count == 1);
@@ -84,6 +103,139 @@ TEST_CASE("JEventSource_ExpertMode_EmitCount") {
         REQUIRE(sut->GetProcessedEventCount() == 2);  // The 2 emitted events were both successfully processed
         REQUIRE(sut->GetSkippedEventCount() == 3);    // The first 3 events were skipped, out of 5 total
     }
-}
 
+    SECTION("ShutsSelfOff_LegacyMode_NoBarriers") {
+        LOG << "Running test: JEventSource_EmitCount :: ShutsSelfOff_LegacyMode_NoBarriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::LegacyMode);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 6);       // Emit called 5 times successfully and fails on the 6th
+        REQUIRE(sut->GetEmittedEventCount() == 5);  // Emits 5 events successfully
+        REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 5);  // All emitted events were finished
+        REQUIRE(sut->GetProcessedEventCount() == 5); // This is reflected in the finished count
+    }
+
+    SECTION("LimitedByNEvents_LegacyMode_NoBarriers") {
+        LOG << "Running test: JEventSource_EmitCount :: LimitedByNEvents_LegacyMode_NoBarriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::LegacyMode);
+        app.SetParameterValue("jana:nevents", 3);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 3);        // Emit called 3 times successfully
+        REQUIRE(sut->GetEmittedEventCount() == 3);   // Nevents limit discovered outside Emit
+        REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 3);
+    }
+
+    SECTION("LimitedByNSkip_LegacyMode_NoBarriers") {
+        LOG << "Running test: JEventSource_EmitCount :: LimitedByNSkip_LegacyMode_NoBarriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::LegacyMode);
+        app.SetParameterValue("jana:nskip", 3);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 6);                // Emit was called 5 times successfully and failed on the 6th
+        REQUIRE(sut->GetEmittedEventCount() == 2);    // The first 3 were skipped, so only 2 entered the topology
+        REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 5);        // FinishEvent() was called for both emitted and skipped events
+        REQUIRE(sut->GetProcessedEventCount() == 2);  // The 2 emitted events were both successfully processed
+        REQUIRE(sut->GetSkippedEventCount() == 3);    // The first 3 events were skipped, out of 5 total
+    }
+
+    SECTION("ShutsSelfOff_ExpertMode_Barriers") {
+        LOG << "Running test: JEventSource_EmitCount :: ShutsSelfOff_ExpertMode_Barriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::ExpertMode);
+        sut->events_per_barrier = 4;
+        sut->events_in_file = 50;
+        app.SetParameterValue("nthreads", 8);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 51);               // Emit called 50 times successfully and fails on the 51st
+        REQUIRE(sut->GetEmittedEventCount() == 50);   // Emits 50 events successfully
+        REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 50);       // All emitted events were finished
+        REQUIRE(sut->GetProcessedEventCount() == 50); // This is reflected in the finished count
+    }
+
+    SECTION("LimitedByNEvents_ExpertMode_Barriers") {
+        LOG << "Running test: JEventSource_EmitCount :: LimitedByNEvents_ExpertMode_Barriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::ExpertMode);
+        sut->events_per_barrier = 4;
+        sut->events_in_file = 50;
+        app.SetParameterValue("nthreads", 8);
+        app.SetParameterValue("jana:nevents", 30);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 30);               // Emit called 30 times successfully
+        REQUIRE(sut->GetEmittedEventCount() ==  30);  // Nevents limit discovered outside Emit
+        REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 30);
+        REQUIRE(sut->GetProcessedEventCount() == 30);
+    }
+
+    SECTION("LimitedByNSkip_ExpertMode_Barriers") {
+        LOG << "Running test: JEventSource_EmitCount :: LimitedByNSkip_ExpertMode_Barriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::ExpertMode);
+        sut->events_per_barrier = 4;
+        sut->events_in_file = 50;
+        app.SetParameterValue("nthreads", 8);
+        app.SetParameterValue("jana:nskip", 10);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 51);                // GetEvent was called 50 times successfully and failed on the 51st
+        REQUIRE(sut->GetEmittedEventCount() == 40);    // The first 10 were skipped, so only 40 entered the topology
+        REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 50);        // FinishEvent() was called for both emitted and skipped events
+        REQUIRE(sut->GetProcessedEventCount() == 40);  // The 40 emitted events were successfully processed
+        REQUIRE(sut->GetSkippedEventCount() == 10);    // The first 10 events were skipped, out of 50 total
+    }
+
+    SECTION("ShutsSelfOff_LegacyMode_Barriers") {
+        LOG << "Running test: JEventSource_EmitCount :: ShutsSelfOff_LegacyMode_Barriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::LegacyMode);
+        sut->events_per_barrier = 4;
+        sut->events_in_file = 50;
+        app.SetParameterValue("nthreads", 8);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 51);               // Emit called 50 times successfully and fails on the 51st
+        REQUIRE(sut->GetEmittedEventCount() == 50);   // Emits 50 events successfully
+        REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 50);       // All emitted events were finished
+        REQUIRE(sut->GetProcessedEventCount() == 50); // This is reflected in the finished count
+    }
+
+    SECTION("LimitedByNEvents_LegacyMode_Barriers") {
+        LOG << "Running test: JEventSource_EmitCount :: LimitedByNEvents_LegacyMode_Barriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::LegacyMode);
+        sut->events_per_barrier = 4;
+        sut->events_in_file = 50;
+        app.SetParameterValue("nthreads", 8);
+        app.SetParameterValue("jana:nevents", 30);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 30);               // Emit called 30 times successfully
+        REQUIRE(sut->GetEmittedEventCount() ==  30);  // Nevents limit discovered outside Emit
+        REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 30);
+        REQUIRE(sut->GetProcessedEventCount() == 30);
+    }
+
+    SECTION("LimitedByNSkip_LegacyMode_Barriers") {
+        LOG << "Running test: JEventSource_EmitCount :: LimitedByNSkip_LegacyMode_Barriers" << LOG_END;
+        sut->SetCallbackStyle(MyEventSource::CallbackStyle::LegacyMode);
+        sut->events_per_barrier = 4;
+        sut->events_in_file = 50;
+        app.SetParameterValue("nthreads", 8);
+        app.SetParameterValue("jana:nskip", 10);
+        app.Run();
+        REQUIRE(sut->open_count == 1);
+        REQUIRE(sut->emit_count == 51);                // GetEvent was called 50 times successfully and failed on the 51st
+        REQUIRE(sut->GetEmittedEventCount() == 40);    // The first 10 were skipped, so only 40 entered the topology
+        REQUIRE(sut->close_count == 1);
+        REQUIRE(sut->finish_event_count == 50);        // FinishEvent() was called for both emitted and skipped events
+        REQUIRE(sut->GetProcessedEventCount() == 40);  // The 40 emitted events were successfully processed
+        REQUIRE(sut->GetSkippedEventCount() == 10);    // The first 10 events were skipped, out of 50 total
+    }
+}
 

--- a/src/programs/unit_tests/Components/JEventSourceTests.cc
+++ b/src/programs/unit_tests/Components/JEventSourceTests.cc
@@ -58,7 +58,7 @@ TEST_CASE("JEventSource_ExpertMode_EmitCount") {
         REQUIRE(sut->GetEmittedEventCount() == 5);  // Emits 5 events successfully
         REQUIRE(sut->close_count == 1);
         REQUIRE(sut->finish_event_count == 5);  // All emitted events were finished
-        REQUIRE(sut->GetFinishedEventCount() == 5); // This is reflected in the finished count
+        REQUIRE(sut->GetProcessedEventCount() == 5); // This is reflected in the finished count
     }
 
     SECTION("LimitedByNEvents") {
@@ -77,12 +77,12 @@ TEST_CASE("JEventSource_ExpertMode_EmitCount") {
         app.SetParameterValue("jana:nskip", 3);
         app.Run();
         REQUIRE(sut->open_count == 1);
-        REQUIRE(sut->emit_count == 6);        // Emit called 5 times successfully and fails on the 6th
-        REQUIRE(sut->GetEmittedEventCount() == 5);   // 5 events successfully emitted, 3 of which were (presumably) skipped
+        REQUIRE(sut->emit_count == 6);                // Emit was called 5 times successfully and failed on the 6th
+        REQUIRE(sut->GetEmittedEventCount() == 2);    // The first 3 were skipped, so only 2 entered the topology
         REQUIRE(sut->close_count == 1);
-        REQUIRE(sut->finish_event_count == 2);        // TODO: Should be 5 because every event that is Emit()ted must be FinishEvent()ted
-        REQUIRE(sut->GetFinishedEventCount() == 2);   // Only two events were successfully processed, the rest were skipped
-        REQUIRE(sut->GetSkippedEventCount() == 3);    // First 3 events skipped out of 5 total
+        REQUIRE(sut->finish_event_count == 5);        // FinishEvent() was called for both emitted and skipped events
+        REQUIRE(sut->GetProcessedEventCount() == 2);  // The 2 emitted events were both successfully processed
+        REQUIRE(sut->GetSkippedEventCount() == 3);    // The first 3 events were skipped, out of 5 total
     }
 }
 

--- a/src/programs/unit_tests/Components/JEventSourceTests.cc
+++ b/src/programs/unit_tests/Components/JEventSourceTests.cc
@@ -22,11 +22,11 @@ struct MyEventSource : public JEventSource {
     Result Emit(JEvent&) override {
         emit_count++;
         REQUIRE(GetApplication() != nullptr);
-        if (GetEmittedEventCount() >= events_in_file) {
-            LOG_INFO(GetLogger()) << "Emit() called, returning FailureFinished" << LOG_END;
+        if (emit_count > events_in_file) {
+            LOG_INFO(GetLogger()) << "Emit() called, iteration " << emit_count << ", returning FailureFinished" << LOG_END;
             return Result::FailureFinished;
         }
-        LOG_INFO(GetLogger()) << "Emit() called, returning Success" << LOG_END;
+        LOG_INFO(GetLogger()) << "Emit() called, iteration " << emit_count << ", returning Success" << LOG_END;
         return Result::Success;
     }
     void Close() override {
@@ -82,6 +82,7 @@ TEST_CASE("JEventSource_ExpertMode_EmitCount") {
         REQUIRE(sut->close_count == 1);
         REQUIRE(sut->finish_event_count == 2);        // TODO: Should be 5 because every event that is Emit()ted must be FinishEvent()ted
         REQUIRE(sut->GetFinishedEventCount() == 2);   // Only two events were successfully processed, the rest were skipped
+        REQUIRE(sut->GetSkippedEventCount() == 3);    // First 3 events skipped out of 5 total
     }
 }
 

--- a/src/programs/unit_tests/Components/NEventNSkipTests.cc
+++ b/src/programs/unit_tests/Components/NEventNSkipTests.cc
@@ -143,9 +143,9 @@ TEST_CASE("JEventSourceArrow with multiple JEventSources") {
         REQUIRE(source1->close_count == 1);
         REQUIRE(source2->close_count == 1);
         REQUIRE(source3->close_count == 1);
-        REQUIRE(source1->GetEmittedEventCount() == 9);   // 3 dropped, 6 emitted
-        REQUIRE(source2->GetEmittedEventCount() == 12);  // 3 dropped, 9 emitted
-        REQUIRE(source3->GetEmittedEventCount() == 7);   // 3 dropped, 4 emitted
+        REQUIRE(source1->GetEmittedEventCount() == 6);   // 3 dropped, 6 emitted
+        REQUIRE(source2->GetEmittedEventCount() == 9);  // 3 dropped, 9 emitted
+        REQUIRE(source3->GetEmittedEventCount() == 4);   // 3 dropped, 4 emitted
         REQUIRE(app.GetNEventsProcessed() == 19);
     }
 
@@ -171,7 +171,7 @@ TEST_CASE("JEventSourceArrow with multiple JEventSources") {
         REQUIRE(source1->close_count == 1);
         REQUIRE(source2->close_count == 1);
         REQUIRE(source3->close_count == 1);
-        REQUIRE(source1->GetEmittedEventCount() == 6);   // 2 dropped, 4 emitted
+        REQUIRE(source1->GetEmittedEventCount() == 4);   // 2 dropped, 4 emitted
         REQUIRE(source2->GetEmittedEventCount() == 13);  // 13 emitted
         REQUIRE(source3->GetEmittedEventCount() == 4);   // 4 emitted
         REQUIRE(app.GetNEventsProcessed() == 21);


### PR DESCRIPTION
## Background

Issue #421 features a segfault on exit, which was introduced in PR #409 when the behavior of JANA was changed to always clear events upon returning them to the pool. This change had some unexpected consequences that exposed a number of other problems:

1. The segfault was triggered by an infinite recursion triggered by JEventSource::GetObjects() looking for data that was supposed to have been inserted during JEventSource::GetEvent(). Ideally this would throw an exception, as discussed in issue #423. *In this PR, the behavior of JFactory::Create() has been changed so that it will throw an exception any time it attempts to call itself, which handles both the case of GetObjects(), and the case of cyclic JFactory dependencies.*

2. The reason that GetObjects() was looking for data that hadn't been inserted is because of another problem. As discussed in issue #424, JEventSource::FinishEvent() was being called even though JEventSource::GetEvent() had failed. This was because JEvent::Clear() failed to distinguish between successfully emitted events and failed events. *In this PR, the behavior of JEvent::Clear() is changed to account for both cases.*

3. The reason that JEventSource::GetEvent() was "failing" was because of the implementation of NSkip, which would only skip one event on each invocation of JEventSourceArrow::Fire() and then return `ComeBackLater`. As discussed in issue #422, this is substantially slower than skipping all events in turn, and will eventually need to be replaced when support for random-access event sources get added, as discussed in issue #146. A better implementation of NSkip would defer to a user-provided `JEventSource::Skip()` callback, and if that fails, repeatedly call `JEventSource::GetEvent()` using the same JEvent container until there are no remaining events to skip. *This PR changes the behavior of NSkip accordingly, although it does not support user-defined `JEventSource::Skip` callbacks yet.*

4. Each JEventSource maintains an EmittedCount and a FinishedCount. However, as discussed in issue #428, the former number includes skipped events, and the latter count does not. This potentially breaks the barrier event logic, which assumes that EmittedCount does _not_ include skipped events. Furthermore, it won't be compatible with future JEventSource::Skip random access, where skipped events are _never_ read. This PR changes the following behavior:
- JEventSource::GetEmittedEventCount() *never* includes skipped events
- JEventSource::GetSkippedEventCount() always reports the exact number of skipped events, random-access or not
- JEventSource::GetFinishedEventCount() is renamed to JEventSource::GetProcessedEventCount() to make it clear that this is does *not* count the number of times JEventSource::FinishEvent() gets called, which also includes non-random-access skipped events. Instead, it matches up with EmittedEventCount. Skipped events are never Emitted, nor are they ever Processed, regardless of whether they are random-access or not.

5. Even if no events are skipped, there is still a problem because the final call to JEventSource::GetObjects will FailFinished. The event will be cleared, which will spuriously call JEventSource::FinishEvent, which will look for data that was meant to be inserted, and when it can't find it, it will call GetObjects(), triggering the infinite recursion and ultimate segfault.

## Remaining work
- This PR does NOT fully implement a user-definable JEventSource::Skip for random access. A Skip() callback is now present, but not in its final form: Currently, it has a JEvent() as a parameter. The final version should move the current Skip() into DoSkip() and provide `virtual size_t JEventSource::Skip(size_t skip_count)` as a user callback controlled by `JEventSource::EnableSkip()`. 

- Barrier events perform a pipeline flush so that a JANA component can safely update some global state. Because barrier events don't define intervals of validity for each piece of state they modify (unlike JResources), they must always be emitted in order, even when the surrounding non-barrier events are skipped. This also prevents the random-access JEventSource::Skip() from being safe to use when barrier events are present in the event stream. JANA2 does not currently account for this.