### PR TITLE
Small fixes for GlueX

### DIFF
--- a/src/libraries/JANA/JEvent.h
+++ b/src/libraries/JANA/JEvent.h
@@ -199,7 +199,9 @@ JFactoryT<T>* JEvent::GetSingle(const T* &t, const char *tag, bool exception_if_
     Get(v, tag);
     if(v.size()!=1){
         t = NULL;
-        if(exception_if_not_one) throw v.size();
+        if(exception_if_not_one) {
+            throw JException("GetSingle<%s>: Factory has wrong number of items: 1 expected, %d found.", JTypeInfo::demangle<T>().c_str(), v.size());
+        }
     }
     t = v[0];
     return fac;

--- a/src/libraries/JANA/JFactory.cc
+++ b/src/libraries/JANA/JFactory.cc
@@ -25,7 +25,11 @@ void JFactory::Create(const std::shared_ptr<const JEvent>& event) {
 
 void JFactory::Create(const JEvent& event) {
 
-    if (mInsideCreate) {
+    if (mInsideCreate && (mStatus != Status::Inserted)) {
+        // Ideally, we disallow any calls to Create() that end up calling it right back. However, we do allow
+        // calls that go down to GetObjects, who inserts the data, but then RETRIEVES the same data it just inserted,
+        // so that it can subsequently calculate and insert OTHER data. Once we refactor JEventSourceEVIOpp, we can consider
+        // removing this weird edge case.
         throw JException("Encountered a cycle in the factory dependency graph! Hint: Maybe this data was supposed to be inserted in the JEventSource");
     }
     FlagGuard insideCreateFlagGuard (&mInsideCreate); // No matter how we exit from Create() (particularly with exceptions) mInsideCreate will be set back to false

--- a/src/libraries/JANA/JFactoryT.h
+++ b/src/libraries/JANA/JFactoryT.h
@@ -178,6 +178,16 @@ public:
             // ClearData won't do anything if Init() hasn't been called
             return;
         }
+        if (mOutput.GetDatabundle().GetPersistentFlag()) {
+            // Persistence is a property of both the factory AND the databundle
+            // - "Don't re-run this factory on the next event"
+            // - "Don't clear this databundle every time the JEvent gets recycled"
+            // Factory is persistent <=> All databundles are persistent
+            // We ARE allowing databundles to be persistent even if they don't have a JFactory
+            // We don't have a way to enforce this generally yet
+            return;
+        }
+
         mStatus = Status::Unprocessed;
         mCreationStatus = CreationStatus::NotCreatedYet;
         for (auto* output : GetDatabundleOutputs()) {

--- a/src/programs/unit_tests/Components/JEventTests.cc
+++ b/src/programs/unit_tests/Components/JEventTests.cc
@@ -189,6 +189,22 @@ TEST_CASE("JEventInsertTests") {
         REQUIRE(retrieved->datum == first->datum);      // Same contents
         REQUIRE(retrieved == first);                    // Same pointer
     }
+    
+    SECTION("Old-style JEvent::GetSingle throws a JException when factory contains multiple objects") {
+        auto first = new FakeJObject(22);
+        event->Insert(first);
+        event->Insert(new FakeJObject(99));
+        event->Insert(new FakeJObject(42));
+
+        const FakeJObject* retrieved = nullptr;
+        try {
+            event->GetSingle(retrieved, "", true);
+            REQUIRE(1 == 0);
+        }
+        catch(JException& e) {
+            std::cout << e << std::endl;
+        }
+    }
 
     // ---------------
     // GetSingleStrict


### PR DESCRIPTION
- Relax JFactory::Create cycle detector for the sake of JEventSourceEVIOpp
- Improve debugging ergonomics by having JEvent::GetSingle throw a JException instead of a size_t
