### PR TITLE
Fixes and refactoring of Outputs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -22,4 +22,15 @@ Databundles are not required to own their contents -- Podio specifically forbids
 ![UML diagram of JFactory machinery, before and after databundles](_media/databundles.png)
 
 
+### Component inputs and outputs
+
+Components may inherit from JHasInputs and/or JHasOutputs. Specifically: JMultifactories, unfolders, and folders inherit from both, (old) JFactories and processors only inherit from JHasInputs, and eventually sources will inherit from HasOutputs. These enable the component writer to declare inputs and outputs respectively, bypassing the (old) JEvent interface.
+
+Different flavors of inputs and outputs are provided. Each input or output is either single (i.e. it corresponds to exactly one databundle) or variadic (i.e. it corresponds to a list of databundles all of the same type and event level). This abstraction allows the component to be externally wired (e.g. by using JOmniFactoryGenerator or JWiredFactoryGenerator). To configure these inputs, the caller needs to provide:
+
+- A vector of databundle names for the single inputs/outputs, assigned in declaration order.
+- A vector of vectors of databundle names for the variadic inputs/outputs, assigned in declaration order.
+
+
+
 

--- a/src/examples/misc/EventGroupExample/BlockingGroupedEventSource.h
+++ b/src/examples/misc/EventGroupExample/BlockingGroupedEventSource.h
@@ -69,8 +69,8 @@ public:
         event.Insert(next_event.second); // JEventGroup
 
         // Tell JANA not to assume ownership of these objects!
-        event.GetFactory<TridasEvent>()->SetFactoryFlag(JFactory::JFactory_Flags_t::NOT_OBJECT_OWNER);
-        event.GetFactory<JEventGroup>()->SetFactoryFlag(JFactory::JFactory_Flags_t::NOT_OBJECT_OWNER);
+        event.GetFactory<TridasEvent>()->SetNotOwnerFlag(true);
+        event.GetFactory<JEventGroup>()->SetNotOwnerFlag(true);
 
         // JANA always needs an event number and a run number, so extract these from the Tridas data somehow
         event.SetEventNumber(next_event.first->event_number);

--- a/src/examples/misc/EventGroupExample/GroupedEventSource.h
+++ b/src/examples/misc/EventGroupExample/GroupedEventSource.h
@@ -38,7 +38,7 @@ public:
 
         current_group->StartEvent();
         event.Insert(current_group);
-        event.GetFactory<JEventGroup>()->SetFactoryFlag(JFactory::JFactory_Flags_t::NOT_OBJECT_OWNER);
+        event.GetFactory<JEventGroup>()->SetNotOwnerFlag(true);
         event.SetEventNumber(++m_current_event_number);
         event.SetRunNumber(m_current_group_id);
 

--- a/src/libraries/JANA/Components/JDatabundle.h
+++ b/src/libraries/JANA/Components/JDatabundle.h
@@ -26,7 +26,8 @@ private:
     // Fields
     Status m_status = Status::Empty;
     std::string m_unique_name;
-    //std::optional<std::string> m_short_name;
+    std::string m_short_name;
+    bool m_has_short_name = true;
     std::string m_type_name;
     JFactory* m_factory = nullptr;
     //std::optional<std::type_index> m_inner_type_index;
@@ -46,7 +47,8 @@ public:
     // Getters
     Status GetStatus() const { return m_status; }
     std::string GetUniqueName() const { return m_unique_name; }
-    //std::optional<std::string> GetShortName() const { return m_short_name; }
+    std::string GetShortName() const { return m_short_name; }
+    bool HasShortName() const { return m_has_short_name; }
     std::string GetTypeName() const { return m_type_name; }
     //std::optional<std::type_index> GetTypeIndex() const { return m_inner_type_index; }
     JCallGraphRecorder::JDataOrigin GetInsertOrigin() const { return m_insert_origin; } ///< If objects were placed here by JEvent::Insert() this records whether that call was made from a source or factory.
@@ -54,8 +56,17 @@ public:
 
     // Setters
     void SetStatus(Status s) { m_status = s;}
-    void SetUniqueName(std::string unique_name) { m_unique_name = unique_name; }
-    //void SetShortName(std::string short_name) { m_short_name = short_name; }
+    void SetUniqueName(std::string unique_name) { m_unique_name = unique_name; m_has_short_name = false; }
+    void SetShortName(std::string short_name) {
+        m_short_name = short_name;
+        if (m_short_name.empty()) {
+            m_unique_name = m_type_name;
+        }
+        else {
+            m_unique_name = m_type_name + ":" + short_name;
+        }
+        m_has_short_name = true;
+    }
     void SetTypeName(std::string type_name) { m_type_name = type_name; }
     void SetInsertOrigin(JCallGraphRecorder::JDataOrigin origin) { m_insert_origin = origin; } ///< Called automatically by JEvent::Insert() to records whether that call was made by a source or factory.
     void SetFactory(JFactory* fac) { m_factory = fac; }

--- a/src/libraries/JANA/Components/JDatabundle.h
+++ b/src/libraries/JANA/Components/JDatabundle.h
@@ -32,6 +32,7 @@ private:
     //std::optional<std::type_index> m_inner_type_index;
     mutable JCallGraphRecorder::JDataOrigin m_insert_origin = JCallGraphRecorder::ORIGIN_NOT_AVAILABLE;
 
+
 protected:
     std::unordered_map<std::type_index, std::unique_ptr<JAny>> mUpcastVTable;
 

--- a/src/libraries/JANA/Components/JHasDatabundleOutputs.h
+++ b/src/libraries/JANA/Components/JHasDatabundleOutputs.h
@@ -1,9 +1,10 @@
 
 #pragma once
 #include <JANA/Components/JDatabundle.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <memory>
 
