### PR TITLE
janacontrol: link against the libzmq target

### DIFF
--- a/src/plugins/janacontrol/CMakeLists.txt
+++ b/src/plugins/janacontrol/CMakeLists.txt
@@ -22,10 +22,8 @@ if (${USE_ZEROMQ})
         PUBLIC_HEADER ${janacontrol_PLUGIN_HEADERS}
         TESTS ${janacontrol_PLUGIN_TESTS})
 
-    target_include_directories(janacontrol PUBLIC ${ZeroMQ_INCLUDE_DIRS})
-    target_link_libraries(janacontrol PUBLIC ${ZeroMQ_LIBRARIES})
-    target_include_directories(janacontrol-tests PUBLIC ${ZeroMQ_INCLUDE_DIRS})
-    target_link_libraries(janacontrol-tests PUBLIC ${ZeroMQ_LIBRARIES})
+    target_link_libraries(janacontrol PUBLIC libzmq)
+    target_link_libraries(janacontrol-tests PUBLIC libzmq)
 
 else()
     message(STATUS "Skipping plugins/janacontrol because USE_ZEROMQ=Off")


### PR DESCRIPTION
ZeroMQ_LIBRARIES and such are not always defined anymore (it depends on how libzmq is packaged), we should use the CMake target that brings all the definitions.

This is prepared using AI.