### PR TITLE
fix: add LinkDef.h for janaview and data model example plugins

### DIFF
--- a/src/examples/misc/RootDatamodelExample/CMakeLists.txt
+++ b/src/examples/misc/RootDatamodelExample/CMakeLists.txt
@@ -14,7 +14,7 @@ if(${USE_ROOT})
 	include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     set(my_pcms)
     foreach( CLASS Hit Cluster )
-        ROOT_GENERATE_DICTIONARY(G__${CLASS} ${CLASS}.h)
+        ROOT_GENERATE_DICTIONARY(G__${CLASS} ${CLASS}.h LINKDEF ${CLASS}_LinkDef.h)
         list(APPEND my_pcms ${CMAKE_CURRENT_BINARY_DIR}/lib${CLASS}_rdict.pcm )
     endforeach()
 

--- a/src/examples/misc/RootDatamodelExample/Cluster_LinkDef.h
+++ b/src/examples/misc/RootDatamodelExample/Cluster_LinkDef.h
@@ -1,4 +1,4 @@
-#ifdef __CINT__
+#ifdef __CLING__
 
 #pragma link off all globals;
 #pragma link off all classes;

--- a/src/examples/misc/RootDatamodelExample/Cluster_LinkDef.h
+++ b/src/examples/misc/RootDatamodelExample/Cluster_LinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class Cluster+;
+
+#endif

--- a/src/examples/misc/RootDatamodelExample/Hit_LinkDef.h
+++ b/src/examples/misc/RootDatamodelExample/Hit_LinkDef.h
@@ -1,4 +1,4 @@
-#ifdef __CINT__
+#ifdef __CLING__
 
 #pragma link off all globals;
 #pragma link off all classes;

--- a/src/examples/misc/RootDatamodelExample/Hit_LinkDef.h
+++ b/src/examples/misc/RootDatamodelExample/Hit_LinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class Hit+;
+
+#endif

--- a/src/plugins/janaview/CMakeLists.txt
+++ b/src/plugins/janaview/CMakeLists.txt
@@ -3,7 +3,7 @@
 if(USE_ROOT)
 
     find_package(ROOT REQUIRED COMPONENTS Gui Core RIO Net Hist Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread MultiProc)
-    ROOT_GENERATE_DICTIONARY(G__jv_mainframe jv_mainframe.h)
+    ROOT_GENERATE_DICTIONARY(G__jv_mainframe jv_mainframe.h LINKDEF jv_mainframe_LinkDef.h)
 
     file(GLOB JANAVIEW_HEADERS "*.h*")
 

--- a/src/plugins/janaview/jv_mainframe_LinkDef.h
+++ b/src/plugins/janaview/jv_mainframe_LinkDef.h
@@ -1,4 +1,4 @@
-#ifdef __CINT__
+#ifdef __CLING__
 
 #pragma link off all globals;
 #pragma link off all classes;

--- a/src/plugins/janaview/jv_mainframe_LinkDef.h
+++ b/src/plugins/janaview/jv_mainframe_LinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class jv_mainframe+;
+
+#endif


### PR DESCRIPTION
In ROOT v6.40.00, a [LinkDef.h is required](https://github.com/root-project/root/commit/d3b89850ce6) (or a C++ module), and this commit adds a minimal LinkDef.h for the janaview and ROOT data model example plugins where it was missing.