### PR TITLE
fix: use consistent/non-empty test collection names

### DIFF
--- a/src/examples/tutorial_with_lightweight_datamodel/03_protocluster_factory/Protocluster_tests.cc
+++ b/src/examples/tutorial_with_lightweight_datamodel/03_protocluster_factory/Protocluster_tests.cc
@@ -170,7 +170,7 @@ TEST_CASE("Protocluster_factory_tests") {
     app.Add(new JFactoryGeneratorT<Protocluster_factory>());
     auto event = std::make_shared<JEvent>(&app);
 
-    event->Insert(make_two_cluster_hits(), "");
+    event->Insert(make_two_cluster_hits(), "rechits");
     auto clusters = event->Get<CalorimeterCluster>("proto");
 
     REQUIRE(clusters.size() == 2);
@@ -187,7 +187,7 @@ TEST_CASE("Protocluster_factory_epic_tests") {
     app.Add(new JFactoryGeneratorT<Protocluster_factory_epic>());
     auto event = std::make_shared<JEvent>(&app);
 
-    event->Insert(make_two_cluster_hits(), "");
+    event->Insert(make_two_cluster_hits(), "rechits");
     auto clusters = event->Get<CalorimeterCluster>("proto");
 
     REQUIRE(clusters.size() == 2);
@@ -204,7 +204,7 @@ TEST_CASE("Protocluster_factory_gluex_tests") {
     app.Add(new JFactoryGeneratorT<Protocluster_factory_gluex>());
     auto event = std::make_shared<JEvent>(&app);
 
-    event->Insert(make_two_cluster_hits(), "");
+    event->Insert(make_two_cluster_hits(), "rechits");
     auto clusters = event->Get<CalorimeterCluster>("proto");
 
     REQUIRE(clusters.size() == 2);

--- a/src/examples/tutorial_with_lightweight_datamodel/05_csv_file_writer/CsvWriter.cc
+++ b/src/examples/tutorial_with_lightweight_datamodel/05_csv_file_writer/CsvWriter.cc
@@ -8,7 +8,7 @@ CsvWriter::CsvWriter() {
     SetCallbackStyle(CallbackStyle::ExpertMode);
 
     m_event_header_in.SetOptional(true);
-    m_calo_hit_collections_in.SetRequestedDatabundleNames({"raw"});
+    m_calo_hit_collections_in.SetRequestedDatabundleNames({"rechits"});
 }
 
 void CsvWriter::Init() {


### PR DESCRIPTION
This PR makes sure that test 03 writes the same name that 05 requests, without empty strings.