### PR TITLE
fix: ensure tests get valid LD_LIBRARY_PATH and JANA_PLUGIN_PATH

### DIFF
--- a/cmake/AddJanaLibrary.cmake
+++ b/cmake/AddJanaLibrary.cmake
@@ -101,6 +101,9 @@ macro(add_jana_library library_name)
         )
         #install(TARGETS ${library_name}_tests RUNTIME DESTINATION bin)
         add_test(NAME ${library_name}_tests COMMAND ${library_name}_tests)
+        set_tests_properties(${library_name}_tests PROPERTIES
+            ENVIRONMENT "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:${library_name}>:$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+        )
     endif()
 endmacro()
 

--- a/cmake/AddJanaPlugin.cmake
+++ b/cmake/AddJanaPlugin.cmake
@@ -70,6 +70,7 @@ macro(add_jana_plugin plugin_name)
         BUILD_WITH_INSTALL_RPATH TRUE
         INSTALL_RPATH_USE_LINK_PATH TRUE
         INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/lib/${INSTALL_NAMESPACE}/plugins"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/JANA/plugins"
     )
 
     target_link_libraries(${plugin_name} PUBLIC "${JANA_NAMESPACE}${PLUGIN_JANA_LIB}")
@@ -105,6 +106,9 @@ macro(add_jana_plugin plugin_name)
         )
         #install(TARGETS ${plugin_name}-tests RUNTIME DESTINATION bin)
         add_test(NAME ${plugin_name}-tests COMMAND ${plugin_name}-tests)
+        set_tests_properties(${plugin_name}-tests PROPERTIES
+            ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+        )
     endif()
 endmacro()
 

--- a/cmake/AddJanaTest.cmake
+++ b/cmake/AddJanaTest.cmake
@@ -35,7 +35,10 @@ macro(add_jana_test test_target_name)
 
     install(TARGETS ${test_target_name} RUNTIME DESTINATION bin)
 
-    add_test(NAME ${test_target_name} COMMAND ${CMAKE_INSTALL_PREFIX}/bin/${test_target_name})
+    add_test(NAME ${test_target_name} COMMAND ${test_target_name})
+    set_tests_properties(${test_target_name} PROPERTIES
+        ENVIRONMENT "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+    )
 
 endmacro()
 

--- a/src/examples/misc/DstExample/CMakeLists.txt
+++ b/src/examples/misc/DstExample/CMakeLists.txt
@@ -5,3 +5,6 @@ add_jana_plugin(DstExample)
 add_test(
     NAME jana-example-dst-tests 
     COMMAND jana -Pplugins=DstExample)
+set_tests_properties(jana-example-dst-tests PROPERTIES
+    ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+)

--- a/src/examples/misc/EventGroupExample/CMakeLists.txt
+++ b/src/examples/misc/EventGroupExample/CMakeLists.txt
@@ -4,4 +4,7 @@ add_jana_plugin(EventGroupExample)
 
 add_test(NAME jana-example-eventgroup-tests 
     COMMAND jana -Pplugins=EventGroupExample)
+set_tests_properties(jana-example-eventgroup-tests PROPERTIES
+    ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+)
 

--- a/src/examples/misc/RootDatamodelExample/CMakeLists.txt
+++ b/src/examples/misc/RootDatamodelExample/CMakeLists.txt
@@ -47,7 +47,10 @@ if(${USE_ROOT})
         COMMAND jana -Pplugins=RootDatamodelExample -Pjana:nevents=10)
         
     set_tests_properties(jana-example-rootdatamodel-tests
-        PROPERTIES DISABLED TRUE)
+        PROPERTIES
+            DISABLED TRUE
+            ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+    )
 
 else()
     message(STATUS "Skipping plugins/RootDatamodelExample because USE_ROOT=Off")

--- a/src/examples/misc/TimesliceExample/CMakeLists.txt
+++ b/src/examples/misc/TimesliceExample/CMakeLists.txt
@@ -8,9 +8,15 @@ if (USE_PODIO)
 
     add_test(NAME jana-example-timeslices-simple-tests
         COMMAND ${CMAKE_INSTALL_PREFIX}/bin/jana -Pplugins=TimesliceExample -Puse_timeslices=0 -Pjana:nevents=10 events.root)
