### PR TITLE
fix: use TARGET_FILE:jana to avoid using jana in path

### DIFF
--- a/src/examples/misc/DstExample/CMakeLists.txt
+++ b/src/examples/misc/DstExample/CMakeLists.txt
@@ -4,4 +4,4 @@ add_jana_plugin(DstExample)
 
 add_test(
     NAME jana-example-dst-tests 
-    COMMAND jana -Pplugins=DstExample)
+    COMMAND $<TARGET_FILE:jana> -Pplugins=DstExample)

--- a/src/examples/misc/EventGroupExample/CMakeLists.txt
+++ b/src/examples/misc/EventGroupExample/CMakeLists.txt
@@ -3,5 +3,5 @@
 add_jana_plugin(EventGroupExample)
 
 add_test(NAME jana-example-eventgroup-tests 
-    COMMAND jana -Pplugins=EventGroupExample)
+    COMMAND $<TARGET_FILE:jana> -Pplugins=EventGroupExample)
 

--- a/src/examples/misc/RootDatamodelExample/CMakeLists.txt
+++ b/src/examples/misc/RootDatamodelExample/CMakeLists.txt
@@ -44,7 +44,7 @@ if(${USE_ROOT})
     install(FILES ${my_pcms} DESTINATION lib/JANA/plugins)
 
     add_test(NAME jana-example-rootdatamodel-tests
-        COMMAND jana -Pplugins=RootDatamodelExample -Pjana:nevents=10)
+        COMMAND $<TARGET_FILE:jana> -Pplugins=RootDatamodelExample -Pjana:nevents=10)
         
     set_tests_properties(jana-example-rootdatamodel-tests
         PROPERTIES DISABLED TRUE)

--- a/src/examples/misc/TimesliceExample/CMakeLists.txt
+++ b/src/examples/misc/TimesliceExample/CMakeLists.txt
@@ -7,10 +7,10 @@ if (USE_PODIO)
     target_link_libraries(TimesliceExample PUBLIC PodioDatamodel PodioDatamodelDict podio::podioRootIO)
 
     add_test(NAME jana-example-timeslices-simple-tests
-        COMMAND ${CMAKE_INSTALL_PREFIX}/bin/jana -Pplugins=TimesliceExample -Puse_timeslices=0 -Pjana:nevents=10 events.root)
+        COMMAND $<TARGET_FILE:jana> -Pplugins=TimesliceExample -Puse_timeslices=0 -Pjana:nevents=10 events.root)
 
     add_test(NAME jana-example-timeslices-complex-tests
-        COMMAND ${CMAKE_INSTALL_PREFIX}/bin/jana -Pplugins=TimesliceExample -Puse_timeslices=1 -Pjana:nevents=10 timeslices.root)
+        COMMAND $<TARGET_FILE:jana> -Pplugins=TimesliceExample -Puse_timeslices=1 -Pjana:nevents=10 timeslices.root)
 
 else()
     message(STATUS "Skipping examples/TimesliceExample because USE_PODIO=Off")

--- a/src/examples/misc/Tutorial/CMakeLists.txt
+++ b/src/examples/misc/Tutorial/CMakeLists.txt
@@ -3,6 +3,6 @@
 add_jana_plugin(Tutorial)
 
 add_test(NAME jana-example-tutorial-tests
-    COMMAND jana -Pplugins=Tutorial -Pjana:nevents=50)
+    COMMAND $<TARGET_FILE:jana> -Pplugins=Tutorial -Pjana:nevents=50)
 
 

--- a/src/examples/tutorial_with_lightweight_datamodel/02_random_hit_source/CMakeLists.txt
+++ b/src/examples/tutorial_with_lightweight_datamodel/02_random_hit_source/CMakeLists.txt
@@ -10,6 +10,6 @@ add_jana_plugin(lw_random_hit_source
 )
 target_link_libraries(lw_random_hit_source PUBLIC lw_random_hit_source_common)
 
-add_test(NAME examples-lw-00-smoketest COMMAND jana -Pplugins=lw_random_hit_source -Pjana:nevents=10)
+add_test(NAME examples-lw-00-smoketest COMMAND $<TARGET_FILE:jana> -Pplugins=lw_random_hit_source -Pjana:nevents=10)
 
 set_tests_properties(examples-lw-00-smoketest PROPERTIES LABELS "examples")

--- a/src/plugins/JTest/CMakeLists.txt
+++ b/src/plugins/JTest/CMakeLists.txt
@@ -3,6 +3,6 @@
 add_jana_plugin(JTest)
 
 add_test(NAME jana-plugin-jtest-tests
-    COMMAND jana -Pplugins=JTest -Pjana:nevents=20)
+    COMMAND $<TARGET_FILE:jana> -Pplugins=JTest -Pjana:nevents=20)
 
 

--- a/src/plugins/janadot/CMakeLists.txt
+++ b/src/plugins/janadot/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Threads REQUIRED)
 target_link_libraries(janadot PUBLIC Threads::Threads)
 
 add_test(NAME jana-plugin-janadot-tests
-    COMMAND jana -Pplugins=JTest,janadot -Pjana:nevents=10)
+    COMMAND $<TARGET_FILE:jana> -Pplugins=JTest,janadot -Pjana:nevents=10)
 
 # TODO: Test that file is not empty!
 


### PR DESCRIPTION
This PR ensures that tests use the actual built target jana executable instead of picking what's in the path.