### PR TITLE
Bugfix: JFactoryPodioT template instantiation error with LinkCollections

### DIFF
--- a/src/libraries/JANA/Podio/JFactoryPodioT.h
+++ b/src/libraries/JANA/Podio/JFactoryPodioT.h
@@ -63,7 +63,6 @@ public:
     void SetCollection(std::unique_ptr<CollectionT> collection);
     void Set(const std::vector<T*>& aData) final;
     void Set(std::vector<T*>&& aData) final;
-    void Insert(T* aDatum) final;
 
 
 
@@ -202,15 +201,6 @@ void JFactoryPodioT<T>::Set(std::vector<T*>&& aData) {
         collection.push_back(*item);
         delete item;
     }
-    SetCollection(std::move(collection));
-}
-
-template <typename T>
-void JFactoryPodioT<T>::Insert(T* aDatum) {
-    CollectionT collection;
-    if (mIsSubsetCollection) collection->setSubsetCollection(true);
-    collection->push_back(*aDatum);
-    delete aDatum;
     SetCollection(std::move(collection));
 }
 


### PR DESCRIPTION
There was a very simple error in JFactoryPodioT::Insert which the compiler should have caught, except this function was not being used anywhere. For some reason podio LinkCollections force the compiler to attempt to instantiate it. 

This fix removes the Insert function entirely, since the feature will no longer work anyhow (Podio now rejects adding non-mutable objects to non-subset collections, permanently breaking the symmetry with JFactoryT). The long-term plan is to retire JFactoryPodioT entirely, and replace it with JPodioDatabundle. 