+    set_tests_properties(jana-example-timeslices-simple-tests PROPERTIES
+        ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+    )
 
     add_test(NAME jana-example-timeslices-complex-tests
         COMMAND ${CMAKE_INSTALL_PREFIX}/bin/jana -Pplugins=TimesliceExample -Puse_timeslices=1 -Pjana:nevents=10 timeslices.root)
+    set_tests_properties(jana-example-timeslices-complex-tests PROPERTIES
+        ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+    )
 
 else()
     message(STATUS "Skipping examples/TimesliceExample because USE_PODIO=Off")

--- a/src/examples/misc/Tutorial/CMakeLists.txt
+++ b/src/examples/misc/Tutorial/CMakeLists.txt
@@ -4,5 +4,8 @@ add_jana_plugin(Tutorial)
 
 add_test(NAME jana-example-tutorial-tests
     COMMAND jana -Pplugins=Tutorial -Pjana:nevents=50)
+set_tests_properties(jana-example-tutorial-tests PROPERTIES
+    ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+)
 
 

--- a/src/examples/tutorial_with_lightweight_datamodel/02_random_hit_source/CMakeLists.txt
+++ b/src/examples/tutorial_with_lightweight_datamodel/02_random_hit_source/CMakeLists.txt
@@ -12,4 +12,7 @@ target_link_libraries(lw_random_hit_source PUBLIC lw_random_hit_source_common)
 
 add_test(NAME examples-lw-00-smoketest COMMAND jana -Pplugins=lw_random_hit_source -Pjana:nevents=10)
 
-set_tests_properties(examples-lw-00-smoketest PROPERTIES LABELS "examples")
+set_tests_properties(examples-lw-00-smoketest PROPERTIES
+    LABELS "examples"
+    ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+)

--- a/src/examples/tutorial_with_lightweight_datamodel/05_csv_file_writer/CMakeLists.txt
+++ b/src/examples/tutorial_with_lightweight_datamodel/05_csv_file_writer/CMakeLists.txt
@@ -13,7 +13,10 @@ add_jana_plugin(lw_csv_file_writer
 
 target_link_libraries(lw_csv_file_writer PUBLIC lw_csv_file_writer_common)
 
-add_test(NAME examples-lw-05-smoketest COMMAND jana -Pplugins=lw_random_hit_source,lw_csv_file_writer -Pjana:nevents=10)
-set_tests_properties(examples-lw-05-smoketest PROPERTIES LABELS "examples")
+add_test(NAME examples-lw-05-smoketest COMMAND $<TARGET_FILE:jana> -Pplugins=lw_random_hit_source,lw_csv_file_writer -Pjana:nevents=10)
+set_tests_properties(examples-lw-05-smoketest PROPERTIES
+    LABELS "examples"
+    ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+)
 
 

--- a/src/plugins/JTest/CMakeLists.txt
+++ b/src/plugins/JTest/CMakeLists.txt
@@ -4,5 +4,8 @@ add_jana_plugin(JTest)
 
 add_test(NAME jana-plugin-jtest-tests
     COMMAND jana -Pplugins=JTest -Pjana:nevents=20)
+set_tests_properties(jana-plugin-jtest-tests PROPERTIES
+    ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+)
 
 

--- a/src/plugins/janadot/CMakeLists.txt
+++ b/src/plugins/janadot/CMakeLists.txt
@@ -6,6 +6,9 @@ target_link_libraries(janadot PUBLIC Threads::Threads)
 
 add_test(NAME jana-plugin-janadot-tests
     COMMAND jana -Pplugins=JTest,janadot -Pjana:nevents=10)
+set_tests_properties(jana-plugin-janadot-tests PROPERTIES
+    ENVIRONMENT "JANA_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lib/JANA/plugins;LD_LIBRARY_PATH=$<TARGET_FILE_DIR:jana2_shared_lib>:$ENV{LD_LIBRARY_PATH}"
+)
 
 # TODO: Test that file is not empty!
 


### PR DESCRIPTION
This PR ensures that the test environment gets the correct (build-time) LD_LIBRARY_PATH and JANA_PLUGIN_PATH so tests don't use stale installed versions.