### PR TITLE
Change how Inspector gets launched

### DIFF
--- a/docs/howto/configuration.md
+++ b/docs/howto/configuration.md
@@ -22,6 +22,7 @@ The following configuration options are used most commonly:
 | jana:show_ticker          | bool    | Controls whether the status ticker is shown |
 | jana:ticker_interval          | int     | Controls how often the status ticker updates (in ms)  |
 | autoactivate | string | Triggers JFactories without needing a JEventProcessor. Format is "datatype1:tag1,datatype2:tag2" |
+| jana:inspect | bool | Controls whether to immediately drop into the Inspector |
 
 JANA automatically provides each component with its own logger. You can control the logging verbosity of individual components
 just like any other parameter. For instance, if your component prefixes its parameters with `BCAL:tracking`,

--- a/src/libraries/JANA/CLI/JMain.cc
+++ b/src/libraries/JANA/CLI/JMain.cc
@@ -40,7 +40,6 @@ void PrintUsageOptions() {
     std::cout << "   -l   --loadconfigs <file>          Load configuration parameters from file" << std::endl;
     std::cout << "   -d   --dumpconfigs <file>          Dump configuration parameters to file" << std::endl;
     std::cout << "   -b   --benchmark                   Run in benchmark mode" << std::endl;
-    std::cout << "   -i   --interactive                 Run in interactive mode" << std::endl;
     std::cout << "        --inspect-collection <name>   Inspect a collection" << std::endl;
     std::cout << "        --inspect-component <name>    Inspect a component" << std::endl;
 }
@@ -137,14 +136,6 @@ int Execute(JApplication* app, UserOptions &options) {
             }
         }
     }
-    else if (options.flags[Interactive]) {
-        app->Initialize();
-        app->Inspect();
-        // TODO: Resume and Scale won't work because Inspector calls nonblocking Run()
-        //       Another thing we could do is app->RequestInspection(); app->Run(true);
-        //       as long as we rejigger app->Run() to jump straight to Inspect() when m_inspecting is set
-        //       Or we could wait until we factor out Run() into JSupervisor
-    }
     else if (options.flags[Benchmark]) {
         // Run JANA in benchmark mode
         JBenchmarker benchmarker(app); // Benchmarking params override default params
@@ -192,8 +183,6 @@ UserOptions ParseCommandLineOptions(int nargs, char *argv[], bool expect_extra) 
     tokenizer["--dumpconfigs"] = DumpConfigs;
     tokenizer["-b"] = Benchmark;
     tokenizer["--benchmark"] = Benchmark;
-    tokenizer["-i"] = Interactive;
-    tokenizer["--interactive"] = Interactive;
     tokenizer["--inspect-collection"] = InspectCollection;
     tokenizer["--inspect-component"] = InspectComponent;
 

--- a/src/libraries/JANA/Engine/JExecutionEngine.cc
+++ b/src/libraries/JANA/Engine/JExecutionEngine.cc
@@ -68,6 +68,10 @@ void JExecutionEngine::Init() {
     }
 }
 
+void JExecutionEngine::RequestInspector() {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    m_interrupt_status = InterruptStatus::InspectRequested;
+}
 
 void JExecutionEngine::RunTopology() {
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -214,7 +218,9 @@ void JExecutionEngine::DrainTopology() {
 
 void JExecutionEngine::RunSupervisor() {
 
-    m_interrupt_status = InterruptStatus::NoInterruptsSupervised;
+    if (m_interrupt_status == InterruptStatus::NoInterruptsUnsupervised) {
+        m_interrupt_status = InterruptStatus::NoInterruptsSupervised;
+    }
     size_t last_event_count = 0;
     clock_t::time_point last_measurement_time = clock_t::now();
 

--- a/src/libraries/JANA/Engine/JExecutionEngine.h
+++ b/src/libraries/JANA/Engine/JExecutionEngine.h
@@ -145,6 +145,7 @@ public:
     bool IsTickerEnabled() const;
     void SetTimeoutEnabled(bool timeout_on);
     bool IsTimeoutEnabled() const;
+    void RequestInspector();
 
     void HandleSIGINT();
     void HandleSIGUSR1();

--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -150,6 +150,9 @@ void JApplication::Initialize() {
     }
 
     topology_builder->create_topology();
+
+    m_params->SetDefaultParameter("jana:inspect", m_inspect, "Controls whether to drop immediately into the Inspector upon Run()");
+
     auto execution_engine = m_service_locator->get<JExecutionEngine>();
 
     // Make sure that Init() is called on any remaining JServices
@@ -196,7 +199,12 @@ void JApplication::Run(bool wait_until_stopped, bool finish) {
 
     LOG_WARN(m_logger) << "Starting processing with " << m_desired_nthreads << " threads requested..." << LOG_END;
     m_execution_engine->ScaleWorkers(m_desired_nthreads);
-    m_execution_engine->RunTopology();
+    if (m_inspect) {
+        m_execution_engine->RequestInspector();
+    }
+    else {
+        m_execution_engine->RunTopology();
+    }
 
     if (!wait_until_stopped) {
         return;

--- a/src/libraries/JANA/JApplication.cc
+++ b/src/libraries/JANA/JApplication.cc
@@ -228,13 +228,6 @@ void JApplication::Scale(int nthreads) {
     m_execution_engine->RunTopology();
 }
 
-void JApplication::Inspect() {
-    ::InspectApplication(this);
-    // While we are inside InspectApplication, any SIGINTs will lead to shutdown.
-    // Once we exit InspectApplication, one SIGINT will pause processing and reopen InspectApplication.
-    m_sigint_count = 0; 
-    m_inspecting = false;
-}
 
 void JApplication::Stop(bool wait_until_stopped, bool finish) {
     if (!m_initialized) {

--- a/src/libraries/JANA/JApplicationFwd.h
+++ b/src/libraries/JANA/JApplicationFwd.h
@@ -139,6 +139,7 @@ private:
     std::shared_ptr<JComponentManager> m_component_manager;
     std::shared_ptr<JExecutionEngine> m_execution_engine;
 
+    bool m_inspect = false;
     bool m_inspecting = false;
     bool m_quitting = false;
     bool m_skip_join = false;

--- a/src/libraries/JANA/JApplicationFwd.h
+++ b/src/libraries/JANA/JApplicationFwd.h
@@ -74,7 +74,6 @@ public:
     void Run(bool wait_until_stopped=true, bool finish=true);
     void Scale(int nthreads);
     void Stop(bool wait_until_stopped=false, bool finish=true);
-    void Inspect();
     void Quit(bool skip_join = false);
     void SetExitCode(int exitCode);
     int GetExitCode();
@@ -140,14 +139,12 @@ private:
     std::shared_ptr<JExecutionEngine> m_execution_engine;
 
     bool m_inspect = false;
-    bool m_inspecting = false;
     bool m_quitting = false;
     bool m_skip_join = false;
     std::atomic_bool m_initialized {false};
     std::atomic_bool m_services_available {false};
     int  m_exit_code = (int) ExitCode::Success;
     int  m_desired_nthreads;
-    std::atomic_int m_sigint_count {0};
 
     // For instantaneous rate calculations
     std::mutex m_inst_rate_mutex;


### PR DESCRIPTION
Previously, the Inspector was controlled by a `--interactive` flag on JMain. This has been changed to the parameter `-Pjana:inspect=1` so that the functionality is automatically available regardless of how users parse command line arguments.