### PR TITLE
Bugfix: Useful error message when event source is missing

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -1,0 +1,16 @@
+
+# Behavior specification
+
+## Introduction
+
+## Initialization
+If no `JEventSources` are present in the processing topology, `JApplication::Initialize()` will still succeed, and all present components will be initialized.
+
+## Execution
+If no `JEventSources` are present in the processing topology, `JExecutionEngine::Run()` will immediately throw a detailed `JException`. This will terminate `JApplication::Run()` and cause `JMain::Execute()` to exit the program.
+
+
+## Finalization
+
+
+

--- a/src/libraries/JANA/Engine/JExecutionEngine.cc
+++ b/src/libraries/JANA/Engine/JExecutionEngine.cc
@@ -78,6 +78,9 @@ void JExecutionEngine::RunTopology() {
     if (m_runstatus == RunStatus::Finished) {
         throw JException("Cannot switch topology runstatus to Running because it is already Finished");
     }
+    if (m_arrow_states.size() == 0) {
+        throw JException("Cannot execute an empty topology! Hint: Have you provided an event source?");
+    }
 
     // Set start time and event count
     m_time_at_start = clock_t::now();
@@ -106,6 +109,12 @@ void JExecutionEngine::ScaleWorkers(size_t nthreads) {
     // an external thread team, should the need arise.
 
     std::unique_lock<std::mutex> lock(m_mutex);
+
+    if (nthreads != 0 && m_arrow_states.size() == 0) {
+        // We check that (nthreads != 0) because this gets called at shutdown even if the topology wasn't run
+        // Remember, we want JApplication::Initialize() to succeed and JMain to shut down cleanly even when the topology is empty
+        throw JException("Cannot execute an empty topology! Hint: Have you provided an event source?");
+    }
 
     auto prev_nthreads = m_worker_states.size();
 

--- a/src/libraries/JANA/JEventSource.cc
+++ b/src/libraries/JANA/JEventSource.cc
@@ -238,7 +238,6 @@ std::pair<JEventSource::Result, size_t> JEventSource::Skip(JEvent& event, size_t
 
     // Return values
     Result result = Result::Success;
-    size_t events_skipped = 0;
 
     while (events_to_skip > 0 && result == Result::Success) {
         try {
@@ -256,7 +255,6 @@ std::pair<JEventSource::Result, size_t> JEventSource::Skip(JEvent& event, size_t
                 CallWithJExceptionWrapper("JEventSource::FinishEvent", [&](){ FinishEvent(event); });
             }
             event.Clear(false);
-            events_skipped += 1;
             events_to_skip -= 1;
         }
         catch (RETURN_STATUS rs) {

--- a/src/programs/unit_tests/Components/JEventSourceTests.cc
+++ b/src/programs/unit_tests/Components/JEventSourceTests.cc
@@ -27,7 +27,7 @@ struct MyEventSource : public JEventSource {
             event.SetSequential(true);
         }
         REQUIRE(GetApplication() != nullptr);
-        if (emit_count > events_in_file) {
+        if (emit_count > (int) events_in_file) {
             LOG_INFO(GetLogger()) << "Emit() called, iteration " << emit_count << ", returning FailureFinished" << LOG_END;
             return Result::FailureFinished;
         }
@@ -40,7 +40,7 @@ struct MyEventSource : public JEventSource {
             event->SetSequential(true);
         }
         REQUIRE(GetApplication() != nullptr);
-        if (emit_count > events_in_file) {
+        if (emit_count > (int) events_in_file) {
             LOG_INFO(GetLogger()) << "GetEvent() called, iteration " << emit_count << ", returning FailureFinished" << LOG_END;
             throw JEventSource::RETURN_STATUS::kNO_MORE_EVENTS;
         }
@@ -51,7 +51,7 @@ struct MyEventSource : public JEventSource {
         LOG_INFO(GetLogger()) << "Close() called" << LOG_END;
         close_count++;
     }
-    void FinishEvent(JEvent& event) override {
+    void FinishEvent(JEvent&) override {
         LOG_INFO(GetLogger()) << "FinishEvent() called" << LOG_END;
         finish_event_count++;
     }

--- a/src/programs/unit_tests/Engine/ScaleTests.cc
+++ b/src/programs/unit_tests/Engine/ScaleTests.cc
@@ -6,6 +6,20 @@
 
 #include "ScaleTests.h"
 
+TEST_CASE("MissingEventSource") {
+    JApplication app;
+    app.Initialize();
+    // Initialize succeeds
+    try {
+        app.Run();
+        // Run() throws
+        REQUIRE(0 == 1);
+    }
+    catch (JException& e) {
+        REQUIRE(e.GetMessage() == "Cannot execute an empty topology! Hint: Have you provided an event source?");
+    }
+}
+
 TEST_CASE("NThreads") {
 
     JApplication app;


### PR DESCRIPTION
This addresses issue #437