### PR TITLE
fix: BUILD_WITH_INSTALL_RPATH=FALSE

### DIFF
--- a/cmake/AddJanaLibrary.cmake
+++ b/cmake/AddJanaLibrary.cmake
@@ -59,7 +59,7 @@ macro(add_jana_library library_name)
     set_target_properties(${library_name} PROPERTIES
         EXPORT_NAME ${library_name}
         SKIP_BUILD_RPATH FALSE
-        BUILD_WITH_INSTALL_RPATH TRUE
+        BUILD_WITH_INSTALL_RPATH FALSE
         INSTALL_RPATH_USE_LINK_PATH TRUE
         INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
     )
@@ -95,7 +95,7 @@ macro(add_jana_library library_name)
         target_link_libraries(${library_name}_tests PRIVATE ${library_name} "${JANA_NAMESPACE}VendoredCatch2")
         set_target_properties(${library_name}_tests PROPERTIES
             SKIP_BUILD_RPATH FALSE
-            BUILD_WITH_INSTALL_RPATH TRUE
+            BUILD_WITH_INSTALL_RPATH FALSE
             INSTALL_RPATH_USE_LINK_PATH TRUE
             INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
         )

--- a/cmake/AddJanaPlugin.cmake
+++ b/cmake/AddJanaPlugin.cmake
@@ -67,7 +67,7 @@ macro(add_jana_plugin plugin_name)
         PREFIX ""
         SUFFIX ".so"
         SKIP_BUILD_RPATH FALSE
-        BUILD_WITH_INSTALL_RPATH TRUE
+        BUILD_WITH_INSTALL_RPATH FALSE
         INSTALL_RPATH_USE_LINK_PATH TRUE
         INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/lib/${INSTALL_NAMESPACE}/plugins"
     )
@@ -99,7 +99,7 @@ macro(add_jana_plugin plugin_name)
         target_link_libraries(${plugin_name}-tests PRIVATE ${plugin_name} "${JANA_NAMESPACE}VendoredCatch2")
         set_target_properties(${plugin_name}-tests PROPERTIES
             SKIP_BUILD_RPATH FALSE
-            BUILD_WITH_INSTALL_RPATH TRUE
+            BUILD_WITH_INSTALL_RPATH FALSE
             INSTALL_RPATH_USE_LINK_PATH TRUE
             INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/lib/${INSTALL_NAMESPACE}/plugins"
         )


### PR DESCRIPTION
This PR ensures that the typical cmake, make, ctest, make install actually works. `BUILD_WITH_INSTALL_RPATH=TRUE` results in the old/previous libraries being used instead of the newly compiled ones.