-class JEvent;
+class JFactorySet;
 
 namespace jana::components {
 
@@ -11,12 +12,13 @@ namespace jana::components {
 class JHasDatabundleOutputs {
 public:
     struct OutputBase {
-    protected:
-        std::vector<std::unique_ptr<JDatabundle>> m_databundles;
-        bool m_is_variadic = false;
-    public:
-        const std::vector<std::unique_ptr<JDatabundle>>& GetDatabundles() const { return m_databundles; }
-        virtual void StoreData(const JEvent& event) = 0;
+        std::string type_name;
+        std::vector<std::string> databundle_names;
+        std::vector<std::unique_ptr<JDatabundle>> databundles;
+        JEventLevel level = JEventLevel::None;
+        bool is_variadic = false;
+
+        virtual void StoreData(const JFactorySet& facset) = 0;
         virtual void Reset() = 0;
     };
 

--- a/src/libraries/JANA/Components/JHasDatabundleOutputs.h
+++ b/src/libraries/JANA/Components/JHasDatabundleOutputs.h
@@ -12,11 +12,14 @@ namespace jana::components {
 class JHasDatabundleOutputs {
 public:
     struct OutputBase {
+    public:
         std::string type_name;
         std::vector<std::string> databundle_names;
         std::vector<JDatabundle*> databundles;
         JEventLevel level = JEventLevel::None;
         bool is_variadic = false;
+
+        const std::vector<JDatabundle*>& GetDatabundles() { return databundles; }
 
         virtual void StoreData(const JFactorySet&) = 0;
         virtual void Reset() = 0;
@@ -26,6 +29,7 @@ private:
     std::vector<OutputBase*> m_databundle_outputs;
 
 public:
+
     const std::vector<OutputBase*>& GetDatabundleOutputs() const {
         return m_databundle_outputs;
     }

--- a/src/libraries/JANA/Components/JHasDatabundleOutputs.h
+++ b/src/libraries/JANA/Components/JHasDatabundleOutputs.h
@@ -14,11 +14,11 @@ public:
     struct OutputBase {
         std::string type_name;
         std::vector<std::string> databundle_names;
-        std::vector<std::unique_ptr<JDatabundle>> databundles;
+        std::vector<JDatabundle*> databundles;
         JEventLevel level = JEventLevel::None;
         bool is_variadic = false;
 
-        virtual void StoreData(const JFactorySet& facset) = 0;
+        virtual void StoreData(const JFactorySet&) = 0;
         virtual void Reset() = 0;
     };
 

--- a/src/libraries/JANA/Components/JHasOutputs.h
+++ b/src/libraries/JANA/Components/JHasOutputs.h
@@ -14,10 +14,13 @@ namespace jana::components {
 
 
 struct JHasOutputs {
-protected:
+public:
     struct OutputBase;
+
+protected:
     std::vector<OutputBase*> m_outputs;
 
+public:
     void RegisterOutput(OutputBase* output) {
         m_outputs.push_back(output);
     }

--- a/src/libraries/JANA/Components/JHasOutputs.h
+++ b/src/libraries/JANA/Components/JHasOutputs.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "JANA/Components/JComponentSummary.h"
+#include "JANA/Utils/JEventLevel.h"
 #include <JANA/JEvent.h>
 #include <JANA/JMultifactory.h>
 
@@ -23,6 +25,7 @@ protected:
     struct OutputBase {
         std::string type_name;
         std::vector<std::string> collection_names;
+        JEventLevel level = JEventLevel::None;
         bool is_variadic = false;
 
         virtual void CreateHelperFactory(JMultifactory& fac) = 0;
@@ -174,6 +177,32 @@ protected:
         }
     };
 #endif
+
+
+    void WireOutputs(JEventLevel component_level, const std::vector<std::string>& single_output_databundle_names, const std::vector<std::vector<std::string>>& variadic_output_databundle_names) {
+        size_t single_output_index = 0;
+        size_t variadic_output_index = 0;
+
+        for (auto* output : m_outputs) {
+            output->collection_names.clear();
+            output->level = component_level;
+            if (output->is_variadic) {
+                output->collection_names = variadic_output_databundle_names.at(variadic_output_index++);
+            }
+            else {
+                output->collection_names.push_back(single_output_databundle_names.at(single_output_index++));
+            }
+        }
+    }
+
+    void SummarizeOutputs(JComponentSummary::Component& summary) const {
+        for (const auto* output : m_outputs) {
+            size_t suboutput_count = output->collection_names.size();
+            for (size_t i=0; i<suboutput_count; ++i) {
+                summary.AddOutput(new JComponentSummary::Collection("", output->collection_names[i], output->type_name, output->level));
+            }
+        }
+    }
 
 };
 

--- a/src/libraries/JANA/Components/JHasOutputs.h
+++ b/src/libraries/JANA/Components/JHasOutputs.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <JANA/JEvent.h>
+#include <JANA/JMultifactory.h>
 
 namespace jana::components {
 
@@ -24,6 +25,8 @@ protected:
         std::vector<std::string> collection_names;
         bool is_variadic = false;
 
+        virtual void CreateHelperFactory(JMultifactory& fac) = 0;
+        virtual void SetCollection(JMultifactory& fac) = 0;
         virtual void InsertCollection(JEvent& event) = 0;
         virtual void Reset() = 0;
     };
@@ -50,6 +53,15 @@ protected:
         void SetNotOwnerFlag(bool not_owner=true) { is_not_owner = not_owner; }
 
     protected:
+
+        void CreateHelperFactory(JMultifactory& fac) override {
+            fac.DeclareOutput<T>(this->collection_names[0]);
+        }
+
+        void SetCollection(JMultifactory& fac) override {
+            fac.SetData<T>(this->collection_names[0], this->m_data);
+        }
+
         void InsertCollection(JEvent& event) override {
             auto fac = event.Insert(m_data, this->collection_names[0]);
             fac->SetNotOwnerFlag(is_not_owner);
@@ -81,9 +93,23 @@ protected:
         }
 
     protected:
+
+        void CreateHelperFactory(JMultifactory& fac) override {
+            fac.DeclarePodioOutput<PodioT>(this->collection_names[0]);
+        }
+
+        void SetCollection(JMultifactory& fac) override {
+            if (m_data == nullptr) {
+                throw JException("JOmniFactory: SetCollection failed due to missing output collection '%s'", this->collection_names[0].c_str());
+                // Otherwise this leads to a PODIO segfault
+            }
+            fac.SetCollection<PodioT>(this->collection_names[0], std::move(this->m_data));
+        }
+
         void InsertCollection(JEvent& event) override {
             event.InsertCollection<PodioT>(std::move(*m_data), this->collection_names[0]);
         }
+
         void Reset() override {
             m_data = std::move(std::make_unique<typename PodioT::collection_type>());
         }
@@ -111,6 +137,24 @@ protected:
         }
 
     protected:
+
+        void CreateHelperFactory(JMultifactory& fac) override {
+            for (auto& coll_name : this->collection_names) {
+                fac.DeclarePodioOutput<PodioT>(coll_name);
+            }
+        }
+
+        void SetCollection(JMultifactory& fac) override {
+            if (m_data.size() != this->collection_names.size()) {
+                throw JException("JOmniFactory: VariadicPodioOutput SetCollection failed: Declared %d collections, but provided %d.", this->collection_names.size(), m_data.size());
+                // Otherwise this leads to a PODIO segfault
+            }
+            size_t i = 0;
+            for (auto& coll_name : this->collection_names) {
+                fac.SetCollection<PodioT>(coll_name, std::move(this->m_data[i++]));
+            }
+        }
+
         void InsertCollection(JEvent& event) override {
             if (m_data.size() != this->collection_names.size()) {
                 throw JException("VariadicPodioOutput InsertCollection failed: Declared %d collections, but provided %d.", this->collection_names.size(), m_data.size());

--- a/src/libraries/JANA/Components/JLightweightDatabundle.h
+++ b/src/libraries/JANA/Components/JLightweightDatabundle.h
@@ -37,7 +37,7 @@ private:
 public:
     JLightweightDatabundleT();
     void ClearData() override;
-    size_t GetSize() const override { return m_data.size();}
+    size_t GetSize() const override { return m_data->size();}
 
     std::vector<T*>& GetData() { return m_data; }
 
@@ -82,7 +82,7 @@ void JLightweightDatabundleT<T>::ClearData() {
     if (!GetNotOwnerFlag()) {
         for (auto p : m_data) delete p;
     }
-    m_data.clear();
+    m_data->clear();
     SetStatus(Status::Empty);
 }
 

--- a/src/libraries/JANA/Components/JLightweightDatabundle.h
+++ b/src/libraries/JANA/Components/JLightweightDatabundle.h
@@ -5,7 +5,7 @@
 #include <JANA/JObject.h> 
 #include <JANA/Utils/JTypeInfo.h>
 
-#ifdef JANA2_HAVE_ROOT
+#if JANA2_HAVE_ROOT
 #include <TObject.h>
 #endif
 
@@ -50,7 +50,7 @@ JLightweightDatabundleT<T>::JLightweightDatabundleT() {
     SetTypeName(JTypeInfo::demangle<T>());
     EnableGetAs<T>();
     EnableGetAs<JObject>( std::is_convertible<T,JObject>() ); // Automatically add JObject if this can be converted to it
-#ifdef JANA2_HAVE_ROOT
+#if JANA2_HAVE_ROOT
     EnableGetAs<TObject>( std::is_convertible<T,TObject>() ); // Automatically add TObject if this can be converted to it
 #endif
 }

--- a/src/libraries/JANA/Components/JLightweightDatabundle.h
+++ b/src/libraries/JANA/Components/JLightweightDatabundle.h
@@ -9,38 +9,27 @@
 #include <TObject.h>
 #endif
 
-class JLightweightDatabundle : public JDatabundle {
-    bool m_is_persistent = false;
-    bool m_not_object_owner = false;
-    bool m_write_to_output = true;
-
-public:
-    JLightweightDatabundle() = default;
-    ~JLightweightDatabundle() override = default;
-    void SetPersistentFlag(bool persistent) { m_is_persistent = persistent; }
-    void SetNotOwnerFlag(bool not_owner) { m_not_object_owner = not_owner; }
-    void SetWriteToOutputFlag(bool write_to_output) { m_write_to_output = write_to_output; }
-
-    bool GetPersistentFlag() { return m_is_persistent; }
-    bool GetNotOwnerFlag() { return m_not_object_owner; }
-    bool GetWriteToOutputFlag() { return m_write_to_output; }
-};
-
-
-
 template <typename T>
-class JLightweightDatabundleT : public JLightweightDatabundle {
+class JLightweightDatabundleT : public JDatabundle {
 private:
     std::vector<T*>* m_data = nullptr;
     bool m_is_owned = false;
+    bool m_is_persistent = false;
+    bool m_not_object_owner = false;
 
 public:
     JLightweightDatabundleT();
     void AttachData(std::vector<T*>* data) { m_data = data; }
     void ClearData() override;
-    size_t GetSize() const override { return m_data->size();}
 
+    size_t GetSize() const override { return m_data->size();}
     std::vector<T*>& GetData() { return *m_data; }
+
+    void SetPersistentFlag(bool persistent) { m_is_persistent = persistent; }
+    void SetNotOwnerFlag(bool not_owner) { m_not_object_owner = not_owner; }
+
+    bool GetPersistentFlag() { return m_is_persistent; }
+    bool GetNotOwnerFlag() { return m_not_object_owner; }
 
     /// EnableGetAs generates a vtable entry so that users may extract the
     /// contents of this JFactoryT from the type-erased JFactory. The user has to manually specify which upcasts

--- a/src/libraries/JANA/Components/JLightweightDatabundle.h
+++ b/src/libraries/JANA/Components/JLightweightDatabundle.h
@@ -36,10 +36,11 @@ private:
 
 public:
     JLightweightDatabundleT();
+    void AttachData(std::vector<T*>* data) { m_data = data; }
     void ClearData() override;
     size_t GetSize() const override { return m_data->size();}
 
-    std::vector<T*>& GetData() { return m_data; }
+    std::vector<T*>& GetData() { return *m_data; }
 
     /// EnableGetAs generates a vtable entry so that users may extract the
     /// contents of this JFactoryT from the type-erased JFactory. The user has to manually specify which upcasts
@@ -80,7 +81,7 @@ void JLightweightDatabundleT<T>::ClearData() {
 
     // Assuming we _are_ the object owner, delete the underlying jobjects
     if (!GetNotOwnerFlag()) {
-        for (auto p : m_data) delete p;
+        for (auto p : *m_data) delete p;
     }
     m_data->clear();
     SetStatus(Status::Empty);
@@ -92,7 +93,7 @@ void JLightweightDatabundleT<T>::EnableGetAs() {
 
     auto upcast_lambda = [this]() {
         std::vector<S*> results;
-        for (auto t : m_data) {
+        for (auto t : *m_data) {
             results.push_back(static_cast<S*>(t));
         }
         return results;

--- a/src/libraries/JANA/Components/JLightweightDatabundle.h
+++ b/src/libraries/JANA/Components/JLightweightDatabundle.h
@@ -58,10 +58,6 @@ JLightweightDatabundleT<T>::JLightweightDatabundleT() {
 template <typename T>
 void JLightweightDatabundleT<T>::ClearData() {
 
-    // ClearData won't do anything if Init() hasn't been called
-    if (GetStatus() == Status::Empty) {
-        return;
-    }
     // ClearData() does nothing if persistent flag is set.
     // User must manually recycle data, e.g. during ChangeRun()
     if (GetPersistentFlag()) {

--- a/src/libraries/JANA/Components/JLightweightOutput.h
+++ b/src/libraries/JANA/Components/JLightweightOutput.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <JANA/Components/JHasDatabundleOutputs.h>
+#include <JANA/Components/JLightweightDatabundle.h>
 #include <JANA/Utils/JTypeInfo.h>
 
 namespace jana::components {
@@ -9,10 +10,18 @@ class Output : public JHasDatabundleOutputs::OutputBase {
     std::vector<T*> m_data;
 
 public:
-    Output(JHasDatabundleOutputs* owner, std::string default_tag_name="") {
+    Output(JHasDatabundleOutputs* owner, std::string short_name="") {
         owner->RegisterOutput(this);
-        this->databundle_names.push_back(default_tag_name);
+        this->databundle_names.push_back(short_name);
         this->type_name = JTypeInfo::demangle<T>();
+        auto databundle = new JLightweightDatabundleT<T>();
+        databundle->SetTypeName(this->type_name);
+        std::string unique_name = short_name.empty() ? this->type_name : this->type_name + ":" + short_name;
+        databundle->SetUniqueName(unique_name);
+        this->databundles.push_back(databundle);
+        // Factory will be set by JFactorySet, not here
+
+        // TODO: Factory flags need to propagate from Output to JLightweightDatabundle
     }
 
     std::vector<T*>& operator()() { return m_data; }

--- a/src/libraries/JANA/Components/JLightweightOutput.h
+++ b/src/libraries/JANA/Components/JLightweightOutput.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <JANA/Components/JHasDatabundleOutputs.h>
-#include <JANA/JEvent.h>
+#include <JANA/Utils/JTypeInfo.h>
 
 namespace jana::components {
 
@@ -11,16 +11,16 @@ class Output : public JHasDatabundleOutputs::OutputBase {
 public:
     Output(JHasDatabundleOutputs* owner, std::string default_tag_name="") {
         owner->RegisterOutput(this);
-        this->collection_names.push_back(default_tag_name);
+        this->databundle_names.push_back(default_tag_name);
         this->type_name = JTypeInfo::demangle<T>();
     }
 
     std::vector<T*>& operator()() { return m_data; }
 
-protected:
-    void PutCollections(const JEvent& event) override {
-        event.Insert(m_data, this->collection_names[0]);
+    void StoreData(const JFactorySet&) override {
+    //    event.Insert(m_data, this->collection_names[0]);
     }
+
     void Reset() override { }
 };
 

--- a/src/libraries/JANA/Components/JLightweightOutput.h
+++ b/src/libraries/JANA/Components/JLightweightOutput.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "JANA/Components/JDatabundle.h"
 #include <JANA/Components/JHasDatabundleOutputs.h>
 #include <JANA/Components/JLightweightDatabundle.h>
 #include <JANA/Utils/JTypeInfo.h>
@@ -8,23 +9,24 @@ namespace jana::components {
 template <typename T>
 class Output : public JHasDatabundleOutputs::OutputBase {
     std::vector<T*> m_data;
+    JLightweightDatabundleT<T>* m_databundle; // Just so that we have a typed reference
 
 public:
     Output(JHasDatabundleOutputs* owner, std::string short_name="") {
         owner->RegisterOutput(this);
         this->databundle_names.push_back(short_name);
         this->type_name = JTypeInfo::demangle<T>();
-        auto databundle = new JLightweightDatabundleT<T>();
-        databundle->SetTypeName(this->type_name);
+        m_databundle = new JLightweightDatabundleT<T>();
+        m_databundle->SetTypeName(this->type_name);
         std::string unique_name = short_name.empty() ? this->type_name : this->type_name + ":" + short_name;
-        databundle->SetUniqueName(unique_name);
-        this->databundles.push_back(databundle);
+        m_databundle->SetUniqueName(unique_name);
+        this->databundles.push_back(m_databundle);
         // Factory will be set by JFactorySet, not here
-
-        // TODO: Factory flags need to propagate from Output to JLightweightDatabundle
     }
 
     std::vector<T*>& operator()() { return m_data; }
+
+    JLightweightDatabundleT<T>& GetDatabundle() { return *m_databundle; }
 
     void StoreData(const JFactorySet&) override {
     //    event.Insert(m_data, this->collection_names[0]);

--- a/src/libraries/JANA/Components/JLightweightOutput.h
+++ b/src/libraries/JANA/Components/JLightweightOutput.h
@@ -14,19 +14,33 @@ class Output : public JHasDatabundleOutputs::OutputBase {
 public:
     Output(JHasDatabundleOutputs* owner, std::string short_name="") {
         owner->RegisterOutput(this);
-        this->databundle_names.push_back(short_name);
         this->type_name = JTypeInfo::demangle<T>();
         m_databundle = new JLightweightDatabundleT<T>();
         m_databundle->SetTypeName(this->type_name);
         std::string unique_name = short_name.empty() ? this->type_name : this->type_name + ":" + short_name;
-        m_databundle->SetUniqueName(unique_name);
+        this->databundle_names.push_back(unique_name);
+        m_databundle->SetShortName(short_name);
         this->databundles.push_back(m_databundle);
         // Factory will be set by JFactorySet, not here
+    }
+
+    void SetShortName(std::string short_name) {
+        this->databundle_names.clear();
+        auto unique_name = type_name + ":" + short_name;
+        this->databundle_names.push_back(unique_name);
+        m_databundle->SetShortName(short_name);
+    }
+
+    void SetUniqueName(std::string unique_name) {
+        this->databundle_names.clear();
+        this->databundle_names.push_back(unique_name);
+        m_databundle->SetUniqueName(unique_name);
     }
 
     std::vector<T*>& operator()() { return m_data; }
 
     JLightweightDatabundleT<T>& GetDatabundle() { return *m_databundle; }
+
 
     void StoreData(const JFactorySet&) override {
     //    event.Insert(m_data, this->collection_names[0]);

--- a/src/libraries/JANA/Components/JOmniFactory.h
+++ b/src/libraries/JANA/Components/JOmniFactory.h
@@ -202,7 +202,8 @@ public:
                         std::vector<JEventLevel> input_collection_levels,
                         std::vector<std::vector<std::string>> variadic_input_collection_names,
                         std::vector<JEventLevel> variadic_input_collection_levels, 
-                        std::vector<std::string> output_collection_names
+                        std::vector<std::string> output_collection_names,
+                        std::vector<std::vector<std::string>> variadic_output_collection_names
                         ) {
 
         m_prefix = (this->GetPluginName().empty()) ? tag : this->GetPluginName() + ":" + tag;
@@ -246,26 +247,16 @@ public:
             i += 1;
         }
 
-        // Figure out variadic outputs
-        size_t variadic_output_count = 0;
-        for (auto* output : m_outputs) {
-            if (output->is_variadic) {
-               variadic_output_count += 1;
-            }
-        }
-        size_t variadic_output_collection_count = FindVariadicCollectionCount(m_outputs.size(), variadic_output_count, output_collection_names.size(), false);
+        size_t single_output_index = 0;
+        size_t variadic_output_index = 0;
 
-        // Set output collection names and create corresponding helper factories
-        i = 0;
         for (auto* output : m_outputs) {
             output->collection_names.clear();
             if (output->is_variadic) {
-                for (size_t j = 0; j<(variadic_output_collection_count/variadic_output_count); ++j) {
-                    output->collection_names.push_back(output_collection_names[i++]);
-                }
+                output->collection_names = variadic_output_collection_names.at(variadic_output_index++);
             }
             else {
-                output->collection_names.push_back(output_collection_names[i++]);
+                output->collection_names.push_back(output_collection_names.at(single_output_index++));
             }
             output->CreateHelperFactory(*this);
         }

--- a/src/libraries/JANA/Components/JOmniFactoryGeneratorT.h
+++ b/src/libraries/JANA/Components/JOmniFactoryGeneratorT.h
@@ -23,6 +23,7 @@ public:
         std::vector<std::vector<std::string>> variadic_input_names = {};
         std::vector<JEventLevel> variadic_input_levels = {};
         std::vector<std::string> output_names = {};
+        std::vector<std::vector<std::string>> variadic_output_names = {};
         FactoryConfigType configs = {}; /// Must be copyable!
     };
 
@@ -95,8 +96,9 @@ public:
             // Set up all of the wiring prereqs so that Init() can do its thing
             // Specifically, it needs valid input/output tags, a valid logger, and
             // valid default values in its Config object
-            factory->PreInit(wiring.tag, wiring.level, wiring.input_names, wiring.input_levels, 
-                             wiring.variadic_input_names, wiring.variadic_input_levels, wiring.output_names);
+            factory->PreInit(wiring.tag, wiring.level, wiring.input_names, wiring.input_levels,
+                             wiring.variadic_input_names, wiring.variadic_input_levels,
+                             wiring.output_names, wiring.variadic_output_names);
 
             // Factory is ready
             factory_set->Add(factory);

--- a/src/libraries/JANA/Components/JPodioDatabundle.h
+++ b/src/libraries/JANA/Components/JPodioDatabundle.h
@@ -23,7 +23,7 @@ public:
 
     virtual void ClearData() override {
         m_collection = nullptr;
-        SetStatus(JDataBundle::Status::Empty);
+        SetStatus(JDatabundle::Status::Empty);
         // Podio clears the data itself when the frame is destroyed.
         // Until then, the collection is immutable.
         //

--- a/src/libraries/JANA/Components/JWiredFactoryGeneratorT.h
+++ b/src/libraries/JANA/Components/JWiredFactoryGeneratorT.h
@@ -51,7 +51,8 @@ public:
                              wiring->input_levels,
                              wiring->variadic_input_names,
                              wiring->variadic_input_levels,
-                             wiring->output_names);
+                             wiring->output_names,
+                             wiring->variadic_output_names);
 
             factory_set->Add(factory);
         }

--- a/src/libraries/JANA/JEventUnfolder.h
+++ b/src/libraries/JANA/JEventUnfolder.h
@@ -146,8 +146,13 @@ public:
                     result = Unfold(parent, child, m_child_number);
                 });
             }
-            for (auto* output : m_outputs) {
-                output->InsertCollection(child);
+            if (result != Result::KeepChildNextParent) {
+                // If the user returns KeepChildNextParent, JANA cannot publish any output databundles (not even empty ones)
+                // because on the next call to Unfold(), podio will throw an exception about inserting the collection twice.
+                // Any data put in an output databundle will be automatically cleared via OutputBase::Reset() before the next Unfold().
+                for (auto* output : m_outputs) {
+                    output->InsertCollection(child);
+                }
             }
             m_child_number += 1;
             if (result == Result::NextChildNextParent || result == Result::KeepChildNextParent) {

--- a/src/libraries/JANA/JFactory.cc
+++ b/src/libraries/JANA/JFactory.cc
@@ -110,6 +110,12 @@ void JFactory::Create(const JEvent& event) {
         CallWithJExceptionWrapper("JFactory::Process", [&](){ Process(event.shared_from_this()); });
         mStatus = Status::Processed;
         mCreationStatus = CreationStatus::Created;
+
+        for (auto* output : GetDatabundleOutputs()) {
+            for (auto* databundle : output->databundles) {
+                databundle->SetStatus(JDatabundle::Status::Created);
+            }
+        }
     }
 }
 

--- a/src/libraries/JANA/JFactory.cc
+++ b/src/libraries/JANA/JFactory.cc
@@ -51,7 +51,7 @@ void JFactory::Create(const JEvent& event) {
     // 1. JFactory::Process() if REGENERATE flag is set
     // ---------------------------------------------------------------------
 
-    if (TestFactoryFlag(REGENERATE)) {
+    if (mRegenerate) {
         if (mStatus == Status::Inserted) {
             // Status::Inserted indicates that the data came from either src->GetObjects() or evt->Insert()
             ClearData(); 

--- a/src/libraries/JANA/JFactory.h
+++ b/src/libraries/JANA/JFactory.h
@@ -38,18 +38,19 @@ public:
         REGENERATE = 0x08        // Replaces JANA1 JFactory_base::use_factory and JFactory::GetCheckSourceFirst()
     };
 
-    JFactory(std::string aName, std::string aTag = "")
-    : mObjectName(std::move(aName)), 
-      mTag(std::move(aTag)), 
-      mStatus(Status::Uninitialized) {
-          SetPrefix(aTag.empty() ? mObjectName : mObjectName + ":" + mTag);
-    };
-
+    JFactory() = default;
     virtual ~JFactory() = default;
 
+    std::string GetTag() const { 
+        auto& db = GetDatabundleOutputs().at(0)->GetDatabundles().at(0);
+        if (db->HasShortName()) {
+            return db->GetShortName();
+        }
+        return db->GetUniqueName();
+    }
 
-    std::string GetTag() const { return mTag; }
-    std::string GetObjectName() const { return mObjectName; }
+    std::string GetObjectName() const { return GetDatabundleOutputs().at(0)->GetDatabundles().at(0)->GetTypeName(); }
+
     std::string GetFactoryName() const { return m_type_name; }
     Status GetStatus() const { return mStatus; }
     CreationStatus GetCreationStatus() const { return mCreationStatus; }
@@ -57,11 +58,7 @@ public:
 
     uint32_t GetPreviousRunNumber(void) const { return mPreviousRunNumber; }
 
-
-    void SetTag(std::string tag) { mTag = std::move(tag); }
-    void SetObjectName(std::string objectName) { mObjectName = std::move(objectName); }
     void SetFactoryName(std::string factoryName) { SetTypeName(factoryName); }
-
     void SetStatus(Status status){ mStatus = status; }
     void SetCreationStatus(CreationStatus status){ mCreationStatus = status; }
     void SetInsertOrigin(JCallGraphRecorder::JDataOrigin origin) { m_insert_origin = origin; } ///< Called automatically by JEvent::Insert() to records whether that call was made by a source or factory.
@@ -134,8 +131,6 @@ public:
 
 protected:
 
-    std::string mObjectName;
-    std::string mTag;
     bool mRegenerate = false;
     bool mWriteToOutput = true;
     int32_t mPreviousRunNumber = -1;

--- a/src/libraries/JANA/JFactory.h
+++ b/src/libraries/JANA/JFactory.h
@@ -68,56 +68,9 @@ public:
 
     void SetPreviousRunNumber(uint32_t aRunNumber) { mPreviousRunNumber = aRunNumber; }
 
-    // Note: JFactory_Flags_t is going to be deprecated. Use Set...Flag()s instead
-    /// Get all flags in the form of a single word
-    inline uint32_t GetFactoryFlags() const { return mFlags; }
-
-    /// Set a flag (or flags)
-    inline void SetFactoryFlag(JFactory_Flags_t f) {
-        mFlags |= (uint32_t) f;
-    }
-
-    /// Clear a flag (or flags)
-    inline void ClearFactoryFlag(JFactory_Flags_t f) {
-        mFlags &= ~(uint32_t) f;
-    }
-
-    /// Test if a flag (or set of flags) is set
-    inline bool TestFactoryFlag(JFactory_Flags_t f) const {
-        return (mFlags & (uint32_t) f) == (uint32_t) f;
-    }
-
-    inline void SetPersistentFlag(bool persistent) { 
-        if (persistent) { 
-            SetFactoryFlag(PERSISTENT); }
-        else { 
-            ClearFactoryFlag(PERSISTENT); }
-    }
-
-    inline void SetNotOwnerFlag(bool not_owner) { 
-        if (not_owner) {
-            SetFactoryFlag(NOT_OBJECT_OWNER); }
-        else { 
-            ClearFactoryFlag(NOT_OBJECT_OWNER); }
-    }
-
-    inline void SetRegenerateFlag(bool regenerate) { 
-        if (regenerate) {
-            SetFactoryFlag(REGENERATE); }
-        else { 
-            ClearFactoryFlag(REGENERATE); }
-    }
-
-    inline void SetWriteToOutputFlag(bool write_to_output) { 
-        if (write_to_output) {
-            SetFactoryFlag(WRITE_TO_OUTPUT); }
-        else {
-            ClearFactoryFlag(WRITE_TO_OUTPUT); }
-    }
-
-    inline bool GetWriteToOutputFlag() { 
-        return TestFactoryFlag(WRITE_TO_OUTPUT);
-    }
+    void SetRegenerateFlag(bool regenerate) { mRegenerate = regenerate; }
+    void SetWriteToOutputFlag(bool write_to_output) { mWriteToOutput = write_to_output; }
+    bool GetWriteToOutputFlag() { return mWriteToOutput; }
 
     /// Get data source value depending on how objects came to be here. (Used mainly by JEvent::Get() )
     inline JCallGraphRecorder::JDataSource GetDataSource() const {
@@ -183,7 +136,8 @@ protected:
 
     std::string mObjectName;
     std::string mTag;
-    uint32_t mFlags = WRITE_TO_OUTPUT;
+    bool mRegenerate = false;
+    bool mWriteToOutput = true;
     int32_t mPreviousRunNumber = -1;
     bool mInsideCreate = false; // Use this to detect cycles in factory dependencies
     std::unordered_map<std::type_index, std::unique_ptr<JAny>> mUpcastVTable;

--- a/src/libraries/JANA/JFactory.h
+++ b/src/libraries/JANA/JFactory.h
@@ -67,6 +67,13 @@ public:
 
     void SetPreviousRunNumber(uint32_t aRunNumber) { mPreviousRunNumber = aRunNumber; }
 
+    virtual void SetFactoryFlag(JFactory_Flags_t f) {
+        switch (f) {
+            case JFactory::REGENERATE: SetRegenerateFlag(false); break;
+            case JFactory::WRITE_TO_OUTPUT: SetWriteToOutputFlag(false); break;
+            default: throw JException("Unsupported factory flag");
+        }
+    };
     void SetRegenerateFlag(bool regenerate) { mRegenerate = regenerate; }
     void SetWriteToOutputFlag(bool write_to_output) { mWriteToOutput = write_to_output; }
     bool GetWriteToOutputFlag() { return mWriteToOutput; }

--- a/src/libraries/JANA/JFactory.h
+++ b/src/libraries/JANA/JFactory.h
@@ -49,7 +49,9 @@ public:
         return db->GetUniqueName();
     }
 
-    std::string GetObjectName() const { return GetDatabundleOutputs().at(0)->GetDatabundles().at(0)->GetTypeName(); }
+    std::string GetObjectName() const { return mObjectName; }
+
+    void SetObjectName(std::string object_name) { mObjectName = object_name; }
 
     std::string GetFactoryName() const { return m_type_name; }
     Status GetStatus() const { return mStatus; }
@@ -136,6 +138,7 @@ protected:
     int32_t mPreviousRunNumber = -1;
     bool mInsideCreate = false; // Use this to detect cycles in factory dependencies
     std::unordered_map<std::type_index, std::unique_ptr<JAny>> mUpcastVTable;
+    std::string mObjectName;
 
     mutable Status mStatus = Status::Uninitialized;
     mutable JCallGraphRecorder::JDataOrigin m_insert_origin = JCallGraphRecorder::ORIGIN_NOT_AVAILABLE; // (see note at top of JCallGraphRecorder.h)

--- a/src/libraries/JANA/JFactorySet.cc
+++ b/src/libraries/JANA/JFactorySet.cc
@@ -246,8 +246,10 @@ void JFactorySet::Clear() {
 
     for (const auto& sFactoryPair : mFactories) {
         auto sFactory = sFactoryPair.second;
-        sFactory->ClearData();
-        // This automatically clears multifactories because their data is stored in helper factories!
+        if (sFactory->GetStatus() != JFactory::Status::Uninitialized) {
+            sFactory->SetStatus(JFactory::Status::Unprocessed);
+            sFactory->SetCreationStatus(JFactory::CreationStatus::NotCreatedYet);
+        }
     }
     for (auto& it : mDatabundlesFromUniqueName) {
         // Clearing is fundamentally an operation on the data bundle, not on the factory itself.

--- a/src/libraries/JANA/JFactorySet.cc
+++ b/src/libraries/JANA/JFactorySet.cc
@@ -123,7 +123,7 @@ bool JFactorySet::Add(JFactory* aFactory)
     mFactoriesFromString[untyped_key] = aFactory;
 
     for (const auto* output : aFactory->GetDatabundleOutputs()) {
-        for (const auto& bundle : output->GetDatabundles()) {
+        for (const auto& bundle : output->databundles) {
             bundle->SetFactory(aFactory);
             Add(bundle.get());
         }

--- a/src/libraries/JANA/JFactorySet.cc
+++ b/src/libraries/JANA/JFactorySet.cc
@@ -248,7 +248,6 @@ void JFactorySet::Clear() {
         // This automatically clears multifactories because their data is stored in helper factories!
     }
     for (auto& it : mDatabundlesFromUniqueName) {
-        // fac->ClearData() only clears JFactoryT's, because that's how it always worked.
         // Clearing is fundamentally an operation on the data bundle, not on the factory itself.
         // Furthermore, "clearing" the factory is misleading because factories can cache arbitrary
         // state inside member variables, and there's no way to clear that.

--- a/src/libraries/JANA/JFactorySet.cc
+++ b/src/libraries/JANA/JFactorySet.cc
@@ -57,7 +57,7 @@ void JFactorySet::Add(JDatabundle* databundle) {
     if (databundle->GetUniqueName().empty()) {
         throw JException("Attempted to add a databundle with no unique_name");
     }
-    LOG << "Added databundle " << databundle->GetUniqueName();
+    LOG << "Added databundle with unique_name=" << databundle->GetUniqueName();
     auto named_result = mDatabundlesFromUniqueName.find(databundle->GetUniqueName());
     if (named_result != std::end(mDatabundlesFromUniqueName)) {
         // Collection is duplicate. Since this almost certainly indicates a user error, and
@@ -92,6 +92,8 @@ bool JFactorySet::Add(JFactory* aFactory)
     /// throw an exception and let the user figure out what to do.
     /// This scenario occurs when the user has multiple JFactory<T> producing the
     /// same T JObject, and is not distinguishing between them via tags.
+    
+    LOG << "Adding JFactory with tag=" << aFactory->GetTag() << " and object name " << aFactory->GetObjectName();
 
     auto typed_key = std::make_pair( aFactory->GetObjectType(), aFactory->GetTag() );
     auto untyped_key = std::make_pair( aFactory->GetObjectName(), aFactory->GetTag() );
@@ -121,8 +123,8 @@ bool JFactorySet::Add(JFactory* aFactory)
     mFactories[typed_key] = aFactory;
     mFactoriesFromString[untyped_key] = aFactory;
 
-    for (const auto* output : aFactory->GetDatabundleOutputs()) {
-        for (const auto& bundle : output->databundles) {
+    for (auto* output : aFactory->GetDatabundleOutputs()) {
+        for (const auto& bundle : output->GetDatabundles()) {
             bundle->SetFactory(aFactory);
             Add(bundle);
         }

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -26,10 +26,8 @@ public:
     using IteratorType = typename std::vector<T*>::const_iterator;
     using PairType = std::pair<IteratorType, IteratorType>;
 
-    JFactoryT(std::string tag="") : JFactory(JTypeInfo::demangle<T>(), tag){
-        auto* main_databundle = mOutput.databundles.at(0);
-        auto* typed_main_databundle = static_cast<JLightweightDatabundleT<T>*>(main_databundle);
-        typed_main_databundle->AttachData(&mData);
+    JFactoryT() {
+        mOutput.GetDatabundle().AttachData(&mData);
 
         EnableGetAs<T>();
         EnableGetAs<JObject>( std::is_convertible<T,JObject>() ); // Automatically add JObject if this can be converted to it
@@ -46,6 +44,8 @@ public:
     void EndRun() override {}
     void Process(const std::shared_ptr<const JEvent>&) override {}
 
+
+    void SetTag(std::string tag) { mOutput.SetShortName(tag); }
 
     std::type_index GetObjectType(void) const override {
         return std::type_index(typeid(T));

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -70,7 +70,7 @@ public:
     }
 
     /// Please use the typed setters instead whenever possible
-    // TODO: Deprecate this!
+    [[deprecated]]
     void Set(const std::vector<JObject*>& aData) override {
         std::vector<T*> data;
         for (auto obj : aData) {
@@ -82,7 +82,7 @@ public:
     }
 
     /// Please use the typed setters instead whenever possible
-    // TODO: Deprecate this!
+    [[deprecated]]
     void Insert(JObject* aDatum) override {
         T* casted = dynamic_cast<T*>(aDatum);
         assert(casted != nullptr);

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -12,6 +12,7 @@
 #include <JANA/JObject.h>
 #include <JANA/JVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
+#include <JANA/Components/JLightweightOutput.h>
 
 #if JANA2_HAVE_ROOT
 #include <TObject.h>
@@ -154,6 +155,7 @@ public:
 
 
 protected:
+    jana::components::Output<T> mOutput {this};
     std::vector<T*> mData;
 };
 

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -128,7 +128,7 @@ public:
     }
 
     /// Set a flag (or flags)
-    inline void SetFactoryFlag(JFactory_Flags_t f) {
+    inline void SetFactoryFlag(JFactory_Flags_t f) override {
         switch (f) {
             case JFactory::PERSISTENT: SetPersistentFlag(true); break;
             case JFactory::NOT_OBJECT_OWNER: SetNotOwnerFlag(true); break;

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -28,6 +28,7 @@ public:
 
     JFactoryT() {
         mOutput.GetDatabundle().AttachData(&mData);
+        SetPrefix(mOutput.GetDatabundle().GetUniqueName());
 
         EnableGetAs<T>();
         EnableGetAs<JObject>( std::is_convertible<T,JObject>() ); // Automatically add JObject if this can be converted to it
@@ -168,9 +169,20 @@ public:
     template <typename S> void EnableGetAs(std::false_type) {}
 
     void ClearData() override {
-        // Data is cleared via JDatabundle::ClearData() now
+        // This is mainly used for test cases now. JFactorySet::Clear directly clears all databundles, 
+        // even those without a corresponding JFactory.
+
+        if (mStatus == Status::Uninitialized) {
+            // ClearData won't do anything if Init() hasn't been called
+            return;
+        }
         mStatus = Status::Unprocessed;
         mCreationStatus = CreationStatus::NotCreatedYet;
+        for (auto* output : GetDatabundleOutputs()) {
+            for (auto* db : output->GetDatabundles()) {
+                db->ClearData();
+            }
+        }
     }
 
 

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -27,6 +27,10 @@ public:
     using PairType = std::pair<IteratorType, IteratorType>;
 
     JFactoryT(std::string tag="") : JFactory(JTypeInfo::demangle<T>(), tag){
+        auto* main_databundle = mOutput.databundles.at(0);
+        auto* typed_main_databundle = static_cast<JLightweightDatabundleT<T>*>(main_databundle);
+        typed_main_databundle->AttachData(&mData);
+
         EnableGetAs<T>();
         EnableGetAs<JObject>( std::is_convertible<T,JObject>() ); // Automatically add JObject if this can be converted to it
 #if JANA2_HAVE_ROOT

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -124,6 +124,37 @@ public:
         mCreationStatus = CreationStatus::Inserted;
     }
 
+    /// Set a flag (or flags)
+    inline void SetFactoryFlag(JFactory_Flags_t f) {
+        switch (f) {
+            case JFactory::PERSISTENT: SetPersistentFlag(true); break;
+            case JFactory::NOT_OBJECT_OWNER: SetNotOwnerFlag(true); break;
+            case JFactory::REGENERATE: SetRegenerateFlag(true); break;
+            case JFactory::WRITE_TO_OUTPUT: SetWriteToOutputFlag(true); break;
+            default: throw JException("Invalid factory flag");
+        }
+    }
+
+    /// Clear a flag (or flags)
+    inline void ClearFactoryFlag(JFactory_Flags_t f) {
+        switch (f) {
+            case JFactory::PERSISTENT: SetPersistentFlag(false); break;
+            case JFactory::NOT_OBJECT_OWNER: SetNotOwnerFlag(false); break;
+            case JFactory::REGENERATE: SetRegenerateFlag(false); break;
+            case JFactory::WRITE_TO_OUTPUT: SetWriteToOutputFlag(false); break;
+            default: throw JException("Invalid factory flag");
+        }
+    }
+
+    inline void SetPersistentFlag(bool persistent) {
+        mOutput.GetDatabundle().SetPersistentFlag(persistent);
+    }
+
+    inline void SetNotOwnerFlag(bool not_owner) {
+        mOutput.GetDatabundle().SetNotOwnerFlag(not_owner);
+    }
+
+
 
     /// EnableGetAs generates a vtable entry so that users may extract the
     /// contents of this JFactoryT from the type-erased JFactory. The user has to manually specify which upcasts
@@ -137,22 +168,7 @@ public:
     template <typename S> void EnableGetAs(std::false_type) {}
 
     void ClearData() override {
-
-        // ClearData won't do anything if Init() hasn't been called
-        if (mStatus == Status::Uninitialized) {
-            return;
-        }
-        // ClearData() does nothing if persistent flag is set.
-        // User must manually recycle data, e.g. during ChangeRun()
-        if (TestFactoryFlag(JFactory_Flags_t::PERSISTENT)) {
-            return;
-        }
-
-        // Assuming we _are_ the object owner, delete the underlying jobjects
-        if (!TestFactoryFlag(JFactory_Flags_t::NOT_OBJECT_OWNER)) {
-            for (auto p : mData) delete p;
-        }
-        mData.clear();
+        // Data is cleared via JDatabundle::ClearData() now
         mStatus = Status::Unprocessed;
         mCreationStatus = CreationStatus::NotCreatedYet;
     }

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -29,6 +29,7 @@ public:
     JFactoryT() {
         mOutput.GetDatabundle().AttachData(&mData);
         SetPrefix(mOutput.GetDatabundle().GetUniqueName());
+        SetObjectName(mOutput.GetDatabundle().GetTypeName());
 
         EnableGetAs<T>();
         EnableGetAs<JObject>( std::is_convertible<T,JObject>() ); // Automatically add JObject if this can be converted to it

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -26,8 +26,9 @@ public:
     using IteratorType = typename std::vector<T*>::const_iterator;
     using PairType = std::pair<IteratorType, IteratorType>;
 
-    JFactoryT() {
+    JFactoryT(std::string tag="") {
         mOutput.GetDatabundle().AttachData(&mData);
+        SetTag(tag);
         SetPrefix(mOutput.GetDatabundle().GetUniqueName());
         SetObjectName(mOutput.GetDatabundle().GetTypeName());
 

--- a/src/libraries/JANA/JMultifactory.h
+++ b/src/libraries/JANA/JMultifactory.h
@@ -141,8 +141,8 @@ public:
 
 template <typename T>
 void JMultifactory::DeclareOutput(std::string tag, bool owns_data) {
-    JFactory* helper = new JMultifactoryHelper<T>(this);
-    if (!owns_data) helper->SetFactoryFlag(JFactory::JFactory_Flags_t::NOT_OBJECT_OWNER);
+    JFactoryT<T>* helper = new JMultifactoryHelper<T>(this);
+    if (!owns_data) helper->SetFactoryFlag(JFactory::NOT_OBJECT_OWNER);
     helper->SetPluginName(m_plugin_name);
     helper->SetFactoryName(GetTypeName()+"::Helper<" + JTypeInfo::demangle<T>() + ">");
     helper->SetTag(std::move(tag));

--- a/src/libraries/JANA/Services/JWiringService.cc
+++ b/src/libraries/JANA/Services/JWiringService.cc
@@ -121,6 +121,18 @@ void JWiringService::AddWirings(const toml::table& table, const std::string& sou
             }
         }
 
+        auto variadic_output_names = f["variadic_output_names"].as_array();
+        if (variadic_output_names != nullptr) {
+            for (const auto& output_name_vec : *variadic_output_names) {
+                std::vector<std::string> temp;
+                for (const auto& output_name : *(output_name_vec.as_array())) {
+                    temp.push_back(output_name.as_string()->get());
+                }
+                wiring->variadic_output_names.push_back(temp);
+            }
+        }
+
+
         auto configs = f["configs"].as_table();
         if (configs != nullptr) {
             for (const auto& config : *configs) {

--- a/src/libraries/JANA/Services/JWiringService.h
+++ b/src/libraries/JANA/Services/JWiringService.h
@@ -27,6 +27,7 @@ public:
         std::vector<JEventLevel> variadic_input_levels;
         std::vector<std::string> output_names;
         std::vector<JEventLevel> output_levels;
+        std::vector<std::vector<std::string>> variadic_output_names;
         std::map<std::string, std::string> configs;
     };
 

--- a/src/libraries/JANA/Utils/JAny.h
+++ b/src/libraries/JANA/Utils/JAny.h
@@ -3,6 +3,7 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
 #pragma once
+#include <utility>
 
 /// Ideally we'd just use std::any, but we are restricted to C++14 for the time being
 struct JAny {

--- a/src/libraries/JANA/Utils/JInspector.cc
+++ b/src/libraries/JANA/Utils/JInspector.cc
@@ -194,8 +194,6 @@ void JInspector::ToText(const JFactory* fac, bool asJson, std::ostream& out) {
         out << "Tag                  " << tag << std::endl;
         out << "Creation status      " << creationStatus << std::endl;
         out << "Object count         " << fac->GetNumObjects() << std::endl;
-        out << "Persistent flag      " << fac->TestFactoryFlag(JFactory::PERSISTENT) << std::endl;
-        out << "NotObjectOwner flag  " << fac->TestFactoryFlag(JFactory::NOT_OBJECT_OWNER) << std::endl;
     }
     else {
         out << "{" << std::endl;
@@ -205,8 +203,6 @@ void JInspector::ToText(const JFactory* fac, bool asJson, std::ostream& out) {
         out << "  \"tag\":           \"" << tag << "\"," << std::endl;
         out << "  \"creation\":      \"" << creationStatus << "\"," << std::endl;
         out << "  \"object_count\":  " << fac->GetNumObjects() << "," << std::endl;
-        out << "  \"persistent\":    " << fac->TestFactoryFlag(JFactory::PERSISTENT) << "," << std::endl;
-        out << "  \"not_obj_owner\": " << fac->TestFactoryFlag(JFactory::NOT_OBJECT_OWNER) << std::endl;
         out << "}" << std::endl;
     }
 }

--- a/src/plugins/janaroot/JEventProcessor_janaroot.cc
+++ b/src/plugins/janaroot/JEventProcessor_janaroot.cc
@@ -175,19 +175,19 @@ void JEventProcessor_janaroot::Process(const std::shared_ptr<const JEvent>& even
 		// exists, the other threads will not have their WRITE_TO_OUTPUT
 		// flags set properly.
 		if(nametags_to_write_out.size()>0){
-			allfactories[i]->ClearFactoryFlag(JFactory::WRITE_TO_OUTPUT);
+			allfactories[i]->SetWriteToOutputFlag(false);
 			// Form nametag for factory to compare to ones listed in config. param.
 			string nametag = allfactories[i]->GetObjectName();
 			string tag = allfactories[i]->GetTag();
 			if(!tag.empty()) nametag += ":" + tag;
 			for(unsigned int j=0; j<nametags_to_write_out.size(); j++){
 				if(nametags_to_write_out[j] == nametag){
-					allfactories[i]->SetFactoryFlag(JFactory::WRITE_TO_OUTPUT);
+					allfactories[i]->SetWriteToOutputFlag(true);
 				}
 			}
 		}
 
-		if(allfactories[i]->TestFactoryFlag(JFactory::WRITE_TO_OUTPUT)) facs.push_back(allfactories[i]);
+		if(allfactories[i]->GetWriteToOutputFlag()) facs.push_back(allfactories[i]);
 	}
 	
 	// Clear all trees' "N" values for this event

--- a/src/programs/unit_tests/CMakeLists.txt
+++ b/src/programs/unit_tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_SOURCES
     Components/GetObjectsTests.cc
     Components/NEventNSkipTests.cc
     Components/JComponentTests.cc
+    Components/JDatabundleTests.cc
     Components/JEventGetAllTests.cc
     Components/JEventProcessorTests.cc
     Components/JEventSourceTests.cc

--- a/src/programs/unit_tests/Components/JDatabundleTests.cc
+++ b/src/programs/unit_tests/Components/JDatabundleTests.cc
@@ -1,0 +1,52 @@
+
+#include "JANA/Components/JDatabundle.h"
+#include "JANA/JApplicationFwd.h"
+#include <catch.hpp>
+#include <JANA/JFactoryT.h>
+#include <JANA/JFactoryGenerator.h>
+#include <JANA/JEvent.h>
+
+namespace jana::databundletests::jfactoryt {
+
+struct Hit { double E; };
+
+class MyFac : public JFactoryT<Hit> {
+    void Process(const std::shared_ptr<const JEvent>&) {
+        mData.push_back(new Hit(22.2));
+    }
+};
+
+TEST_CASE("JDatabundle_JFactoryT") {
+
+    JApplication app;
+    app.Add(new JFactoryGeneratorT<MyFac>);
+    auto event = std::make_shared<JEvent>(&app);
+
+    SECTION("OldMechanism") {
+        auto data = event->Get<Hit>();
+        REQUIRE(data.size() == 1);
+        REQUIRE(data.at(0)->E == 22.2);
+    }
+    SECTION("NewMechanism") {
+
+        auto databundle = event->GetFactorySet()->GetDatabundle("jana::databundletests::jfactoryt::Hit");
+
+        REQUIRE(databundle != nullptr); // Databundle should ALWAYS exist whether factory runs or not
+        REQUIRE(databundle->GetStatus() == JDatabundle::Status::Empty);
+        REQUIRE(databundle->GetFactory() != nullptr);
+
+        databundle->GetFactory()->Create(*event);
+
+        REQUIRE(databundle->GetStatus() == JDatabundle::Status::Created);
+        REQUIRE(databundle->GetSize() == 1);
+
+        auto typed_databundle = dynamic_cast<JLightweightDatabundleT<Hit>*>(databundle);
+
+        REQUIRE(typed_databundle != nullptr);
+        REQUIRE(typed_databundle->GetData().size() == 1);
+        REQUIRE(typed_databundle->GetData().at(0)->E == 22.2);
+    }
+}
+
+}
+

--- a/src/programs/unit_tests/Components/JDatabundleTests.cc
+++ b/src/programs/unit_tests/Components/JDatabundleTests.cc
@@ -12,7 +12,7 @@ struct Hit { double E; };
 
 class MyFac : public JFactoryT<Hit> {
     void Process(const std::shared_ptr<const JEvent>&) {
-        mData.push_back(new Hit(22.2));
+        mData.push_back(new Hit{22.2});
     }
 };
 

--- a/src/programs/unit_tests/Components/UnfoldTests.cc
+++ b/src/programs/unit_tests/Components/UnfoldTests.cc
@@ -3,7 +3,10 @@
 #include <JANA/JEventProcessor.h>
 #include <JANA/Topology/JUnfoldArrow.h>
 #include <JANA/Topology/JFoldArrow.h>
+
+#if JANA2_HAVE_PODIO
 #include <PodioDatamodel/ExampleHitCollection.h>
+#endif
 
 namespace jana {
 namespace unfoldtests {
@@ -200,9 +203,11 @@ TEST_CASE("FoldArrowTests") {
 
 
 class NoOpUnfolder : public JEventUnfolder {
+#if JANA2_HAVE_PODIO
     PodioOutput<ExampleHit> m_hits_out {this}; 
     // We never insert these hits, and that should be fine 
     // because they should never get pushed to the frame
+#endif
 
 public:
     NoOpUnfolder() {

--- a/src/programs/unit_tests/Components/UnfoldTests.cc
+++ b/src/programs/unit_tests/Components/UnfoldTests.cc
@@ -3,6 +3,7 @@
 #include <JANA/JEventProcessor.h>
 #include <JANA/Topology/JUnfoldArrow.h>
 #include <JANA/Topology/JFoldArrow.h>
+#include <PodioDatamodel/ExampleHitCollection.h>
 
 namespace jana {
 namespace unfoldtests {
@@ -199,6 +200,10 @@ TEST_CASE("FoldArrowTests") {
 
 
 class NoOpUnfolder : public JEventUnfolder {
+    PodioOutput<ExampleHit> m_hits_out {this}; 
+    // We never insert these hits, and that should be fine 
+    // because they should never get pushed to the frame
+
 public:
     NoOpUnfolder() {
         SetParentLevel(JEventLevel::Timeslice);
@@ -251,7 +256,7 @@ TEST_CASE("NoOpUnfolder_Tests") {
     app.Run();
 }
 
-    
+
 } // namespace arrowtests
 } // namespace jana
 


### PR DESCRIPTION
## Bugfixes:
- Unfolder inserted outputs even when KeepChildKeepParent returned
- JHasOutputs uses vector<vector<string>> for variadic output names

## Refactoring:
- JOmnifactory uses JHasOutputs
- JFactory inherits from JHasDatabundleOutputs
- JFactoryT uses JLightweightDatabundle
- JFactorySet uses JDatabundle::ClearData